### PR TITLE
Clean REMOTE_PERSISTENT_KERNEL_FLAG

### DIFF
--- a/gpu_driven/README.md
+++ b/gpu_driven/README.md
@@ -9,7 +9,6 @@ For UCCL's host/CPU-driven P2P engine, see [p2p](../p2p/) folder.
 2.	Rank 0 writes batched commands into a host-mapped ring buffer managed by local CPU proxy.
 3.	The CPU proxy of that rank polls that ring, posts `IBV_WR_RDMA_WRITE_WITH_IMM`, and recycles WQEs on completion.
 4.	Rank 1’s proxy (on the remote node) posts matching receives and funnels completed work into a peer-copy kernel (optional) that pushes data to additional GPUs through NVLink. This step mimicks the requirements in MoE models where a token can be routed to multiple experts on the remote node via NVLink for de-duplication.
-5.  Modify NUM_GPUS in uccl/gpu_driven/include/common.hpp based on your testbed.
 
 ## Install
 

--- a/gpu_driven/include/common.hpp
+++ b/gpu_driven/include/common.hpp
@@ -24,7 +24,6 @@
 #define kIterations 40000
 #define kNumThBlocks 6
 #define kNumThPerBlock 1
-#define kRemoteNVLinkBatchSize 16
 #define kObjectSize 10752  // 10.5 KB
 #define kMaxOutstandingSends 2048
 #define kMaxOutstandingRecvs 2048
@@ -40,7 +39,7 @@
 #define NVLINK_SM_PER_PROCESS 1
 
 // P2P enable flags (once per GPU pair)
-std::once_flag peer_ok_flag[MAX_NUM_GPUS][MAX_NUM_GPUS];
+extern std::once_flag peer_ok_flag[MAX_NUM_GPUS][MAX_NUM_GPUS];
 bool pin_thread_to_cpu(int cpu);
 void cpu_relax();
 

--- a/gpu_driven/include/common.hpp
+++ b/gpu_driven/include/common.hpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
 #include <thread>
 #include <stdio.h>
 #include <unistd.h>
@@ -37,7 +38,12 @@
 #define MAX_NUM_GPUS 8
 #define RECEIVER_BATCH_SIZE 16
 #define NVLINK_SM_PER_PROCESS 1
+
+// P2P enable flags (once per GPU pair)
+std::once_flag peer_ok_flag[MAX_NUM_GPUS][MAX_NUM_GPUS];
 bool pin_thread_to_cpu(int cpu);
 void cpu_relax();
+
+void maybe_enable_peer_access(int src_dev, int dst_dev);
 
 #endif  // COMMON_HPP

--- a/gpu_driven/include/common.hpp
+++ b/gpu_driven/include/common.hpp
@@ -34,7 +34,7 @@
 #define kWarmupOps 10000
 #define kRemoteBufferSize kBatchSize* kNumThBlocks* kObjectSize * 100
 #define MAIN_THREAD_CPU_IDX 31
-#define NUM_GPUS 1
+#define MAX_NUM_GPUS 8
 #define RECEIVER_BATCH_SIZE 16
 #define NVLINK_SM_PER_PROCESS 1
 bool pin_thread_to_cpu(int cpu);

--- a/gpu_driven/include/common.hpp
+++ b/gpu_driven/include/common.hpp
@@ -11,7 +11,6 @@
 #include <stdio.h>
 #include <unistd.h>
 
-// #define REMOTE_PERSISTENT_KERNEL
 #define USE_GRACE_HOPPER
 #define MEASURE_PER_OP_LATENCY
 #define ASSUME_WR_IN_ORDER
@@ -24,12 +23,7 @@
 #define kIterations 40000
 #define kNumThBlocks 6
 #define kNumThPerBlock 1
-#ifdef SYNCHRONOUS_COMPLETION
-#define kRemoteNVLinkBatchSize \
-  16  // Immediately synchronize stream for latency.
-#else
-#define kRemoteNVLinkBatchSize 512
-#endif
+#define kRemoteNVLinkBatchSize 16
 #define kObjectSize 10752  // 10.5 KB
 #define kMaxOutstandingSends 2048
 #define kMaxOutstandingRecvs 2048
@@ -42,12 +36,7 @@
 #define MAIN_THREAD_CPU_IDX 31
 #define NUM_GPUS 1
 #define RECEIVER_BATCH_SIZE 16
-#ifdef SYNCHRONOUS_COMPLETION
-#define NVLINK_SM_PER_PROCESS \
-  1  // Total number of SMs used is NVLINK_SM_PER_PROCESS * kNumThBlocks
-#else
-#define NVLINK_SM_PER_PROCESS 2
-#endif
+#define NVLINK_SM_PER_PROCESS 1
 bool pin_thread_to_cpu(int cpu);
 void cpu_relax();
 

--- a/gpu_driven/include/peer_copy_worker.hpp
+++ b/gpu_driven/include/peer_copy_worker.hpp
@@ -21,7 +21,6 @@ struct PeerWorkerCtx {
   // Counters / timings
   uint64_t async_memcpy_count = 0;
   uint64_t prev_completed_async_memcpy_count = 0;
-  uint64_t async_memcpy_total_time = 0;
   uint64_t highest_issued_wr_id = 0;
 
   // Batch buffers

--- a/gpu_driven/include/peer_copy_worker.hpp
+++ b/gpu_driven/include/peer_copy_worker.hpp
@@ -10,9 +10,6 @@ struct PeerCopyShared {
   // Controls the worker loop
   std::atomic<bool> run{true};
 
-  // P2P enable flags (once per GPU pair)
-  std::once_flag peer_ok_flag[MAX_NUM_GPUS][MAX_NUM_GPUS];
-
   // Source GPU for receiving host-side staging to device
   int src_device = 0;
 };

--- a/gpu_driven/include/peer_copy_worker.hpp
+++ b/gpu_driven/include/peer_copy_worker.hpp
@@ -11,7 +11,7 @@ struct PeerCopyShared {
   std::atomic<bool> run{true};
 
   // P2P enable flags (once per GPU pair)
-  std::once_flag peer_ok_flag[NUM_GPUS][NUM_GPUS];
+  std::once_flag peer_ok_flag[MAX_NUM_GPUS][MAX_NUM_GPUS];
 
   // Source GPU for receiving host-side staging to device
   int src_device = 0;

--- a/gpu_driven/include/proxy.hpp
+++ b/gpu_driven/include/proxy.hpp
@@ -36,7 +36,13 @@ class Proxy {
 
   explicit Proxy(Config const& cfg) : cfg_(cfg) {
     const size_t total_size = kRemoteBufferSize;
-    for (int d = 0; d < NUM_GPUS; ++d) {
+    int nDevices;
+    cudaError_t err = cudaGetDeviceCount(&nDevices);
+    if (err != cudaSuccess) {
+        printf("CUDA error: %s\n", cudaGetErrorString(err));
+        std::abort();
+    }
+    for (int d = 0; d < nDevices; ++d) {
       GPU_RT_CHECK(gpuSetDevice(d));
       void* buf = nullptr;
       GPU_RT_CHECK(gpuMalloc(&buf, total_size));

--- a/gpu_driven/include/proxy.hpp
+++ b/gpu_driven/include/proxy.hpp
@@ -39,8 +39,8 @@ class Proxy {
     int nDevices;
     cudaError_t err = cudaGetDeviceCount(&nDevices);
     if (err != cudaSuccess) {
-        printf("CUDA error: %s\n", cudaGetErrorString(err));
-        std::abort();
+      printf("CUDA error: %s\n", cudaGetErrorString(err));
+      std::abort();
     }
     for (int d = 0; d < nDevices; ++d) {
       GPU_RT_CHECK(gpuSetDevice(d));

--- a/gpu_driven/include/proxy_ctx.hpp
+++ b/gpu_driven/include/proxy_ctx.hpp
@@ -40,9 +40,9 @@ struct ProxyCtx {
 
   // GPU copy helpers (moved from function-static thread_local)
   gpuStream_t copy_stream = nullptr;
-  bool peer_enabled[NUM_GPUS][NUM_GPUS] = {};
+  bool peer_enabled[MAX_NUM_GPUS][MAX_NUM_GPUS] = {};
   size_t pool_index = 0;
 
   // Optional: per-GPU destination buffers if you previously used a global
-  void* per_gpu_device_buf[NUM_GPUS] = {nullptr};
+  void* per_gpu_device_buf[MAX_NUM_GPUS] = {nullptr};
 };

--- a/gpu_driven/src/common.cpp
+++ b/gpu_driven/src/common.cpp
@@ -3,6 +3,8 @@
 #include <immintrin.h>
 #endif
 
+std::once_flag peer_ok_flag[MAX_NUM_GPUS][MAX_NUM_GPUS];
+
 bool pin_thread_to_cpu(int cpu) {
   int num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
   if (cpu < 0 || cpu >= num_cpus) return false;

--- a/gpu_driven/src/peer_copy_worker.cpp
+++ b/gpu_driven/src/peer_copy_worker.cpp
@@ -86,29 +86,12 @@ void peer_copy_worker(PeerCopyShared& shared, PeerWorkerCtx& ctx,
         std::max(ctx.highest_issued_wr_id, ctx.task_wrs[copy_batch_size - 1]);
 
     auto st = std::chrono::high_resolution_clock::now();
-    gpuError_t err;
-    std::string func_name;
-
-    if (false) {
-      /* This works with dual mode. */
-      /* I suspect there is contention with application kernel and copy kernel
-       * in launch_peer_bulk_copy2 */
-      err =
-          gpuMemcpyPeerAsync(t.dst_ptr, t.dst_dev, t.src_ptr, shared.src_device,
-                             t.bytes * copy_batch_size, stream);
-      func_name = "gpuMemcpyPeerAsync";
-    } else if (false) {
-      err = launch_peer_bulk_copy(t.dst_ptr, t.dst_dev, t.src_ptr,
-                                  shared.src_device, t.bytes * copy_batch_size,
-                                  stream);
-      func_name = "launch_peer_bulk_copy";
-    } else if (false) {
-      /* The fastest among the three. */
-      // TODO(MaoZiming): enable this.
-      err = launch_peer_bulk_copy2(ctx.tasks, copy_batch_size, stream,
-                                   shared.src_device, d_tasks);
-      func_name = "launch_peer_bulk_copy2";
-    }
+    // NOTE(MaoZiming): peer_copy.cu has some kernels such as
+    // launch_peer_bulk_copy2 that might be good.
+    gpuError_t err =
+        gpuMemcpyPeerAsync(t.dst_ptr, t.dst_dev, t.src_ptr, shared.src_device,
+                           t.bytes * copy_batch_size, stream);
+    std::string func_name = "gpuMemcpyPeerAsync";
     if (err != gpuSuccess) {
       fprintf(stderr, "%s failed (%s) wr_id=%llu\n", func_name.c_str(),
               gpuGetErrorString(err), static_cast<unsigned long long>(t.wr_id));

--- a/gpu_driven/src/rdma.cpp
+++ b/gpu_driven/src/rdma.cpp
@@ -668,8 +668,8 @@ void remote_process_completions(ProxyCtx& S, int idx, CopyRingBuffer& g_ring,
   int nDevices;
   cudaError_t err = cudaGetDeviceCount(&nDevices);
   if (err != cudaSuccess) {
-      printf("CUDA error: %s\n", cudaGetErrorString(err));
-      std::abort();
+    printf("CUDA error: %s\n", cudaGetErrorString(err));
+    std::abort();
   }
   for (int i = 0; i < ne; ++i) {
     int src_addr_offset = 0;

--- a/gpu_driven/src/rdma.cpp
+++ b/gpu_driven/src/rdma.cpp
@@ -665,6 +665,12 @@ void remote_process_completions(ProxyCtx& S, int idx, CopyRingBuffer& g_ring,
   }
   std::vector<CopyTask> task_vec;
   task_vec.reserve(num_wr_imm);
+  int nDevices;
+  cudaError_t err = cudaGetDeviceCount(&nDevices);
+  if (err != cudaSuccess) {
+      printf("CUDA error: %s\n", cudaGetErrorString(err));
+      std::abort();
+  }
   for (int i = 0; i < ne; ++i) {
     int src_addr_offset = 0;
     // int destination_gpu;
@@ -672,7 +678,7 @@ void remote_process_completions(ProxyCtx& S, int idx, CopyRingBuffer& g_ring,
     if (wc[i].opcode != IBV_WC_RECV_RDMA_WITH_IMM) {
       continue;
     }
-    int destination_gpu = wc[i].imm_data % NUM_GPUS;
+    int destination_gpu = wc[i].imm_data % nDevices;
     if (S.per_gpu_device_buf[destination_gpu] == nullptr) {
       fprintf(stderr, "per_gpu_device_buf[%d] is null\n", destination_gpu);
       std::abort();


### PR DESCRIPTION
* clean `REMOTE_PERSISTENT_KERNEL_FLAG`
* Remove the need to set `NUM_GPUS`. 
* Use `gpuMemcpyPeerAsync` for now. Left a note for possibly using `launch_peer_bulk_copy`.