### PR TITLE
Fix util.h minor compiler warning

### DIFF
--- a/include/util/util.h
+++ b/include/util/util.h
@@ -64,8 +64,7 @@ inline int receive_message(int sockfd, void* buffer, size_t n_bytes) {
   int bytes_read = 0;
   int r;
   while (bytes_read < static_cast<int>(n_bytes)) {
-    r = read(sockfd,
-             static_cast<char*>(buffer) + bytes_read,
+    r = read(sockfd, static_cast<char*>(buffer) + bytes_read,
              static_cast<size_t>(n_bytes - bytes_read));
     if (r < 0 && !(errno == EAGAIN || errno == EWOULDBLOCK)) {
       CHECK(false) << "ERROR reading from socket";
@@ -82,7 +81,8 @@ inline int send_message(int sockfd, void const* buffer, size_t n_bytes) {
   int r;
   while (bytes_sent < static_cast<int>(n_bytes)) {
     // Make sure we write exactly n_bytes
-    r = write(sockfd, static_cast<const char*>(buffer) + bytes_sent, n_bytes - bytes_sent);
+    r = write(sockfd, static_cast<char const*>(buffer) + bytes_sent,
+              n_bytes - bytes_sent);
     if (r < 0 && !(errno == EAGAIN || errno == EWOULDBLOCK)) {
       CHECK(false) << "ERROR writing to socket";
     }


### PR DESCRIPTION
I got some warning from importing the util headers
```
❯ make
/usr/bin/g++ -O3 -std=c++17 -Wall -pthread -Iinclude -I/usr/local/cuda/include -I/usr/include -I../include -MMD -MP -c src/proxy.cpp -o src/proxy.o
/usr/bin/g++ -O3 -std=c++17 -Wall -pthread -Iinclude -I/usr/local/cuda/include -I/usr/include -I../include -MMD -MP -c src/rdma.cpp -o src/rdma.o
In file included from src/rdma.cpp:28:
../include/util/util.h:408:1: warning: multi-line comment [-Wcomment]
  408 | // #define load_acquire(p)                   \
      | ^
../include/util/util.h:414:1: warning: multi-line comment [-Wcomment]
  414 | // #define store_release(p, v)  \
      | ^
../include/util/util.h: In function ‘int uccl::receive_message(int, void*, size_t)’:
../include/util/util.h:66:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   66 |   while (bytes_read < n_bytes) {
      |          ~~~~~~~~~~~^~~~~~~~~
../include/util/util.h:68:29: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
   68 |     r = read(sockfd, buffer + bytes_read, n_bytes - bytes_read);
      |                      ~~~~~~~^~~~~~~~~~~~
../include/util/util.h: In function ‘int uccl::send_message(int, const void*, size_t)’:
../include/util/util.h:82:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   82 |   while (bytes_sent < n_bytes) {
      |          ~~~~~~~~~~~^~~~~~~~~
../include/util/util.h:84:30: warning: pointer of type ‘void *’ used in arithmetic [-Wpointer-arith]
   84 |     r = write(sockfd, buffer + bytes_sent, n_bytes - bytes_sent);
      |                       ~~~~~~~^~~~~~~~~~~~
../include/util/util.h: In function ‘int uccl::get_dev_index(const char*)’:
../include/util/util.h:646:27: warning: unused variable ‘sa’ [-Wunused-variable]
  646 |       struct sockaddr_in* sa = (struct sockaddr_in*)iap->ifa_addr;
```