### PR TITLE
Update README to avoid mismatching python version issue 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ More UCCL features are under development in this repo, currently including:
 
 ## Quick Start
 
-The easiest way to use UCCL is to first build based on your platform: 
+The easiest way to use UCCL is to first build based on your platform,python version of your UCCL test environment is better to provide to avoid the version mismatching issue bettween UCCL compilation environment and UCCL test environment: 
 ```bash
 git clone https://github.com/uccl-project/uccl.git --recursive
-cd uccl && bash build_and_install.sh [cuda|rocm]
+cd uccl && bash build_and_install.sh [cuda|rocm] [python version of UCCL test environment]
 ```
 
 Then, when running your PyTorch applications, set the environment variable accordingly: 

--- a/p2p/README.md
+++ b/p2p/README.md
@@ -22,7 +22,7 @@ p2p/
 The easiest way is to: 
 ```bash
 git clone https://github.com/uccl-project/uccl.git --recursive
-cd uccl && bash build_and_install.sh [cuda|rocm] p2p
+cd uccl && bash build_and_install.sh [cuda|rocm] p2p [python version of UCCL test environment]
 ```
 
 Alternatively, you can setup your local dev environment by: 


### PR DESCRIPTION
## Description
Please include a summary of the changes and the related issue.
I met an issue of loading NCCL p2p module wrongly, whcih is caused by mismatching python version of UCCL compilation and test environment 
Fixes # (issue)
use the right version of python during UCCL compilation 
## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ *] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [* ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ *] I have updated the documentation.
- [ ] I have added tests.
