### PR TITLE
fix circular import on amd

### DIFF
--- a/uccl/__init__.py
+++ b/uccl/__init__.py
@@ -2,7 +2,7 @@ import os
 
 try:
     from . import _rocm_init
-except ModuleNotFoundError:
+except ImportError:
     pass
 else:
     _rocm_init.initialize()


### PR DESCRIPTION
## Description
- fix circular import on amd by replacing "ModuleNotFoundError" with "ImportError":
```
cannot import name '_rocm_init' from partially initialized module 'uccl' (most likely due to a circular import)
```

Fixes # (issue)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [x] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
