### PR TITLE
make p2p work on amd

### DIFF
--- a/doc/dev_rdma.md
+++ b/doc/dev_rdma.md
@@ -109,7 +109,7 @@ Build `librccl-net-uccl.so`
 
 ```bash
 cd $UCCL_HOME/rdma
-make -f Makefile_hip -j
+make -f MakefileHip -j
 ```
 
 Run `rccl-tests`:
@@ -128,7 +128,7 @@ Using the following to build `librccl-net-uccl.so`
 
 ```bash
 cd $UCCL_HOME/rdma
-make -f Makefile_hip -j
+make -f MakefileHip -j
 ```
 
 Run `rccl-tests`:
@@ -156,7 +156,7 @@ Use `UCCL_PARAM()` to introduce new environment variables.
 | UCCL_ROCE_TRAFFIC_CLASS | Traffic class for RoCE | 3 |
 | UCCL_ROCE_SERVICE_LEVEL | Service level for RoCE | 135 |
 | UCCL_IB_SERVICE_LEVEL | Service level for IB | 0 |
-| UCCL_RCMODE | Use RC for data transfer | true (Broadcom NIC), false (others) |
+| UCCL_RCMODE | Use RC for data transfer | 1 (Broadcom NIC), 0 (others) |
 | UCCL_BYPASS_PACING | Bypass the pacing stage | true |
 | UCCL_NUM_ENGINES | Number of engines per device | 4 (NVIDIA), 1 (AMD) |
 | UCCL_PORT_ENTROPY | Path/QP per engine | 32 (NVIDIA), 256 (AMD) |

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -138,7 +138,7 @@ else
             CXX=/opt/rocm/bin/hipcc cmake -B build/release -S . -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF >/dev/null 2>&1 || true
             cd ../..
           fi
-          cd rdma && make clean -f Makefile_hip && make -j$(nproc) -f Makefile_hip && cd ..
+          cd rdma && make clean -f MakefileHip && make -j$(nproc) -f MakefileHip && cd ..
           TARGET_SO=rdma/librccl-net-uccl.so
       elif [[ "$TARGET" == efa ]]; then
           cd efa && make clean && make -j$(nproc) && cd ..

--- a/p2p/MakefileHip
+++ b/p2p/MakefileHip
@@ -1,0 +1,86 @@
+# Makefile for UCCL P2P Engine pybind11 project
+
+# Compiler and flags
+HIP_HOME?=/opt/rocm
+HIP_INC  := $(HIP_HOME)/include
+HIP_LIB  := $(HIP_HOME)/lib
+CONDA_LIB_HOME?=/usr/lib
+CXX := g++
+CXXFLAGS := -O3 -shared -std=c++17 -fPIC -I../include -I../rdma -I$(HIP_INC) \
+	-Wno-pointer-arith -Wno-sign-compare -Wno-unused-variable \
+	-Wl,-rpath=/usr/lib/x86_64-linux-gnu -I${CONDA_LIB_HOME}/../include -L${CONDA_LIB_HOME} -lglog -lgflags -lgtest -lz -lelf -libverbs -lpthread \
+	-DLAZY_CREATE_ENGINE
+
+# Python and pybind11 configuration
+PYTHON          ?= python3
+PYTHON_CONFIG    = $(PYTHON)-config
+PYEXT           := $(shell $(PYTHON_CONFIG) --extension-suffix)
+PYBIND11_INCLUDES := $(shell $(PYTHON) -m pybind11 --includes)
+PYTHON_LDFLAGS := $(shell $(PYTHON_CONFIG) --ldflags)
+
+# Python installation path
+PYTHON_SITE_PACKAGES := $(shell $(PYTHON) -c "import site; print(site.getsitepackages()[0])")
+INSTALL_DIR          := $(PYTHON_SITE_PACKAGES)/uccl
+
+# Redis
+REDIS_PKGCONFIG := pkg-config
+REDIS_CFLAGS    := $(shell $(REDIS_PKGCONFIG) --cflags hiredis redis++)
+REDIS_LIBS      := $(shell $(REDIS_PKGCONFIG) --libs hiredis redis++)
+CXXFLAGS       += $(REDIS_CFLAGS) -D__HIP_PLATFORM_AMD__
+LDFLAGS         = -L$(HIP_LIB) -lamdhip64 $(REDIS_LIBS) \
+                  -Wl,-rpath,$(HIP_LIB) -I${CONDA_LIB_HOME}/../include -L${CONDA_LIB_HOME} -lglog -lgflags -lgtest \
+                  -lz -lelf -libverbs -lpthread
+
+# Target and source files
+TARGET   := p2p$(PYEXT)
+SOURCES := engine.cc pybind_engine.cc
+OBJECTS := $(SOURCES:.cc=.o)
+
+# Default target
+all: $(TARGET)
+
+# Build the shared library
+$(TARGET): $(OBJECTS) ../rdma/librdma_hip.a
+	$(CXX) $(OBJECTS) ../rdma/librdma_hip.a \
+	      -L$(HIP_LIB) -lamdhip64 \
+	      -o $@ $(LDFLAGS) $(PYTHON_LDFLAGS) $(CXXFLAGS) \
+	      -Wl,-rpath,$(HIP_LIB)
+
+
+../rdma/librdma_hip.a: ../rdma/*.cc ../rdma/*.h
+	make CXXFLAGS=-DLAZY_CREATE_ENGINE -C ../rdma -f MakefileHip
+
+# Compile source files
+%.o: %.cc
+	$(CXX) $(CXXFLAGS) $(PYBIND11_INCLUDES) -c $< -o $@
+
+# Install the module
+install: $(TARGET)
+	@mkdir -p $(INSTALL_DIR)
+	@cp $(TARGET) $(INSTALL_DIR)/
+	@echo "Installation complete. Module installed as: $(INSTALL_DIR)/$(TARGET)"
+
+# Clean build artifacts
+clean:
+	rm -f $(OBJECTS) $(TARGET)
+	make -C ../rdma clean
+
+# Test the module
+test: $(TARGET)
+	$(PYTHON) test_engine.py
+
+# Install pybind11 if not available
+install-deps:
+	pip3 install pybind11
+
+# Help target
+help:
+	@echo "Available targets:"
+	@echo "  all          - Build the pybind11 module"
+	@echo "  install      - Install the module to Python site-packages"
+	@echo "  clean        - Remove build artifacts"
+	@echo "  test         - Run the test script"
+	@echo "  install-deps - Install pybind11 dependency"
+	@echo "  help         - Show this help message"
+
+.PHONY: all clean test install-deps help install 

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -112,6 +112,19 @@ python benchmark_uccl_dual.py --role server --device cpu --local-gpu-idx 0 --num
 python benchmark_uccl_dual.py --role client --device cpu --local-gpu-idx 0 --num-cpus 4 --remote-ip <Remote IP>
 ```
 
+To benchmark on AMD GPUs: 
+```bash
+make -j -f MakefileHip install
+
+export CONDA_LIB_HOME="/work1/yzhou/yangzhou/anaconda3/lib"
+export LD_LIBRARY_PATH=${CONDA_LIB_HOME}:/opt/rocm-6.3.1/lib:${LD_LIBRARY_PATH}
+export UCCL_RCMODE=1
+
+python benchmark_uccl.py --role server --device gpu --local-gpu-idx 0 --num-cpus 4
+python benchmark_uccl.py --role client --device gpu --local-gpu-idx 0 --num-cpus 4 --remote-ip <Server IP>
+```
+
+
 ### Running NIXL (with UCX backend)
 
 If you have not installed nixl with RDMA support, you can follow: 
@@ -205,6 +218,8 @@ To benchmark dual direction transfer, you can run `benchmark_nccl_dual.py` with 
 
 
 ## Usage Examples
+
+<details><summary>Click me</summary>
 
 ### Basic Endpoint Setup
 
@@ -337,8 +352,12 @@ assert success
 print(f"Received sizes: {recv_size_list}")
 ```
 
+</details>
+
 
 ## API Reference
+
+<details><summary>Click me</summary>
 
 ### Endpoint Class
 
@@ -500,6 +519,8 @@ Poll the status of an asynchronous transfer operation.
 **Returns:**
 - `success` (bool): Whether polling succeeded
 - `is_done` (bool): Whether the transfer has completed
+
+</details>
 
 
 ## Development and Testing

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -12,7 +12,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <vector>
-#define USE_REDIS
+// #define USE_REDIS
 #ifdef USE_REDIS
 #include <sw/redis++/redis++.h>
 #endif

--- a/rdma/MakefileHip
+++ b/rdma/MakefileHip
@@ -23,7 +23,7 @@ test_src := $(filter-out rdma_test.cc,$(test_src))
 test_bin = $(test_src:.cc=)
 
 .PHONY: build
-build: $(test_bin) $(lib_obj) $(PLUGIN_SO)
+build: $(test_bin) $(lib_obj) $(PLUGIN_SO) librdma_hip.a
 
 %_test: %_test.cc $(DEPS) $(lib_obj)
 	g++ $< -o $@ $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
@@ -34,6 +34,9 @@ build: $(test_bin) $(lib_obj) $(PLUGIN_SO)
 $(PLUGIN_SO): nccl_plugin.cc $(DEPS) $(lib_obj)
 	g++ $(NCCL_INC) -fPIC -shared -o $@ -Wl,-soname,$(PLUGIN_SO) nccl_plugin.cc $(lib_obj) $(INC) $(LIBS_SHARED) $(CXXFLAGS)
 
+librdma_hip.a: $(lib_obj)
+	ar rcs $@ $(lib_obj)
+
 .PHONY: clean
 clean:
-	rm -f *.o $(test_bin) $(PLUGIN_SO)
+	rm -f *.o $(test_bin) $(PLUGIN_SO) librdma_hip.a


### PR DESCRIPTION
I also commented out `#define USE_REDIS` in engine.h to make the build easier on AMD. @MaoZiming FYI. Later, I will figure out a way to install all deps via pip. See https://github.com/uccl-project/uccl/issues/194. 

<img width="485" height="212" alt="image" src="https://github.com/user-attachments/assets/11cd4609-608b-4005-acc6-1325dc374840" />
