### PR TITLE
Automatically detecting EFA devices and ENA devices

### DIFF
--- a/doc/dev_efa.md
+++ b/doc/dev_efa.md
@@ -98,8 +98,8 @@ ib_send_lat -d rdmap16s27 --report_gbits -x 0 -c UD -F <serverip>
 ### Run transport tests
 
 ```bash
-./util_efa_test --logtostderr
-./util_efa_test --logtostderr <serverip>
+./util_efa_test --logtostderr            # server
+./util_efa_test --logtostderr <serverip> # client
 ```
 
 ```bash

--- a/efa/Makefile
+++ b/efa/Makefile
@@ -32,6 +32,9 @@ transport_test: transport_test.cc $(DEPS) $(lib_obj)
 util_efa_test: util_efa_test.cc $(DEPS) $(lib_obj)
 	g++ util_efa_test.cc -o util_efa_test $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
+util_efa_device_name_list_test: util_efa_device_name_list_test.cc util_efa.cc $(DEPS) $(filter-out util_efa.o,$(lib_obj))
+	g++ -DUCCL_TESTING util_efa_device_name_list_test.cc util_efa.cc -o util_efa_device_name_list_test $(filter-out util_efa.o,$(lib_obj)) $(INC) $(LIBS) $(CXXFLAGS) -lgtest_main
+
 timely_test: timely_test.cc $(DEPS) $(lib_obj)
 	g++ timely_test.cc -o timely_test $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 

--- a/efa/transport_config.h
+++ b/efa/transport_config.h
@@ -42,24 +42,7 @@ static bool const kSplitSendRecvEngine =
 #ifdef P4D
 static const uint8_t NUM_DEVICES = (kNumVdevices + 1) / 2;
 static const uint8_t EFA_GID_IDX = 0;
-static const std::string EFA_DEVICE_NAME_LIST[] = {
-    "rdmap16s27",
 
-    "rdmap32s27",
-
-    "rdmap144s27",
-
-    "rdmap160s27",
-};
-static const std::string ENA_DEVICE_NAME_LIST[] = {
-    "ens32",
-
-    "ens65",
-
-    "ens130",
-
-    "ens163",
-};
 static constexpr double kLinkBandwidth = 100.0 * 1e9 / 8;  // 100Gbps
 #endif
 static const uint8_t EFA_PORT_NUM = 1;  // The port of EFA device to use.

--- a/efa/util_efa.cc
+++ b/efa/util_efa.cc
@@ -82,11 +82,13 @@ static void init_device_name_lists() {
   }
 
   if (g_efa_device_names.empty()) {
-    LOG(ERROR) << "No EFA devices discovered via environment variables or hardware enumeration";
+    LOG(ERROR) << "No EFA devices discovered via environment variables or "
+                  "hardware enumeration";
   }
 
   if (g_ena_device_names.empty()) {
-    LOG(ERROR) << "No ENA devices discovered via environment variables or hardware enumeration";
+    LOG(ERROR) << "No ENA devices discovered via environment variables or "
+                  "hardware enumeration";
   }
 }
 

--- a/efa/util_efa.cc
+++ b/efa/util_efa.cc
@@ -82,15 +82,11 @@ static void init_device_name_lists() {
   }
 
   if (g_efa_device_names.empty()) {
-    g_efa_device_names.assign(std::begin(EFA_DEVICE_NAME_LIST),
-                              std::end(EFA_DEVICE_NAME_LIST));
-    LOG(WARNING) << "Using fallback EFA device names";
+    LOG(ERROR) << "No EFA devices discovered via environment variables or hardware enumeration";
   }
 
   if (g_ena_device_names.empty()) {
-    g_ena_device_names.assign(std::begin(ENA_DEVICE_NAME_LIST),
-                              std::end(ENA_DEVICE_NAME_LIST));
-    LOG(WARNING) << "Using fallback ENA device names";
+    LOG(ERROR) << "No ENA devices discovered via environment variables or hardware enumeration";
   }
 }
 

--- a/efa/util_efa.cc
+++ b/efa/util_efa.cc
@@ -54,7 +54,10 @@ static void init_device_name_lists() {
           }
           ibv_close_device(ctx);
         }
-        if (ok && name) g_efa_device_names.push_back(name);
+        if (ok && name) {
+          g_efa_device_names.push_back(name);
+          LOG(INFO) << "Discovered EFA device " << name;
+        }
       }
       ibv_free_device_list(list);
     }
@@ -68,6 +71,7 @@ static void init_device_name_lists() {
         if (ifa->ifa_name && strncmp(ifa->ifa_name, "ens", 3) == 0) {
           if (std::find(g_ena_device_names.begin(), g_ena_device_names.end(), ifa->ifa_name) == g_ena_device_names.end()) {
             g_ena_device_names.push_back(ifa->ifa_name);
+            LOG(INFO) << "Discovered ENA device " << ifa->ifa_name;
           }
         }
       }

--- a/efa/util_efa.h
+++ b/efa/util_efa.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <mutex>
 #include <set>
+#include <vector>
 #include <assert.h>
 #include <cuda_runtime.h>
 #include <errno.h>
@@ -469,6 +470,10 @@ class EFASocket {
 
   friend class EFAFactory;
 };
+
+
+const std::vector<std::string>& GetEfaDeviceNameList();
+const std::vector<std::string>& GetEnaDeviceNameList();
 
 /**
  * @brief This helper function gets the Infiniband name from the dev index.

--- a/efa/util_efa.h
+++ b/efa/util_efa.h
@@ -500,3 +500,14 @@ static inline int util_efa_get_ip_from_dev_idx(int dev_idx, std::string* ip) {
 }
 
 }  // namespace uccl
+
+/**
+ * @brief Reset the device name lists for testing.
+ *
+ * @return void
+ */
+#ifdef UCCL_TESTING
+namespace uccl::_detail {
+void ResetDeviceNameListsForTest();
+}  // namespace uccl::_detail
+#endif

--- a/efa/util_efa.h
+++ b/efa/util_efa.h
@@ -484,7 +484,11 @@ const std::vector<std::string>& GetEnaDeviceNameList();
  */
 static inline int util_efa_get_ib_name_from_dev_idx(int dev_idx,
                                                     char* ib_name) {
-  sprintf(ib_name, "%s", EFA_DEVICE_NAME_LIST[dev_idx].c_str());
+  const auto &efa_list = GetEfaDeviceNameList();
+  DCHECK_GE(dev_idx, 0);
+  DCHECK_LT(static_cast<size_t>(dev_idx), efa_list.size())
+      << "dev_idx " << dev_idx << " out of range; NUM_DEVICES mismatch";
+  sprintf(ib_name, "%s", efa_list[dev_idx].c_str());
   return 0;
 }
 
@@ -495,14 +499,19 @@ static inline int util_efa_get_ib_name_from_dev_idx(int dev_idx,
  * @return int
  */
 static inline int util_efa_get_ip_from_dev_idx(int dev_idx, std::string* ip) {
-  *ip = get_dev_ip(ENA_DEVICE_NAME_LIST[dev_idx].c_str());
-  return *ip == "" ? -1 : 0;
+  const auto &ena_list = GetEnaDeviceNameList();
+  DCHECK_GE(dev_idx, 0);
+  DCHECK_LT(static_cast<size_t>(dev_idx), ena_list.size())
+      << "dev_idx " << dev_idx << " out of range; NUM_DEVICES mismatch";
+  *ip = get_dev_ip(ena_list[dev_idx].c_str());
+  return ip->empty() ? -1 : 0;
 }
 
 }  // namespace uccl
 
 /**
- * @brief Reset the device name lists for testing.
+ * @brief Exposes private variables g_efa_device_names and g_ena_device_names
+ * for testing purposes.
  *
  * @return void
  */

--- a/efa/util_efa.h
+++ b/efa/util_efa.h
@@ -471,9 +471,8 @@ class EFASocket {
   friend class EFAFactory;
 };
 
-
-const std::vector<std::string>& GetEfaDeviceNameList();
-const std::vector<std::string>& GetEnaDeviceNameList();
+std::vector<std::string> const& GetEfaDeviceNameList();
+std::vector<std::string> const& GetEnaDeviceNameList();
 
 /**
  * @brief This helper function gets the Infiniband name from the dev index.
@@ -484,7 +483,7 @@ const std::vector<std::string>& GetEnaDeviceNameList();
  */
 static inline int util_efa_get_ib_name_from_dev_idx(int dev_idx,
                                                     char* ib_name) {
-  const auto &efa_list = GetEfaDeviceNameList();
+  auto const& efa_list = GetEfaDeviceNameList();
   DCHECK_GE(dev_idx, 0);
   DCHECK_LT(static_cast<size_t>(dev_idx), efa_list.size())
       << "dev_idx " << dev_idx << " out of range; NUM_DEVICES mismatch";
@@ -499,7 +498,7 @@ static inline int util_efa_get_ib_name_from_dev_idx(int dev_idx,
  * @return int
  */
 static inline int util_efa_get_ip_from_dev_idx(int dev_idx, std::string* ip) {
-  const auto &ena_list = GetEnaDeviceNameList();
+  auto const& ena_list = GetEnaDeviceNameList();
   DCHECK_GE(dev_idx, 0);
   DCHECK_LT(static_cast<size_t>(dev_idx), ena_list.size())
       << "dev_idx " << dev_idx << " out of range; NUM_DEVICES mismatch";

--- a/efa/util_efa_device_name_list_test.cc
+++ b/efa/util_efa_device_name_list_test.cc
@@ -1,4 +1,7 @@
-#define UCCL_TESTING     // must precede any header that pulls in util_efa.h
+#ifndef UCCL_TESTING
+#define UCCL_TESTING
+#endif
+
 #include "util_efa.h"
 #include <gtest/gtest.h>
 #include <cstdlib>

--- a/efa/util_efa_device_name_list_test.cc
+++ b/efa/util_efa_device_name_list_test.cc
@@ -22,7 +22,7 @@ class EnaDevice : public EfaDeviceNameListTest {
   void TearDown() override { unsetenv("UCCL_ENA_DEVICES"); }
 };
 
-// 1. Env-var path
+// 1. Set env var EFA devices
 TEST_F(EfaDeviceNameListTest, RespectsEnvVariable) {
   setenv("UCCL_EFA_DEVICES", "efa0,efa1, rdmap42", /*overwrite=*/1);
 
@@ -30,7 +30,7 @@ TEST_F(EfaDeviceNameListTest, RespectsEnvVariable) {
   EXPECT_EQ(list, std::vector<std::string>({"efa0", "efa1", "rdmap42"}));
 }
 
-// 1.1 Env-var path ENA
+// 2. Set env var ENA devices
 TEST_F(EnaDevice, RespectsEnvVariable) {
   setenv("UCCL_ENA_DEVICES", "ena0,ena1, ens42", /*overwrite=*/1);
 
@@ -38,28 +38,4 @@ TEST_F(EnaDevice, RespectsEnvVariable) {
   EXPECT_EQ(list, std::vector<std::string>({"ena0", "ena1", "ens42"}));
 }
 
-// 2. Fallback path (no env, no real hw)
-//    We don’t enumerate hardware in a unit test, so we just make sure
-//    the function returns the built-in defaults when env is empty.
-TEST_F(EfaDeviceNameListTest, UsesBuiltInDefaultsWhenEnvMissing) {
-  // Explicitly ensure environment variables are not set to force hardware
-  // enumeration
-  unsetenv("UCCL_EFA_DEVICES");
-  unsetenv("UCCL_ENA_DEVICES");
 
-  // Check EFA defaults
-  auto const& efa_list = GetEfaDeviceNameList();
-  std::vector<std::string> kExpectedEfaDefaults = {
-      "rdmap16s27", "rdmap32s27", "rdmap144s27", "rdmap160s27"};
-  for (auto const& name : kExpectedEfaDefaults)
-    EXPECT_NE(std::find(efa_list.begin(), efa_list.end(), name), efa_list.end())
-        << "Missing EFA default: " << name;
-
-  // Check ENA defaults
-  auto const& ena_list = GetEnaDeviceNameList();
-  std::vector<std::string> kExpectedEnaDefaults = {"ens32", "ens65", "ens130",
-                                                   "ens163"};
-  for (auto const& name : kExpectedEnaDefaults)
-    EXPECT_NE(std::find(ena_list.begin(), ena_list.end(), name), ena_list.end())
-        << "Missing ENA default: " << name;
-}

--- a/efa/util_efa_device_name_list_test.cc
+++ b/efa/util_efa_device_name_list_test.cc
@@ -12,22 +12,21 @@ using uccl::_detail::ResetDeviceNameListsForTest;
 
 class EfaDeviceNameListTest : public ::testing::Test {
  protected:
-   void SetUp() override { ResetDeviceNameListsForTest(); }
-   void TearDown() override { unsetenv("UCCL_EFA_DEVICES"); }
+  void SetUp() override { ResetDeviceNameListsForTest(); }
+  void TearDown() override { unsetenv("UCCL_EFA_DEVICES"); }
 };
 
 class EnaDevice : public EfaDeviceNameListTest {
  protected:
-   void SetUp() override { ResetDeviceNameListsForTest(); }
-   void TearDown() override { unsetenv("UCCL_ENA_DEVICES"); }
+  void SetUp() override { ResetDeviceNameListsForTest(); }
+  void TearDown() override { unsetenv("UCCL_ENA_DEVICES"); }
 };
-
 
 // 1. Env-var path
 TEST_F(EfaDeviceNameListTest, RespectsEnvVariable) {
   setenv("UCCL_EFA_DEVICES", "efa0,efa1, rdmap42", /*overwrite=*/1);
 
-  const auto& list = GetEfaDeviceNameList();
+  auto const& list = GetEfaDeviceNameList();
   EXPECT_EQ(list, std::vector<std::string>({"efa0", "efa1", "rdmap42"}));
 }
 
@@ -35,7 +34,7 @@ TEST_F(EfaDeviceNameListTest, RespectsEnvVariable) {
 TEST_F(EnaDevice, RespectsEnvVariable) {
   setenv("UCCL_ENA_DEVICES", "ena0,ena1, ens42", /*overwrite=*/1);
 
-  const auto& list = GetEnaDeviceNameList();
+  auto const& list = GetEnaDeviceNameList();
   EXPECT_EQ(list, std::vector<std::string>({"ena0", "ena1", "ens42"}));
 }
 
@@ -43,19 +42,24 @@ TEST_F(EnaDevice, RespectsEnvVariable) {
 //    We don’t enumerate hardware in a unit test, so we just make sure
 //    the function returns the built-in defaults when env is empty.
 TEST_F(EfaDeviceNameListTest, UsesBuiltInDefaultsWhenEnvMissing) {
-  // Explicitly ensure environment variables are not set to force hardware enumeration
+  // Explicitly ensure environment variables are not set to force hardware
+  // enumeration
   unsetenv("UCCL_EFA_DEVICES");
   unsetenv("UCCL_ENA_DEVICES");
 
   // Check EFA defaults
-  const auto& efa_list = GetEfaDeviceNameList();
-  std::vector<std::string> kExpectedEfaDefaults = {"rdmap16s27", "rdmap32s27", "rdmap144s27", "rdmap160s27"};
-  for (const auto& name : kExpectedEfaDefaults)
-    EXPECT_NE(std::find(efa_list.begin(), efa_list.end(), name), efa_list.end()) << "Missing EFA default: " << name;
+  auto const& efa_list = GetEfaDeviceNameList();
+  std::vector<std::string> kExpectedEfaDefaults = {
+      "rdmap16s27", "rdmap32s27", "rdmap144s27", "rdmap160s27"};
+  for (auto const& name : kExpectedEfaDefaults)
+    EXPECT_NE(std::find(efa_list.begin(), efa_list.end(), name), efa_list.end())
+        << "Missing EFA default: " << name;
 
   // Check ENA defaults
-  const auto& ena_list = GetEnaDeviceNameList();
-  std::vector<std::string> kExpectedEnaDefaults = {"ens32", "ens65", "ens130", "ens163"};
-  for (const auto& name : kExpectedEnaDefaults)
-    EXPECT_NE(std::find(ena_list.begin(), ena_list.end(), name), ena_list.end()) << "Missing ENA default: " << name;
+  auto const& ena_list = GetEnaDeviceNameList();
+  std::vector<std::string> kExpectedEnaDefaults = {"ens32", "ens65", "ens130",
+                                                   "ens163"};
+  for (auto const& name : kExpectedEnaDefaults)
+    EXPECT_NE(std::find(ena_list.begin(), ena_list.end(), name), ena_list.end())
+        << "Missing ENA default: " << name;
 }

--- a/efa/util_efa_device_name_list_test.cc
+++ b/efa/util_efa_device_name_list_test.cc
@@ -1,0 +1,58 @@
+#define UCCL_TESTING     // must precede any header that pulls in util_efa.h
+#include "util_efa.h"
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+using uccl::GetEfaDeviceNameList;
+using uccl::GetEnaDeviceNameList;
+using uccl::_detail::ResetDeviceNameListsForTest;
+
+class EfaDeviceNameListTest : public ::testing::Test {
+ protected:
+   void SetUp() override { ResetDeviceNameListsForTest(); }
+   void TearDown() override { unsetenv("UCCL_EFA_DEVICES"); }
+};
+
+class EnaDevice : public EfaDeviceNameListTest {
+ protected:
+   void SetUp() override { ResetDeviceNameListsForTest(); }
+   void TearDown() override { unsetenv("UCCL_ENA_DEVICES"); }
+};
+
+
+// 1. Env-var path
+TEST_F(EfaDeviceNameListTest, RespectsEnvVariable) {
+  setenv("UCCL_EFA_DEVICES", "efa0,efa1, rdmap42", /*overwrite=*/1);
+
+  const auto& list = GetEfaDeviceNameList();
+  EXPECT_EQ(list, std::vector<std::string>({"efa0", "efa1", "rdmap42"}));
+}
+
+// 1.1 Env-var path ENA
+TEST_F(EnaDevice, RespectsEnvVariable) {
+  setenv("UCCL_ENA_DEVICES", "ena0,ena1, ens42", /*overwrite=*/1);
+
+  const auto& list = GetEnaDeviceNameList();
+  EXPECT_EQ(list, std::vector<std::string>({"ena0", "ena1", "ens42"}));
+}
+
+// 2. Fallback path (no env, no real hw)
+//    We don’t enumerate hardware in a unit test, so we just make sure
+//    the function returns the built-in defaults when env is empty.
+TEST_F(EfaDeviceNameListTest, UsesBuiltInDefaultsWhenEnvMissing) {
+  // Explicitly ensure environment variables are not set to force hardware enumeration
+  unsetenv("UCCL_EFA_DEVICES");
+  unsetenv("UCCL_ENA_DEVICES");
+
+  // Check EFA defaults
+  const auto& efa_list = GetEfaDeviceNameList();
+  std::vector<std::string> kExpectedEfaDefaults = {"rdmap16s27", "rdmap32s27", "rdmap144s27", "rdmap160s27"};
+  for (const auto& name : kExpectedEfaDefaults)
+    EXPECT_NE(std::find(efa_list.begin(), efa_list.end(), name), efa_list.end()) << "Missing EFA default: " << name;
+
+  // Check ENA defaults
+  const auto& ena_list = GetEnaDeviceNameList();
+  std::vector<std::string> kExpectedEnaDefaults = {"ens32", "ens65", "ens130", "ens163"};
+  for (const auto& name : kExpectedEnaDefaults)
+    EXPECT_NE(std::find(ena_list.begin(), ena_list.end(), name), ena_list.end()) << "Missing ENA default: " << name;
+}

--- a/efa/util_efa_device_name_list_test.cc
+++ b/efa/util_efa_device_name_list_test.cc
@@ -37,5 +37,3 @@ TEST_F(EnaDevice, RespectsEnvVariable) {
   auto const& list = GetEnaDeviceNameList();
   EXPECT_EQ(list, std::vector<std::string>({"ena0", "ena1", "ens42"}));
 }
-
-

--- a/format.sh
+++ b/format.sh
@@ -8,10 +8,10 @@ DIRECTORIES=("afxdp" "efa" "gpu_driven" "rdma" "misc" "p2p" "include")
 EXTENSIONS=("cpp" "cxx" "cc" "h" "hpp" "cu" "cuh")
 EXCLUDE=("afxdp/lib")
 
-# Check if clang-format is installed
+Check if clang-format is installed
 if ! command -v clang-format &> /dev/null; then
-    echo "clang-format could not be found. Please install it first."
-    exit 1
+   echo "clang-format could not be found. Please install it first."
+   exit 1
 fi
 
 # Ensure clang-format version is 14
@@ -21,8 +21,8 @@ REQUIRED_VERSION="14"
 INSTALLED_VERSION=$(clang-format --version | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d. -f1)
 
 if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
-    echo "clang-format version $REQUIRED_VERSION is required. Found version: $INSTALLED_VERSION."
-    exit 1
+   echo "clang-format version $REQUIRED_VERSION is required. Found version: $INSTALLED_VERSION."
+   exit 1
 fi
 
 echo "Formatting C++ files..."

--- a/format.sh
+++ b/format.sh
@@ -8,10 +8,10 @@ DIRECTORIES=("afxdp" "efa" "gpu_driven" "rdma" "misc" "p2p" "include")
 EXTENSIONS=("cpp" "cxx" "cc" "h" "hpp" "cu" "cuh")
 EXCLUDE=("afxdp/lib")
 
-Check if clang-format is installed
+# Check if clang-format is installed
 if ! command -v clang-format &> /dev/null; then
-   echo "clang-format could not be found. Please install it first."
-   exit 1
+    echo "clang-format could not be found. Please install it first."
+    exit 1
 fi
 
 # Ensure clang-format version is 14
@@ -21,8 +21,8 @@ REQUIRED_VERSION="14"
 INSTALLED_VERSION=$(clang-format --version | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d. -f1)
 
 if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
-   echo "clang-format version $REQUIRED_VERSION is required. Found version: $INSTALLED_VERSION."
-   exit 1
+    echo "clang-format version $REQUIRED_VERSION is required. Found version: $INSTALLED_VERSION."
+    exit 1
 fi
 
 echo "Formatting C++ files..."


### PR DESCRIPTION
PR for Issue #13 to change from static EFA/ENA device list to automatically detecting devices.

Logic
- At init, enumerate RDMA devices via ibv_get_device_list() and filter by rdmap*/efa* prefix → build EFA_DEVICE_NAME_LIST dynamically.
- Enumerate NICs with getifaddrs() and collect ens* → ENA_DEVICE_NAME_LIST.
- Allow overrides via UCCL_EFA_DEVICES / UCCL_ENA_DEVICES env vars for edge cases (ex. admin/manually renamed devices)
- Keep current hard-coded names as a final fallback (I can also add a warn if used).

Testing
- Added `util_efa_device_name_list_test.cc` for unit tests
- Tested unit tests on a non-EFA device (my local Linux desktop)