### PR TITLE
support for building with different cuda/rocm versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ The easiest way to use UCCL is to first build based on your platform. The build 
 git clone https://github.com/uccl-project/uccl.git --recursive
 cd uccl && bash build_and_install.sh [cuda|rocm|therock] [all|rdma|p2p|efa|ep] [py_version] [rocm_index_url]
 ```
-> Note: when building for ROCm with python packaging through TheRock, please specify your ROCm index url; the default is `https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu` and it may not be what you want. When installing UCCL wheels for TheRock, please provide pip with the index url and add the optional extra `[rocm]` to the wheel, e.g., `pip install --extra-index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu wheelhouse-therock/uccl-0.0.1.post4+therock-py3-none-manylinux_2_35_x86_64.whl[rocm]`.
-
+> Note: 
+> - when building for ROCm with python packaging through TheRock, please specify your ROCm index url; the default is `https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu` and it may not be what you want. When installing UCCL wheels for TheRock, please provide pip with the index url and add the optional extra `[rocm]` to the wheel, e.g., `pip install --extra-index-url https://rocm.nightlies.amd.com/v2/gfx94X-dcgpu wheelhouse-therock/uccl-0.0.1.post4+therock-py3-none-manylinux_2_35_x86_64.whl[rocm]`.
+> - you can build with different CUDA or ROCm versions by specifying tags such as cuda13 or rocm6. The default versions are CUDA 12.x for the "cuda" tag and ROCm 7.x for the "rocm" tag.
 
 Then, when running your PyTorch applications, set the environment variable accordingly: 
 ```bash

--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -5,7 +5,7 @@ BUILD_TYPE=${2:-all}
 PY_VER=${3:-$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")}
 GFX_VER=${4:-gfx94X-dcgpu}
 
-if [[ $TARGET != "cuda" && $TARGET != "rocm" && $TARGET != "therock" ]]; then
+if [[ $TARGET != cuda* && $TARGET != rocm* && $TARGET != "therock" ]]; then
   echo "Usage: $0 [cuda|rocm|therock] [all|rdma|p2p|efa|ep] [py_version] [rocm_index_url]" >&2
   exit 1
 fi

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:12.3.2-devel-ubuntu22.04
+ARG BASE_IMAGE=nvidia/cuda:12.3.2-devel-ubuntu22.04
+FROM ${BASE_IMAGE}
 ARG PY_VER=3.13
 
 # Non-interactive APT

--- a/docker/Dockerfile.efa
+++ b/docker/Dockerfile.efa
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:12.3.2-devel-ubuntu22.04
+ARG BASE_IMAGE=nvidia/cuda:12.3.2-devel-ubuntu22.04
+FROM ${BASE_IMAGE}
 ARG PY_VER=3.13
 
 # Non-interactive APT

--- a/docker/Dockerfile.gh
+++ b/docker/Dockerfile.gh
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
+ARG BASE_IMAGE=nvidia/cuda:12.4.1-devel-ubuntu22.04
+FROM ${BASE_IMAGE}
 ARG PY_VER=3.13
 
 # Non-interactive APT

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,4 +1,5 @@
-FROM rocm/dev-ubuntu-22.04
+ARG BASE_IMAGE=rocm/dev-ubuntu-22.04
+FROM ${BASE_IMAGE}
 ARG PY_VER=3.13
 
 # Non-interactive APT


### PR DESCRIPTION
## Description
The latest ROCm Docker images already use ROCm 7. It is necessary to provide options for users to build wheel packages for different ROCm/CUDA versions.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [x] My code follows the style guidelines, e.g. `format.sh`.
- [x] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [x] I have updated the documentation.
- [ ] I have added tests.
