### PR TITLE
Fair NIC allocation

### DIFF
--- a/p2p/README.md
+++ b/p2p/README.md
@@ -113,7 +113,7 @@ python benchmark.py \
 On Server:
 ```bash
 UCX_TLS=cuda_ipc,cuda_copy,rc,tcp \
-python benchmark_nixl.py --role server --local-gpu-idx 0
+python benchmark_nixl.py --role server --device gpu --local-gpu-idx 0 
 ```
 
 On Client:

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -45,7 +45,8 @@ Endpoint::Endpoint(uint32_t const local_gpu_idx, uint32_t const num_cpus)
       << "Local GPU index out of range";
 
   auto ib_nics = uccl::get_rdma_nics();
-  // Find the RDMA NIC that is closest to each of the GPUs, ensuring fair NIC allocation.
+  // Find the RDMA NIC that is closest to each of the GPUs,
+  // ensuring fair NIC allocation.
   std::vector<bool> nic_allocated(ib_nics.size(), false);
   for (int i = 0; i < gpu_cards.size(); i++) {
     auto gpu_device_path = gpu_cards[i];

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -45,15 +45,32 @@ Endpoint::Endpoint(uint32_t const local_gpu_idx, uint32_t const num_cpus)
       << "Local GPU index out of range";
 
   auto ib_nics = uccl::get_rdma_nics();
-  // Find the RDMA NIC that is closest to each of the GPUs.
+  // Find the RDMA NIC that is closest to each of the GPUs, ensuring fair NIC allocation.
+  std::vector<bool> nic_allocated(ib_nics.size(), false);
   for (int i = 0; i < gpu_cards.size(); i++) {
     auto gpu_device_path = gpu_cards[i];
-    auto ib_nic_it = std::min_element(
-        ib_nics.begin(), ib_nics.end(), [&](auto const& a, auto const& b) {
-          return uccl::cal_pcie_distance(gpu_device_path, a.second) <
-                 uccl::cal_pcie_distance(gpu_device_path, b.second);
-        });
-    gpu_to_dev[i] = ib_nic_it - ib_nics.begin();
+    int best_nic = -1;
+    int best_distance = std::numeric_limits<int>::max();
+    for (int j = 0; j < ib_nics.size(); ++j) {
+      if (nic_allocated[j]) continue;
+      int dist = uccl::cal_pcie_distance(gpu_device_path, ib_nics[j].second);
+      if (dist < best_distance) {
+        best_distance = dist;
+        best_nic = j;
+      }
+    }
+    if (best_nic != -1) {
+      gpu_to_dev[i] = best_nic;
+      nic_allocated[best_nic] = true;
+    } else {
+      // If all NICs are allocated, fallback to the closest
+      auto ib_nic_it = std::min_element(
+          ib_nics.begin(), ib_nics.end(), [&](auto const& a, auto const& b) {
+            return uccl::cal_pcie_distance(gpu_device_path, a.second) <
+                   uccl::cal_pcie_distance(gpu_device_path, b.second);
+          });
+      gpu_to_dev[i] = ib_nic_it - ib_nics.begin();
+    }
   }
   std::cout << "Detected best GPU-NIC mapping: " << std::endl;
   for (int i = 0; i < gpu_cards.size(); i++) {


### PR DESCRIPTION
The current logic of choosing the NIC for GPU seems to allocate only the first closest.

```
       GPU0    GPU1    GPU2    GPU3    GPU4    GPU5    GPU6    GPU7    NIC0    NIC1    NIC2    NIC3    NIC4    NIC5    NIC6    NIC7    CPU Affinity    NUMA Affinity   GPU NUMA ID
GPU0     X      NV18    NV18    NV18    NV18    NV18    NV18    NV18    PIX     PIX     NODE    NODE    SYS     SYS     SYS     SYS     0-55,112-167    0               N/A
GPU1    NV18     X      NV18    NV18    NV18    NV18    NV18    NV18    PIX     PIX     NODE    NODE    SYS     SYS     SYS     SYS     0-55,112-167    0               N/A
GPU2    NV18    NV18     X      NV18    NV18    NV18    NV18    NV18    NODE    NODE    PIX     PIX     SYS     SYS     SYS     SYS     0-55,112-167    0               N/A
GPU3    NV18    NV18    NV18     X      NV18    NV18    NV18    NV18    NODE    NODE    PIX     PIX     SYS     SYS     SYS     SYS     0-55,112-167    0               N/A
GPU4    NV18    NV18    NV18    NV18     X      NV18    NV18    NV18    SYS     SYS     SYS     SYS     PIX     PIX     NODE    NODE    56-111,168-223  1               N/A
GPU5    NV18    NV18    NV18    NV18    NV18     X      NV18    NV18    SYS     SYS     SYS     SYS     PIX     PIX     NODE    NODE    56-111,168-223  1               N/A
GPU6    NV18    NV18    NV18    NV18    NV18    NV18     X      NV18    SYS     SYS     SYS     SYS     NODE    NODE    PIX     PIX     56-111,168-223  1               N/A
GPU7    NV18    NV18    NV18    NV18    NV18    NV18    NV18     X      SYS     SYS     SYS     SYS     NODE    NODE    PIX     PIX     56-111,168-223  1               N/A
NIC0    PIX     PIX     NODE    NODE    SYS     SYS     SYS     SYS      X      PIX     NODE    NODE    SYS     SYS     SYS     SYS
NIC1    PIX     PIX     NODE    NODE    SYS     SYS     SYS     SYS     PIX      X      NODE    NODE    SYS     SYS     SYS     SYS
NIC2    NODE    NODE    PIX     PIX     SYS     SYS     SYS     SYS     NODE    NODE     X      PIX     SYS     SYS     SYS     SYS
NIC3    NODE    NODE    PIX     PIX     SYS     SYS     SYS     SYS     NODE    NODE    PIX      X      SYS     SYS     SYS     SYS
NIC4    SYS     SYS     SYS     SYS     PIX     PIX     NODE    NODE    SYS     SYS     SYS     SYS      X      PIX     NODE    NODE
NIC5    SYS     SYS     SYS     SYS     PIX     PIX     NODE    NODE    SYS     SYS     SYS     SYS     PIX      X      NODE    NODE
NIC6    SYS     SYS     SYS     SYS     NODE    NODE    PIX     PIX     SYS     SYS     SYS     SYS     NODE    NODE     X      PIX
NIC7    SYS     SYS     SYS     SYS     NODE    NODE    PIX     PIX     SYS     SYS     SYS     SYS     NODE    NODE    PIX      X        
```
Current :

Detected best GPU-NIC mapping:
	GPU 0 -> NIC  (mlx5_0)
	GPU 1 -> NIC  (mlx5_0)
	GPU 2 -> NIC  (mlx5_2)
	GPU 3 -> NIC  (mlx5_2)
	GPU 4 -> NIC  (mlx5_4)
	GPU 5 -> NIC  (mlx5_4)
	GPU 6 -> NIC  (mlx5_6)
	GPU 7 -> NIC  (mlx5_6)
	
After :

Detected best GPU-NIC mapping:
        GPU 0 -> NIC  (mlx5_0)
        GPU 1 -> NIC  (mlx5_1)
        GPU 2 -> NIC  (mlx5_2)
        GPU 3 -> NIC  (mlx5_3)
        GPU 4 -> NIC  (mlx5_4)
        GPU 5 -> NIC  (mlx5_5)
        GPU 6 -> NIC  (mlx5_6)
        GPU 7 -> NIC  (mlx5_7)