### PR TITLE
Fix kvtrans because of the RDMAEndpoint API change.

### DIFF
--- a/kvtrans/engine.cc
+++ b/kvtrans/engine.cc
@@ -90,7 +90,8 @@ bool Endpoint::reg_kv(void const* data, size_t size, uint64_t& mr_id) {
   mr_id = next_mr_id_.fetch_add(1);
 
   uccl::Mhandle* mhandle;
-  ep_->uccl_regmr(local_gpu_idx_, const_cast<void*>(data), size, 0, &mhandle);
+  ep_->uccl_regmr(gpu_to_dev[local_gpu_idx_], const_cast<void*>(data), size, 0,
+                  &mhandle);
 
   mr_id_to_mr_[mr_id] = new MR{mr_id, mhandle};
 

--- a/kvtrans/engine.cc
+++ b/kvtrans/engine.cc
@@ -9,7 +9,7 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-const uint8_t ib_cluster_dev_suffix_list[8] = {4, 5, 6, 7, 0, 1, 2, 3};
+const uint8_t gpu_to_dev[8] = {4, 5, 6, 7, 0, 1, 2, 3};
 
 Endpoint::Endpoint(const uint32_t local_gpu_idx, const uint32_t num_cpus)
     : local_gpu_idx_(local_gpu_idx), num_cpus_(num_cpus) {
@@ -21,8 +21,7 @@ Endpoint::Endpoint(const uint32_t local_gpu_idx, const uint32_t num_cpus)
   google::InstallFailureSignalHandler();
 
   // Initialize the RDMA endpoint with lazy creation.
-  ep_ =
-      new uccl::RDMAEndpoint(ib_cluster_dev_suffix_list, NUM_DEVICES, num_cpus);
+  ep_ = new uccl::RDMAEndpoint(NUM_ENGINES);
 
   // Initialize the engine based on the GPU index.
 #ifdef LAZY_CREATE_ENGINE
@@ -56,8 +55,9 @@ bool Endpoint::connect(std::string const& ip_addr, int const& remote_gpu_idx,
   // Create a new connection ID
   conn_id = next_conn_id_.fetch_add(1);
 
-  uccl::ConnID uccl_conn_id =
-      ep_->test_uccl_connect(local_gpu_idx_, ip_addr, remote_gpu_idx);
+  uccl::ConnID uccl_conn_id = ep_->test_uccl_connect(
+      gpu_to_dev[local_gpu_idx_], local_gpu_idx_, gpu_to_dev[remote_gpu_idx],
+      remote_gpu_idx, ip_addr);
 
   // Store the connection ID.
   conn_id_to_conn_[conn_id] =
@@ -74,8 +74,8 @@ bool Endpoint::accept(std::string& ip_addr, int& remote_gpu_idx,
   // For demo purposes, simulate accepted connection
   conn_id = next_conn_id_.fetch_add(1);
 
-  uccl::ConnID uccl_conn_id =
-      ep_->test_uccl_accept(local_gpu_idx_, ip_addr, &remote_gpu_idx);
+  uccl::ConnID uccl_conn_id = ep_->test_uccl_accept(
+      gpu_to_dev[local_gpu_idx_], local_gpu_idx_, ip_addr, &remote_gpu_idx);
 
   // Store the connection ID.
   conn_id_to_conn_[conn_id] =

--- a/kvtrans/engine.cc
+++ b/kvtrans/engine.cc
@@ -25,7 +25,7 @@ Endpoint::Endpoint(const uint32_t local_gpu_idx, const uint32_t num_cpus)
 
   // Initialize the engine based on the GPU index.
 #ifdef LAZY_CREATE_ENGINE
-  ep_->initialize_engine_by_dev(local_gpu_idx_);
+  ep_->initialize_engine_by_dev(gpu_to_dev[local_gpu_idx_]);
 #endif
 
   std::cout << "Endpoint initialized successfully" << std::endl;

--- a/rdma/transport.h
+++ b/rdma/transport.h
@@ -939,12 +939,14 @@ class RDMAEndpoint {
   bool initialize_engine_by_dev(int dev);
 
   /// For testing easily.
-  ConnID test_uccl_connect(int dev, std::string remote_ip, int remote_dev) {
-    return uccl_connect(dev, dev, remote_dev, remote_dev, remote_ip,
+  ConnID test_uccl_connect(int dev, int gpu, int remote_dev, int remote_gpu,
+                           std::string remote_ip) {
+    return uccl_connect(dev, gpu, remote_dev, remote_gpu, remote_ip,
                         kTestListenPort + remote_dev);
   }
-  ConnID test_uccl_accept(int dev, std::string& remote_ip, int* remote_dev) {
-    return uccl_accept(dev, test_listen_fds_[dev], dev, remote_ip, remote_dev);
+  ConnID test_uccl_accept(int dev, int gpu, std::string& remote_ip,
+                          int* remote_dev) {
+    return uccl_accept(dev, test_listen_fds_[dev], gpu, remote_ip, remote_dev);
   }
   /// For testing easily.
 

--- a/rdma/transport_test.cc
+++ b/rdma/transport_test.cc
@@ -297,7 +297,7 @@ static void server_worker(void) {
 
   for (int i = 0; i < FLAGS_nflow; i++) {
     int remote_dev;
-    auto conn_id = ep->test_uccl_accept(0, remote_ip, &remote_dev);
+    auto conn_id = ep->test_uccl_accept(0, 0, remote_ip, &remote_dev);
     printf("Server accepted connection from %s (flow#%d)\n", remote_ip.c_str(),
            i);
 #ifdef GPU
@@ -351,7 +351,7 @@ static void client_worker(void) {
   mhandles.resize(FLAGS_nflow);
 
   for (int i = 0; i < FLAGS_nflow; i++) {
-    auto conn_id = ep->test_uccl_connect(0, FLAGS_serverip, 0);
+    auto conn_id = ep->test_uccl_connect(0, 0, 0, 0, FLAGS_serverip);
     printf("Client connected to %s (flow#%d)\n", FLAGS_serverip.c_str(), i);
 #ifdef GPU
     void* data;


### PR DESCRIPTION
This PR fixes kvtrans because of the `RDMAEndpoint` API change. In addition, it modifies `test_uccl_connect()`, `test_uccl_accept()` to receive local dev index as a parameter.