### PR TITLE
Add Nvlink copy for p2p

### DIFF
--- a/include/util/cuda.h
+++ b/include/util/cuda.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cuda_runtime.h>
+
+#define CUDA_CHECK(call)                                            \
+  do {                                                              \
+    cudaError_t err__ = (call);                                     \
+    if (err__ != cudaSuccess) {                                     \
+      fprintf(stderr, "CUDA error %s:%d: %s\n", __FILE__, __LINE__, \
+              cudaGetErrorString(err__));                           \
+      std::abort();                                                 \
+    }                                                               \
+  } while (0)

--- a/include/util/net.h
+++ b/include/util/net.h
@@ -454,7 +454,7 @@ static bool parse_ip(std::string const& ip, sockaddr_storage* out,
   return false;
 }
 
-bool is_local_ip(std::string const& ip) {
+static bool is_local_ip(std::string const& ip) {
   sockaddr_storage target;
   socklen_t tlen = 0;
   int tfam = 0;

--- a/include/util/net.h
+++ b/include/util/net.h
@@ -9,6 +9,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <sys/socket.h>
@@ -435,6 +436,56 @@ static int find_interfaces(char* ifNames, union socketAddress* ifAddrs,
                              maxIfs);
   }
   return nIfs;
+}
+
+static bool parse_ip(std::string const& ip, sockaddr_storage* out,
+                     socklen_t* outlen, int* family) {
+  std::memset(out, 0, sizeof(*out));
+  if (inet_pton(AF_INET, ip.c_str(), &((sockaddr_in*)out)->sin_addr) == 1) {
+    *family = AF_INET;
+    *outlen = sizeof(sockaddr_in);
+    return true;
+  }
+  if (inet_pton(AF_INET6, ip.c_str(), &((sockaddr_in6*)out)->sin6_addr) == 1) {
+    *family = AF_INET6;
+    *outlen = sizeof(sockaddr_in6);
+    return true;
+  }
+  return false;
+}
+
+bool is_local_ip(std::string const& ip) {
+  sockaddr_storage target;
+  socklen_t tlen = 0;
+  int tfam = 0;
+  if (!parse_ip(ip, &target, &tlen, &tfam)) return false;
+
+  ifaddrs* ifs = nullptr;
+  if (getifaddrs(&ifs) != 0) return false;
+
+  bool found = false;
+  for (auto* it = ifs; it != nullptr; it = it->ifa_next) {
+    if (!it->ifa_addr) continue;
+    if (it->ifa_addr->sa_family != tfam) continue;
+
+    if (tfam == AF_INET) {
+      auto* a = (sockaddr_in*)it->ifa_addr;
+      auto* b = (sockaddr_in*)&target;
+      if (std::memcmp(&a->sin_addr, &b->sin_addr, sizeof(in_addr)) == 0) {
+        found = true;
+        break;
+      }
+    } else if (tfam == AF_INET6) {
+      auto* a = (sockaddr_in6*)it->ifa_addr;
+      auto* b = (sockaddr_in6*)&target;
+      if (std::memcmp(&a->sin6_addr, &b->sin6_addr, sizeof(in6_addr)) == 0) {
+        found = true;
+        break;
+      }
+    }
+  }
+  freeifaddrs(ifs);
+  return found;
 }
 
 }  // namespace uccl

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -346,15 +346,6 @@ bool Endpoint::regv(std::vector<void const*> const& data_v,
   return true;
 }
 
-bool Endpoint::py_send(uint64_t conn_id, uint64_t mr_id, void const* data,
-                       size_t size, std::optional<uccl::FifoItem> slot_item) {
-  py::gil_scoped_release release;
-  if (slot_item.has_value())
-    return send(conn_id, mr_id, data, size, slot_item.value());
-  else
-    return send(conn_id, mr_id, data, size);
-}
-
 bool Endpoint::send_ipc(uint64_t conn_id, uint64_t mr_id, void const* data,
                         size_t size, void const* meta, size_t meta_len) {
   py::gil_scoped_release release;

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -220,9 +220,6 @@ bool Endpoint::connect(py::bytes const& meta_bytes, uint64_t& conn_id) {
       // If the local GPU is the same as the remote GPU, we can use a special
       // connection ID to indicate this.
       conn_id = kNvlinkConn;
-      std::cout << "Connecting to self (local GPU is same as remote GPU), "
-                   "using NVLink connection ID."
-                << std::endl;
       return true;
     }
     if (is_nvlink_peer(local_gpu_idx_, remote_gpu_idx_)) {
@@ -396,8 +393,6 @@ bool Endpoint::send_ipc(uint64_t conn_id, uint64_t mr_id, void const* data,
 bool Endpoint::send(uint64_t conn_id, uint64_t mr_id, void const* data,
                     size_t size, uccl::FifoItem const& slot_item) {
   DCHECK(size <= 0xffffffff);
-  printf("Sending data of size %zu to conn_id %lu, mr_id %lu\n", size, conn_id,
-         mr_id);
   if (conn_id == kNvlinkConn) {
     auto* mr = mr_id_to_mr_[mr_id];
     int dst_gpu = remote_gpu_idx_;
@@ -417,7 +412,6 @@ bool Endpoint::send(uint64_t conn_id, uint64_t mr_id, void const* data,
       CUDA_CHECK(cudaMemcpyPeerAsync(reinterpret_cast<void*>(slot_item.addr),
                                      dst_gpu, data, src_gpu, size, s));
     }
-
     return true;
   }
   return send(conn_id, mr_id, data, size);

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -42,6 +42,13 @@ class Endpoint {
   const uint32_t kMaxInflightChunks = 8;
 
  public:
+  cudaStream_t pick_stream() {
+    if (streams_.empty()) return nullptr;
+    uint32_t i =
+        rr_stream_.fetch_add(1, std::memory_order_relaxed) % streams_.size();
+    return streams_[i];
+  }
+
   /*
    * Create engine threads running in background for a single interface. It also
    * opens a TCP listening thread waiting for incoming connections.
@@ -106,6 +113,9 @@ class Endpoint {
    *   size: the size of the data
    */
   bool send(uint64_t conn_id, uint64_t mr_id, void const* data, size_t size);
+
+  bool send(uint64_t conn_id, uint64_t mr_id, void const* data, size_t size,
+            uccl::FifoItem const& slot_item);
 
   bool read(uint64_t conn_id, uint64_t mr_id, void* dst, size_t size,
             uccl::FifoItem const& slot_item);
@@ -209,6 +219,7 @@ class Endpoint {
                      std::vector<PeerInfo>& out);
 
   int local_gpu_idx_;
+  int remote_gpu_idx_;
   uint32_t num_cpus_;
 
   uccl::RDMAEndpoint* ep_;
@@ -228,6 +239,8 @@ class Endpoint {
 
   // Assuming 1TB GPU memory, 128KB KV block size.
   static constexpr size_t kMaxNumChunksPerTransfer = 1024ul * 1024 * 1024 / 128;
+  std::atomic<uint32_t> rr_stream_{0};
+  std::vector<cudaStream_t> streams_;
 
   // Used for large KV transfer.
   class TransferMetaData {

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -104,8 +104,6 @@ class Endpoint {
   bool regv(std::vector<void const*> const& data_v,
             std::vector<size_t> const& size_v, std::vector<uint64_t>& mr_id_v);
 
-  bool py_send(uint64_t conn_id, uint64_t mr_id, void const* data, size_t size,
-               std::optional<uccl::FifoItem> slot_item);
   bool send_ipc(uint64_t conn_id, uint64_t mr_id, void const* data, size_t size,
                 void const* meta, size_t meta_len);
   /*

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -18,6 +18,7 @@
 #endif
 
 namespace py = pybind11;
+constexpr uint64_t kNvlinkConn = UINT64_MAX;
 
 struct MR {
   uint64_t mr_id_;
@@ -103,6 +104,10 @@ class Endpoint {
   bool regv(std::vector<void const*> const& data_v,
             std::vector<size_t> const& size_v, std::vector<uint64_t>& mr_id_v);
 
+  bool py_send(uint64_t conn_id, uint64_t mr_id, void const* data, size_t size,
+               std::optional<uccl::FifoItem> slot_item);
+  bool send_ipc(uint64_t conn_id, uint64_t mr_id, void const* data, size_t size,
+                void const* meta, size_t meta_len);
   /*
    * Send data to the remote server. Blocking.
    *

--- a/p2p/pybind_engine.cc
+++ b/p2p/pybind_engine.cc
@@ -88,11 +88,10 @@ PYBIND11_MODULE(p2p, m) {
               uccl::FifoItem item;
               uccl::deserialize_fifo_item(buf.data(), &item);
               return self.send(conn_id, mr_id,
-                                  reinterpret_cast<void const*>(ptr), size,
-                                  item);
+                               reinterpret_cast<void const*>(ptr), size, item);
             } else {
               return self.send(conn_id, mr_id,
-                                  reinterpret_cast<void const*>(ptr), size);
+                               reinterpret_cast<void const*>(ptr), size);
             }
           },
           "Send a data buffer, optionally using metadata (serialized FifoItem)",

--- a/p2p/pybind_engine.cc
+++ b/p2p/pybind_engine.cc
@@ -73,12 +73,25 @@ PYBIND11_MODULE(p2p, m) {
       .def(
           "send",
           [](Endpoint& self, uint64_t conn_id, uint64_t mr_id, uint64_t ptr,
-             size_t size) {
-            return self.send(conn_id, mr_id, reinterpret_cast<void const*>(ptr),
-                             size);
+             size_t size, py::object meta_blob = py::none()) {
+            if (!meta_blob.is_none()) {
+              std::string buf = py::cast<py::bytes>(meta_blob);
+              if (buf.size() != sizeof(uccl::FifoItem))
+                throw std::runtime_error(
+                    "meta must be exactly 64 bytes (serialized FifoItem)");
+
+              uccl::FifoItem item;
+              uccl::deserialize_fifo_item(buf.data(), &item);
+              return self.send(conn_id, mr_id,
+                               reinterpret_cast<void const*>(ptr), size, item);
+            } else {
+              return self.send(conn_id, mr_id,
+                               reinterpret_cast<void const*>(ptr), size);
+            }
           },
-          "Send a data buffer", py::arg("conn_id"), py::arg("mr_id"),
-          py::arg("ptr"), py::arg("size"))
+          "Send a data buffer, optionally using metadata (serialized FifoItem)",
+          py::arg("conn_id"), py::arg("mr_id"), py::arg("ptr"), py::arg("size"),
+          py::arg("meta") = py::none())
       .def(
           "read",
           [](Endpoint& self, uint64_t conn_id, uint64_t mr_id, uint64_t ptr,

--- a/p2p/pybind_engine.cc
+++ b/p2p/pybind_engine.cc
@@ -87,13 +87,12 @@ PYBIND11_MODULE(p2p, m) {
 
               uccl::FifoItem item;
               uccl::deserialize_fifo_item(buf.data(), &item);
-              return self.py_send(conn_id, mr_id,
+              return self.send(conn_id, mr_id,
                                   reinterpret_cast<void const*>(ptr), size,
                                   item);
             } else {
-              return self.py_send(conn_id, mr_id,
-                                  reinterpret_cast<void const*>(ptr), size,
-                                  std::nullopt);
+              return self.send(conn_id, mr_id,
+                                  reinterpret_cast<void const*>(ptr), size);
             }
           },
           "Send a data buffer, optionally using metadata (serialized FifoItem)",

--- a/p2p/test_engine_nvlink.py
+++ b/p2p/test_engine_nvlink.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Test script for the UCCL P2P Engine pybind11 extension
-using torch.distributed for inter-process communication.
+Test script for the UCCL P2P Engine
+using NVLink for inter-process communication.
 
 Run with:
   torchrun --nproc_per_node=2 test_engine_nvlink.py

--- a/p2p/test_engine_nvlink.py
+++ b/p2p/test_engine_nvlink.py
@@ -62,9 +62,7 @@ def test_local():
         tensor = torch.zeros(1024, dtype=torch.float32, device='cuda:0')
         assert tensor.is_contiguous()
 
-        success, mr_id = engine.reg(tensor.data_ptr(), tensor.numel() * 4)
-        assert success
-
+        mr_id = 0
         ok, fifo_blob = engine.advertise(conn_id,
                                  mr_id,
                                  tensor.data_ptr(),
@@ -92,13 +90,11 @@ def test_local():
         tensor = torch.ones(1024, dtype=torch.float32, device='cuda:0')
         assert tensor.is_contiguous()
 
-        success, mr_id = engine.reg(tensor.data_ptr(), tensor.numel() * 4)
-        assert success
-
         fifo_blob = q.get(timeout=10)
         print("Received FIFO blob from server")
         assert isinstance(fifo_blob, (bytes, bytearray)) and len(fifo_blob)
 
+        mr_id = 0
         success = engine.send(conn_id, mr_id, tensor.data_ptr(), tensor.numel() * 4, fifo_blob)
         assert success
         print("✓ Client sent data")

--- a/p2p/test_engine_nvlink.py
+++ b/p2p/test_engine_nvlink.py
@@ -4,7 +4,7 @@ Test script for the UCCL P2P Engine
 using NVLink for inter-process communication.
 
 Run with:
-  torchrun --nproc_per_node=2 test_engine_nvlink.py
+  OMP_NUM_THREADS=4 torchrun --nproc_per_node=2 test_engine_nvlink.py
 or:
   python -m torch.distributed.run --nproc_per_node=2 test_engine_nvlink.py
 """
@@ -110,7 +110,9 @@ def test_local_dist():
         print("[server] Buffer exposed for RDMA READ")
 
         _send_bytes(bytes(fifo_blob), dst=1)
-        time.sleep(1.0)
+
+        success = _recv_int(src=1)
+        assert success
 
         assert tensor.allclose(torch.ones(1024, dtype=torch.float32, device="cuda:0"))
         print("[server] Received correct data")
@@ -143,6 +145,8 @@ def test_local_dist():
         )
         assert success
         print("[client] Sent data")
+
+        _send_int(success, dst=0)
 
 
 def main():

--- a/p2p/test_engine_read.py
+++ b/p2p/test_engine_read.py
@@ -9,7 +9,7 @@ import sys, os, time, socket, struct, multiprocessing
 from typing import Tuple
 
 try:
-    from uccl import p2p          # ← your pybind11 module
+    from uccl import p2p
 except ImportError as e:
     sys.stderr.write(f"Failed to import p2p: {e}\n")
     sys.stderr.write("Build the pybind11 extension first (make)\n")

--- a/rdma/transport_config.h
+++ b/rdma/transport_config.h
@@ -32,6 +32,8 @@ UCCL_PARAM(NUM_ENGINES, "NUM_ENGINES", 4);
 UCCL_PARAM(PORT_ENTROPY, "PORT_ENTROPY", 32);
 // Maximum chunk size for each WQE.
 UCCL_PARAM(CHUNK_SIZE_KB, "CHUNK_SIZE_KB", 64);
+// Number of CUDA streams per engine.
+UCCL_PARAM(NumCudaStreams, "NUM_CUDA_STREAMS", 8);
 
 static constexpr uint32_t MAX_PEER = 256;
 // Maximum number of flows (one-way) on each engine.


### PR DESCRIPTION
Adding a simple API for local inter-process `cudaMemcpy`.
UCCL P2P will initiate a dummy connection `kNvlinkConn`.
Current code uses out-of-band notification for completed transfer. In a future PR, this should be folded into UCCL and UCCL should provide a receiver API for application to poll for completion, similar to `Endpoint::recv`. 