### PR TITLE
Persistent Kernel for NVLink forwarding + Batching multiple tokens in one rdma write.

### DIFF
--- a/p2p/include/common.hpp
+++ b/p2p/include/common.hpp
@@ -35,28 +35,30 @@
     }                                                         \
   } while (0)
 
-#define REMOTE_PERSISTENT_KERNEL
+// #define REMOTE_PERSISTENT_KERNEL
 #define MEASURE_PER_OP_LATENCY
 #define ENABLE_WRITE_WITH_IMMEDIATE
 #define ASSUME_WR_IN_ORDER
 #define NUMA_AWARE_SCHEDULING
 #define ENABLE_PROXY_CUDA_MEMCPY
 #define SYNCHRONOUS_COMPLETION
+// #define RDMA_BATCH_TOKENS
 #define kQueueSize 1024
 #define kQueueMask (kQueueSize - 1)
-#define kMaxInflight 32
+#define kMaxInflight 48
 #define kBatchSize 16
 #define kIterations 1000000
-#define kNumThBlocks 4
+#define kNumThBlocks 6
 #define kNumThPerBlock 1
 #ifdef SYNCHRONOUS_COMPLETION
-#define kRemoteNVLinkBatchSize 1  // Immediately synchronize stream for latency.
+#define kRemoteNVLinkBatchSize \
+  16  // Immediately synchronize stream for latency.
 #else
 #define kRemoteNVLinkBatchSize 512
 #endif
-#define kObjectSize 8192  // 8 KB
-#define kMaxOutstandingSends 1024
-#define kMaxOutstandingRecvs 1024
+#define kObjectSize 10752  // 10.5 KB
+#define kMaxOutstandingSends 2048
+#define kMaxOutstandingRecvs 2048
 #define kSignalledEvery 1
 #define kSenderAckQueueDepth 1024
 #define kNumPollingThreads 0  // Rely on CPU proxy to poll.

--- a/p2p/include/common.hpp
+++ b/p2p/include/common.hpp
@@ -72,14 +72,6 @@
 #define NVLINK_SM_PER_PROCESS 2
 #endif
 // #define SEPARATE_POLLING
-// Command structure for each transfer
-struct TransferCmd {
-  uint64_t cmd;
-  uint32_t dst_rank;  // remote node id (MPI-style)
-  uint32_t dst_gpu;   // GPU id on remote node
-  void* src_ptr;      // device pointer to data
-  uint64_t bytes;     // transfer size
-};
 
 bool pin_thread_to_cpu(int cpu);
 

--- a/p2p/include/common.hpp
+++ b/p2p/include/common.hpp
@@ -42,11 +42,11 @@
 #define NUMA_AWARE_SCHEDULING
 #define ENABLE_PROXY_CUDA_MEMCPY
 #define SYNCHRONOUS_COMPLETION
-// #define RDMA_BATCH_TOKENS
+#define RDMA_BATCH_TOKENS
 #define kQueueSize 1024
 #define kQueueMask (kQueueSize - 1)
-#define kMaxInflight 48
-#define kBatchSize 16
+#define kMaxInflight 64
+#define kBatchSize 32
 #define kIterations 1000000
 #define kNumThBlocks 6
 #define kNumThPerBlock 1

--- a/p2p/include/common.hpp
+++ b/p2p/include/common.hpp
@@ -35,6 +35,7 @@
     }                                                         \
   } while (0)
 
+// #define REMOTE_PERSISTENT_KERNEL
 #define MEASURE_PER_OP_LATENCY
 #define ENABLE_WRITE_WITH_IMMEDIATE
 #define ASSUME_WR_IN_ORDER

--- a/p2p/include/common.hpp
+++ b/p2p/include/common.hpp
@@ -35,7 +35,7 @@
     }                                                         \
   } while (0)
 
-// #define REMOTE_PERSISTENT_KERNEL
+#define REMOTE_PERSISTENT_KERNEL
 #define MEASURE_PER_OP_LATENCY
 #define ENABLE_WRITE_WITH_IMMEDIATE
 #define ASSUME_WR_IN_ORDER

--- a/p2p/include/gpu_kernel.cuh
+++ b/p2p/include/gpu_kernel.cuh
@@ -4,7 +4,6 @@
 #include "common.hpp"
 #include "ring_buffer.cuh"
 
-__global__ void gpu_issue_batched_commands(
-    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rbs);
+__global__ void gpu_issue_batched_commands(DeviceToHostCmdBuffer* rbs);
 
 #endif  // GPU_KERNEL_CUH

--- a/p2p/include/gpu_kernel.cuh
+++ b/p2p/include/gpu_kernel.cuh
@@ -4,6 +4,7 @@
 #include "common.hpp"
 #include "ring_buffer.cuh"
 
-__global__ void gpu_issue_batched_commands(RingBuffer* rbs);
+__global__ void gpu_issue_batched_commands(
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rbs);
 
 #endif  // GPU_KERNEL_CUH

--- a/p2p/include/peer_copy.cuh
+++ b/p2p/include/peer_copy.cuh
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "copy_ring.hpp"
+#include "ring_buffer.cuh"
 #include <cuda_runtime.h>
 
 template <typename X, typename Y, typename Z = decltype(X() + Y())>
@@ -25,3 +26,10 @@ template <int PIPE_DEPTH,  // same as kPipelineDepth
           typename VecT>   // 16 B per transaction
 __global__ void peer_copy_kernel_vec_pipelined(
     CopyTask const* __restrict__ tasks, int num_tasks, int tasks_per_block);
+
+HostToDeviceNVlinkBuffer* initialize_ring_buffer_for_nvlink_forwarding(
+    cudaStream_t stream);
+
+bool post_copy_task(HostToDeviceNVlinkBuffer* rb, CopyTask const* host_tasks,
+                    int num_tasks, cudaStream_t stream, int src_device,
+                    CopyTask*& d_tasks);

--- a/p2p/include/proxy.hpp
+++ b/p2p/include/proxy.hpp
@@ -10,16 +10,22 @@
 #include <immintrin.h>
 
 struct ProxyCtx {
-  RingBuffer* rb_host;  // host pointer (CPU visible address of RingBuffer)
-  int my_rank;          // rank id for this proxy (if simulating multiple)
+  RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>*
+      rb_host;  // host pointer (CPU visible address of RingBuffer)
+  int my_rank;  // rank id for this proxy (if simulating multiple)
 };
 
-void cpu_proxy(RingBuffer* rb, int block_idx, void* gpu_buffer,
-               size_t total_size, int rank, char const* peer_ip);
-void cpu_proxy_local(RingBuffer* rb, int block_idx);
-void remote_cpu_proxy(RingBuffer* rb, int block_idx, void* gpu_buffer,
-                      size_t total_size, int rank, char const* peer_ip,
-                      CopyRing& g_ring);
+void cpu_proxy(
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
+    int block_idx, void* gpu_buffer, size_t total_size, int rank,
+    char const* peer_ip);
+void cpu_proxy_local(
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
+    int block_idx);
+void remote_cpu_proxy(
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
+    int block_idx, void* gpu_buffer, size_t total_size, int rank,
+    char const* peer_ip, CopyRing& g_ring);
 
 // Proxy id to start time unordered_map
 extern thread_local std::unordered_map<

--- a/p2p/include/proxy.hpp
+++ b/p2p/include/proxy.hpp
@@ -10,22 +10,17 @@
 #include <immintrin.h>
 
 struct ProxyCtx {
-  RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>*
+  DeviceToHostCmdBuffer*
       rb_host;  // host pointer (CPU visible address of RingBuffer)
   int my_rank;  // rank id for this proxy (if simulating multiple)
 };
 
-void cpu_proxy(
-    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
-    int block_idx, void* gpu_buffer, size_t total_size, int rank,
-    char const* peer_ip);
-void cpu_proxy_local(
-    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
-    int block_idx);
-void remote_cpu_proxy(
-    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
-    int block_idx, void* gpu_buffer, size_t total_size, int rank,
-    char const* peer_ip, CopyRing& g_ring);
+void cpu_proxy(DeviceToHostCmdBuffer* rb, int block_idx, void* gpu_buffer,
+               size_t total_size, int rank, char const* peer_ip);
+void cpu_proxy_local(DeviceToHostCmdBuffer* rb, int block_idx);
+void remote_cpu_proxy(DeviceToHostCmdBuffer* rb, int block_idx,
+                      void* gpu_buffer, size_t total_size, int rank,
+                      char const* peer_ip, CopyRing& g_ring);
 
 // Proxy id to start time unordered_map
 extern thread_local std::unordered_map<

--- a/p2p/include/rdma.hpp
+++ b/p2p/include/rdma.hpp
@@ -115,4 +115,8 @@ void remote_notify_sender_batch(struct ibv_qp* ack_qp,
 void create_per_thread_ack_qp(void* gpu_buffer, size_t size,
                               RDMAConnectionInfo* local_info, int rank,
                               ibv_cq* cq);
+void post_rdma_async_batched(void* buf, size_t bytes, size_t num_wrs,
+                             std::vector<uint64_t> wrs_to_post, ibv_cq* cq,
+                             std::unordered_set<uint64_t>& finished_wrs,
+                             std::mutex& finished_wrs_mutex);
 #endif  // RDMA_HPP

--- a/p2p/include/ring_buffer.cuh
+++ b/p2p/include/ring_buffer.cuh
@@ -5,15 +5,88 @@
 #include <atomic>
 #include <cuda.h>
 
-// Host-pinned lock-free ring buffer (single-producer GPU, single-consumer CPU)
+// Command structure for each transfer
+struct TransferCmd {
+  uint64_t cmd;
+  uint32_t dst_rank;  // remote node id (MPI-style)
+  uint32_t dst_gpu;   // GPU id on remote node
+  void* src_ptr;      // device pointer to data
+  uint64_t bytes;     // transfer size
+};
+
+enum class FlowDirection { HostToDevice, DeviceToHost };
+
+__device__ __forceinline__ uint64_t ld_volatile(uint64_t* ptr) {
+  uint64_t ans;
+  asm volatile("ld.volatile.global.u64 %0, [%1];"
+               : "=l"(ans)
+               : "l"(ptr)
+               : "memory");
+  return ans;
+}
+
+// Host-pinned lock-free ring buffer
+template <typename T, FlowDirection Dir, uint32_t Capacity>
 struct alignas(128) RingBuffer {
-  uint64_t head;  // Next slot to produce
-  uint64_t tail;  // Next slot to consume
-  TransferCmd buf[kQueueSize];
+  uint64_t head;
+  uint64_t tail;
+  T buf[Capacity];
   uint64_t cycle_accum;
   uint64_t op_count;
   uint64_t cycle_start;
   uint64_t cycle_end;
+
+  static constexpr uint32_t mask() { return Capacity - 1; }
+  __host__ __device__ __forceinline__ bool full() const {
+    return head - tail == Capacity;
+  }
+
+  __host__ __device__ __forceinline__ bool empty() const {
+    return head == tail;
+  }
+
+  __host__ __device__ __forceinline__ bool push(const T& item) {
+    if (full()) return false;
+    buf[head & mask()] = item;
+    head++;
+    return true;
+  }
+
+  __host__ __device__ __forceinline__ void commit() {
+#if __CUDA_ARCH__
+    if constexpr (Dir == FlowDirection::DeviceToHost) __threadfence_system();
+#else
+    if constexpr (Dir == FlowDirection::DeviceToHost)
+      std::atomic_thread_fence(std::memory_order_release);
+#endif
+  }
+
+  __host__ __device__ __forceinline__ bool pop(T& out) {
+    if (empty()) return false;
+
+#if __CUDA_ARCH__
+    if constexpr (Dir == FlowDirection::HostToDevice) __threadfence();
+#endif
+    out = buf[tail & mask()];
+    tail++;
+    return true;
+  }
+
+  __device__ __forceinline__ void record_cycles(unsigned long long start) {
+#if __CUDA_ARCH__
+    if constexpr (Dir == FlowDirection::DeviceToHost) {
+      auto now = clock64();
+      cycle_accum += (now - start);
+      ++op_count;
+      if (!cycle_start) cycle_start = start;
+      cycle_end = now;
+    }
+#endif
+  }
+
+  __device__ __forceinline__ uint64_t volatile_tail() {
+    return ld_volatile(&tail);
+  }
 };
 
 #endif  // RING_BUFFER_CUH

--- a/p2p/src/benchmark_local.cu
+++ b/p2p/src/benchmark_local.cu
@@ -31,12 +31,9 @@ int main(int argc, char** argv) {
   cudaGetDeviceProperties(&prop, 0);
   printf("clock rate: %d kHz\n", prop.clockRate);
 
-  RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rbs;
-  cudaHostAlloc(
-      &rbs,
-      sizeof(RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>) *
-          kNumThBlocks,
-      cudaHostAllocMapped);
+  DeviceToHostCmdBuffer* rbs;
+  cudaHostAlloc(&rbs, sizeof(DeviceToHostCmdBuffer) * kNumThBlocks,
+                cudaHostAllocMapped);
 
   for (int i = 0; i < kNumThBlocks; ++i) {
     rbs[i].head = 0;

--- a/p2p/src/benchmark_local.cu
+++ b/p2p/src/benchmark_local.cu
@@ -31,8 +31,12 @@ int main(int argc, char** argv) {
   cudaGetDeviceProperties(&prop, 0);
   printf("clock rate: %d kHz\n", prop.clockRate);
 
-  RingBuffer* rbs;
-  cudaHostAlloc(&rbs, sizeof(RingBuffer) * kNumThBlocks, cudaHostAllocMapped);
+  RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rbs;
+  cudaHostAlloc(
+      &rbs,
+      sizeof(RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>) *
+          kNumThBlocks,
+      cudaHostAllocMapped);
 
   for (int i = 0; i < kNumThBlocks; ++i) {
     rbs[i].head = 0;

--- a/p2p/src/benchmark_remote.cu
+++ b/p2p/src/benchmark_remote.cu
@@ -43,12 +43,9 @@ int main(int argc, char** argv) {
   cudaGetDeviceProperties(&prop, 0);
   printf("clock rate: %d kHz\n", prop.clockRate);
 
-  RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rbs;
-  cudaHostAlloc(
-      &rbs,
-      sizeof(RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>) *
-          kNumThBlocks,
-      cudaHostAllocMapped);
+  DeviceToHostCmdBuffer* rbs;
+  cudaHostAlloc(&rbs, sizeof(DeviceToHostCmdBuffer) * kNumThBlocks,
+                cudaHostAllocMapped);
   for (int i = 0; i < kNumThBlocks; ++i) {
     rbs[i].head = 0;
     rbs[i].tail = 0;

--- a/p2p/src/benchmark_remote.cu
+++ b/p2p/src/benchmark_remote.cu
@@ -43,8 +43,12 @@ int main(int argc, char** argv) {
   cudaGetDeviceProperties(&prop, 0);
   printf("clock rate: %d kHz\n", prop.clockRate);
 
-  RingBuffer* rbs;
-  cudaHostAlloc(&rbs, sizeof(RingBuffer) * kNumThBlocks, cudaHostAllocMapped);
+  RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rbs;
+  cudaHostAlloc(
+      &rbs,
+      sizeof(RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>) *
+          kNumThBlocks,
+      cudaHostAllocMapped);
   for (int i = 0; i < kNumThBlocks; ++i) {
     rbs[i].head = 0;
     rbs[i].tail = 0;

--- a/p2p/src/gpu_kernel.cu
+++ b/p2p/src/gpu_kernel.cu
@@ -5,16 +5,14 @@
 #include <stdint.h>
 #include <stdio.h>
 
-__global__ void gpu_issue_batched_commands(
-    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rbs) {
+__global__ void gpu_issue_batched_commands(DeviceToHostCmdBuffer* rbs) {
   int const bid = blockIdx.x;
   int const tid = threadIdx.x;
-  RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb =
-      &rbs[bid];
   if (tid != 0) {
     return;
   }
   printf("Device Block %d: Scheduled\n", bid);
+  auto rb = &rbs[bid];
 
 #ifdef MEASURE_PER_OP_LATENCY
   uint32_t complete = 0;
@@ -29,26 +27,24 @@ __global__ void gpu_issue_batched_commands(
 
   rb->cycle_start = 0;
   for (int it = 0; it < kIterations;) {
-    uint64_t my_hdr;
     uint64_t cur_tail;
 
 #ifdef MEASURE_PER_OP_LATENCY
-    // if (complete < my_hdr + todo) {
-    uint32_t cidx = complete & kQueueMask;
     cur_tail = rb->volatile_tail();
     if (complete < cur_tail) {
       // __threadfence_system();
       for (int i = complete; i < cur_tail; ++i) {
-        if (rb->buf[cidx].cmd != 0) {
+        if (rb->get_entry(complete).cmd != 0) {
           printf(
               "Device Block %d: Error at complete %u, rb->tail:%lu, expected "
               "0, got %llu\n",
-              bid, complete, rb->tail, rb->buf[cidx].cmd);
+              bid, complete, rb->tail, rb->get_entry(complete).cmd);
           return;
         }
         if (complete >= kWarmupOps) {
           unsigned long long t1 = clock64();
-          unsigned long long cycles = t1 - start_cycle_smem[cidx];
+          unsigned long long cycles =
+              t1 - start_cycle_smem[complete & kQueueMask];
           cycle_accum_smem += cycles;
           op_count_smem++;
           if (rb->cycle_start == 0) {
@@ -57,49 +53,38 @@ __global__ void gpu_issue_batched_commands(
         }
       }
       complete = cur_tail;
-    }  // else {
-       // break;
-       // }
-       // }
+    }
 #endif
 
     unsigned int todo =
         (it + kBatchSize <= kIterations) ? kBatchSize : (kIterations - it);
 
     // Dynamically send the number of todos to send.
-    // while (true) {
     uint64_t cur_head = rb->head;
+    uint64_t my_hdr = cur_head;
     cur_tail = rb->volatile_tail();
     uint64_t free_slots = kMaxInflight - (cur_head - cur_tail);
 
     if (free_slots >= todo) {
-      // rb->head = cur_head + todo;
-      my_hdr = cur_head;
-      // break;
     } else if (free_slots >= 1) {
-      // rb->head = cur_head + free_slots;
-      my_hdr = cur_head;
       todo = free_slots;
-      // break;
     } else {
       continue;
     }
-    /* Spin */
-    // }
 
     for (int i = 0; i < todo; ++i) {
-      uint32_t idx = (my_hdr + i) & kQueueMask;
       unsigned long long t0 = clock64();
-      rb->buf[idx].cmd = (static_cast<uint64_t>(bid) << 32) | (it + i + 1);
-      rb->buf[idx].dst_rank = bid;
-      rb->buf[idx].dst_gpu = 0;
-      rb->buf[idx].src_ptr =
-          reinterpret_cast<void*>(static_cast<uintptr_t>(it + i + 1));
-      rb->buf[idx].bytes = kObjectSize;
-      start_cycle_smem[idx] = t0;
+      start_cycle_smem[(my_hdr + i) & kQueueMask] = t0;
+      rb->set_buffer(
+          my_hdr + i,
+          TransferCmd{.cmd = (static_cast<uint64_t>(bid) << 32) | (it + i + 1),
+                      .dst_rank = static_cast<uint32_t>(bid),
+                      .dst_gpu = 0,
+                      .src_ptr = reinterpret_cast<void*>(
+                          static_cast<uintptr_t>(it + i + 1)),
+                      .bytes = kObjectSize});
     }
-    rb->commit();
-    rb->head = my_hdr + todo;
+    rb->commit_with_head(my_hdr + todo);
 
     it += todo;
     if (complete > kWarmupOps) {
@@ -112,8 +97,6 @@ __global__ void gpu_issue_batched_commands(
 
 #ifdef MEASURE_PER_OP_LATENCY
   while (complete < kIterations) {
-    // while (complete >= ld_volatile(&rb->tail)) { /* spin */
-    // }
     if (complete >= kWarmupOps && complete < ld_volatile(&rb->tail)) {
       unsigned long long t1 = clock64();
       cycle_accum_smem += (t1 - start_cycle_smem[complete & kQueueMask]);

--- a/p2p/src/peer_copy.cu
+++ b/p2p/src/peer_copy.cu
@@ -2,6 +2,7 @@
 #include "common.hpp"
 #include "copy_ring.hpp"
 #include "peer_copy.cuh"
+#include "ring_buffer.cuh"
 #include <cstdio>
 #include <cuda_pipeline.h>
 #include <cuda_runtime.h>
@@ -181,4 +182,146 @@ __global__ void peer_copy_kernel_vec_pipelined(
 
     __syncthreads();
   }
+}
+
+__device__ __forceinline__ unsigned long long atomicSubULL(
+    unsigned long long* addr, unsigned long long val) {
+  return atomicAdd(
+      reinterpret_cast<unsigned long long*>(addr),
+      static_cast<unsigned long long>(-static_cast<long long>(val)));
+}
+
+__device__ __forceinline__ bool pop_global(HostToDeviceNVlinkBuffer* rb,
+                                           CopyTask& out) {
+  // Reserve a slot atomically
+  const uint64_t my_tail =
+      atomicAdd(reinterpret_cast<unsigned long long*>(&rb->tail), 1ULL);
+
+  __threadfence_system();
+
+  // Check if we raced past the current head
+  if (my_tail >= rb->head) {
+    // undo reservation
+    atomicSubULL(reinterpret_cast<unsigned long long*>(&rb->tail), 1ULL);
+    return false;
+  }
+
+  out = rb->get_entry(my_tail);
+  return true;
+}
+
+__global__ void peer_copy_kernel_vec_many(HostToDeviceNVlinkBuffer* rb) {
+  unsigned const lane = threadIdx.x & 0x1F;  // 0–31
+
+  while (true) {
+    CopyTask task;
+    bool have = false;
+    if (lane == 0) have = pop_global(rb, task);
+    have = __shfl_sync(0xFFFFFFFF, have, 0);
+    if (!have) continue;
+
+    unsigned long long src_ll = 0, dst_ll = 0;
+    if (lane == 0) {
+      src_ll = (unsigned long long)task.src_ptr;
+      dst_ll = (unsigned long long)task.dst_ptr;
+    }
+    src_ll = __shfl_sync(0xFFFFFFFF, src_ll, 0);
+    dst_ll = __shfl_sync(0xFFFFFFFF, dst_ll, 0);
+    size_t nbytes = __shfl_sync(0xFFFFFFFF, task.bytes, 0);
+
+    char const* __restrict__ src = (char const*)src_ll;
+    char* __restrict__ dst = (char*)dst_ll;
+
+#if defined(DEBUG) || !defined(NDEBUG)
+    if (((uintptr_t)src & 0xF) || ((uintptr_t)dst & 0xF)) {
+      // rare – but don’t crash the whole grid
+      if (lane == 0)
+        for (size_t i = 0; i < nbytes; ++i) dst[i] = src[i];
+      continue;
+    }
+#endif
+
+    size_t offset = lane * 16;
+    for (; offset + 127 < nbytes; offset += 32 * 16)
+      copy128(src + offset, dst + offset);
+
+    if (lane == 0) {
+      for (size_t i = (nbytes & ~size_t(127)); i < nbytes; ++i) dst[i] = src[i];
+    }
+  }
+}
+
+__global__ void peer_copy_kernel_vec_persistent(HostToDeviceNVlinkBuffer* rb)
+// Only one thread polls task, doesn't work.
+{
+  __shared__ CopyTask sm_task;
+
+  while (true) {
+    if (threadIdx.x == 0) {
+      if (!rb->pop(sm_task)) sm_task.bytes = 0;
+    }
+    __syncthreads();
+    if (sm_task.bytes == 0) {
+      continue;
+    }
+
+    char const* __restrict__ src = static_cast<char const*>(sm_task.src_ptr);
+    char* __restrict__ dst = static_cast<char*>(sm_task.dst_ptr);
+    size_t nbytes = sm_task.bytes;
+
+    size_t offset = threadIdx.x * 16;
+    for (; offset + 127 < nbytes; offset += blockDim.x * 16)
+      copy128(src + offset, dst + offset);
+
+    if (threadIdx.x == 0) {
+      for (size_t i = (nbytes & ~size_t(127)); i < nbytes; ++i) dst[i] = src[i];
+    }
+    __syncthreads();
+  }
+}
+
+HostToDeviceNVlinkBuffer* initialize_ring_buffer_for_nvlink_forwarding(
+    cudaStream_t stream) {
+  HostToDeviceNVlinkBuffer* rb;
+  cudaError_t err =
+      cudaHostAlloc(reinterpret_cast<void**>(&rb),
+                    sizeof(HostToDeviceNVlinkBuffer), cudaHostAllocMapped);
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Error allocating ring buffer for NVLink forwarding: %s\n",
+            cudaGetErrorString(err));
+    std::abort();
+  }
+
+  new (rb) HostToDeviceNVlinkBuffer{};
+  constexpr int threads_per_block = 256;
+  dim3 blocks(NVLINK_SM_PER_PROCESS);
+  peer_copy_kernel_vec_many<<<blocks, threads_per_block, 0, stream>>>(rb);
+  err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    fprintf(stderr, "Error launching kernel for NVLink forwarding: %s\n",
+            cudaGetErrorString(err));
+    std::abort();
+  }
+  return rb;
+}
+
+bool post_copy_task(HostToDeviceNVlinkBuffer* rb, CopyTask const* host_tasks,
+                    int num_tasks, cudaStream_t stream, int src_device,
+                    CopyTask*& d_tasks) {
+  uint64_t cur_head = rb->head;
+  uint64_t cur_tail = rb->volatile_tail();
+
+  int free_slots = rb->capacity - (cur_head - cur_tail);
+  if (free_slots < num_tasks) {
+    printf(
+        "Not enough free slots in ring buffer: %d available, %d requested, "
+        "rb->capacity: %d, cur_head: %lu, cur_tail: %lu\n",
+        free_slots, num_tasks, rb->capacity, cur_head, cur_tail);
+    return false;
+  }
+  for (int i = 0; i < num_tasks; ++i) {
+    rb->set_buffer(cur_head + i, host_tasks[i]);
+  }
+  rb->commit_with_head(cur_head + num_tasks);
+  return true;
 }

--- a/p2p/src/peer_copy.cu
+++ b/p2p/src/peer_copy.cu
@@ -313,10 +313,10 @@ bool post_copy_task(HostToDeviceNVlinkBuffer* rb, CopyTask const* host_tasks,
 
   int free_slots = rb->capacity - (cur_head - cur_tail);
   if (free_slots < num_tasks) {
-    printf(
-        "Not enough free slots in ring buffer: %d available, %d requested, "
-        "rb->capacity: %d, cur_head: %lu, cur_tail: %lu\n",
-        free_slots, num_tasks, rb->capacity, cur_head, cur_tail);
+    // printf(
+    //     "Not enough free slots in ring buffer: %d available, %d requested, "
+    //     "rb->capacity: %d, cur_head: %lu, cur_tail: %lu\n",
+    //     free_slots, num_tasks, rb->capacity, cur_head, cur_tail);
     return false;
   }
   for (int i = 0; i < num_tasks; ++i) {

--- a/p2p/src/peer_copy_worker.cpp
+++ b/p2p/src/peer_copy_worker.cpp
@@ -126,7 +126,10 @@ void peer_copy_worker(CopyRing& g_ring, int idx) {
     }
 #ifdef REMOTE_PERSISTENT_KERNEL
     else {
-      post_copy_task(rb, tasks, copy_batch_size, stream, src_device, d_tasks);
+      bool post_success = false;
+      while (!post_success)
+        post_success = post_copy_task(rb, tasks, copy_batch_size, stream,
+                                      src_device, d_tasks);
     }
 #endif
     if (err != cudaSuccess) {

--- a/p2p/src/peer_copy_worker.cpp
+++ b/p2p/src/peer_copy_worker.cpp
@@ -35,6 +35,10 @@ void maybe_enable_peer_access(int src_dev, int dst_dev) {
 }
 
 void sync_and_post(CopyRing& g_ring, cudaStream_t& stream, int idx) {
+  // printf("async_memcpy_count: %lu, prev_completed_async_memcpy_count: %lu,
+  // highest_issued_wr_id: %lu\n",
+  //        async_memcpy_count, prev_completed_async_memcpy_count,
+  //        highest_issued_wr_id);
   if (async_memcpy_count > prev_completed_async_memcpy_count) {
     cudaError_t err = cudaStreamSynchronize(stream);
     if (err != cudaSuccess) {

--- a/p2p/src/peer_copy_worker.cpp
+++ b/p2p/src/peer_copy_worker.cpp
@@ -118,7 +118,6 @@ void peer_copy_worker(CopyRing& g_ring, int idx) {
 #else
     } else {
 #endif
-
       /* The fastest among the three. */
       err = launch_peer_bulk_copy2(tasks, copy_batch_size, stream, src_device,
                                    d_tasks);
@@ -126,7 +125,7 @@ void peer_copy_worker(CopyRing& g_ring, int idx) {
     }
 #ifdef REMOTE_PERSISTENT_KERNEL
     else {
-      bool post_success = false;
+      bool post_success = true;
       while (!post_success)
         post_success = post_copy_task(rb, tasks, copy_batch_size, stream,
                                       src_device, d_tasks);

--- a/p2p/src/proxy.cpp
+++ b/p2p/src/proxy.cpp
@@ -245,8 +245,13 @@ void post_gpu_command(
 
   if (!wrs_to_post.empty()) {
     auto start = std::chrono::high_resolution_clock::now();
+#ifdef RDMA_BATCH_TOKENS
+    post_rdma_async_batched(gpu_buffer, kObjectSize, batch_size, wrs_to_post,
+                            cq, finished_wrs, finished_wrs_mutex);
+#else
     post_rdma_async_chained(gpu_buffer, kObjectSize, batch_size, wrs_to_post,
                             cq, finished_wrs, finished_wrs_mutex);
+#endif
     auto end = std::chrono::high_resolution_clock::now();
     total_rdma_write_durations +=
         std::chrono::duration_cast<std::chrono::microseconds>(end - start);

--- a/p2p/src/proxy.cpp
+++ b/p2p/src/proxy.cpp
@@ -25,9 +25,10 @@ inline uint64_t load_volatile_u64(uint64_t volatile* addr) {
   return val;
 }
 
-void remote_cpu_proxy(RingBuffer* rb, int block_idx, void* gpu_buffer,
-                      size_t total_size, int rank, char const* peer_ip,
-                      CopyRing& g_ring) {
+void remote_cpu_proxy(
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
+    int block_idx, void* gpu_buffer, size_t total_size, int rank,
+    char const* peer_ip, CopyRing& g_ring) {
   printf("Remote CPU thread for block %d started\n", block_idx + 1);
 
 #ifdef NUMA_AWARE_SCHEDULING
@@ -72,9 +73,10 @@ void remote_cpu_proxy(RingBuffer* rb, int block_idx, void* gpu_buffer,
 #endif
 }
 
-void notify_gpu_completion(std::unordered_set<uint64_t>& finished_wrs,
-                           std::mutex& finished_wrs_mutex, RingBuffer* rb,
-                           int block_idx, uint64_t& my_tail) {
+void notify_gpu_completion(
+    std::unordered_set<uint64_t>& finished_wrs, std::mutex& finished_wrs_mutex,
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
+    int block_idx, uint64_t& my_tail) {
 // This assumes we don't have EFA NICs.
 #ifdef ASSUME_WR_IN_ORDER
   if (finished_wrs.size() > 0) {
@@ -173,8 +175,9 @@ void notify_gpu_completion(std::unordered_set<uint64_t>& finished_wrs,
 }
 
 void post_gpu_command(
-    RingBuffer* rb, uint64_t& my_tail, size_t& seen, int block_idx,
-    void* gpu_buffer, ibv_cq* cq, std::unordered_set<uint64_t>& finished_wrs,
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
+    uint64_t& my_tail, size_t& seen, int block_idx, void* gpu_buffer,
+    ibv_cq* cq, std::unordered_set<uint64_t>& finished_wrs,
     std::mutex& finished_wrs_mutex,
     std::chrono::duration<double, std::micro>& total_rdma_write_durations) {
   // Force loading rb->head from DRAM.
@@ -252,8 +255,10 @@ void post_gpu_command(
   }
 }
 
-void cpu_proxy(RingBuffer* rb, int block_idx, void* gpu_buffer,
-               size_t total_size, int rank, char const* peer_ip) {
+void cpu_proxy(
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
+    int block_idx, void* gpu_buffer, size_t total_size, int rank,
+    char const* peer_ip) {
   printf("CPU thread for block %d started\n", block_idx + 1);
 #ifdef NUMA_AWARE_SCHEDULING
   per_thread_rdma_init(gpu_buffer, total_size, rank, block_idx);
@@ -346,7 +351,9 @@ void cpu_proxy(RingBuffer* rb, int block_idx, void* gpu_buffer,
       (float)wr_time_total / completion_count, wr_time_total, completion_count);
 }
 
-void cpu_proxy_local(RingBuffer* rb, int block_idx) {
+void cpu_proxy_local(
+    RingBuffer<TransferCmd, FlowDirection::DeviceToHost, kQueueSize>* rb,
+    int block_idx) {
   // printf("CPU thread for block %d started\n", block_idx);
   pin_thread_to_cpu(block_idx + 1);
 


### PR DESCRIPTION
This includes the refactoring of the ring buffer.
The performance for the persistent kernel isn't good right now. Because multiple threads polling from the same CopyTask causes contention. 

```
Overall avg GPU-measured latency  : 91.028 µs
Total cycles                      : 1070584556832
Total ops                         : 5939904
End-to-end wall-clock time        : 1348.715 ms
Ops Throughput                    : 4.40 Mops
Total Throughput                  : 378.82 Gbps
```