### PR TITLE
Add Batched transfer metadata exchange for NIXL plugin

### DIFF
--- a/p2p/Makefile
+++ b/p2p/Makefile
@@ -17,6 +17,8 @@ PYEXT           := $(shell $(PYTHON_CONFIG) --extension-suffix)
 PYBIND11_INCLUDES := $(shell $(PYTHON) -m pybind11 --includes)
 PYTHON_LDFLAGS := $(shell $(PYTHON_CONFIG) --ldflags)
 
+PYTHON_LIB := $(shell $(PYTHON_CONFIG) --ldflags | grep -o 'python[0-9.]*' | head -1 | sed 's/^/-l/')
+
 # Installation path
 PYTHON_SITE_PACKAGES := $(shell $(PYTHON) -c "import site; print(site.getsitepackages()[0])")
 INSTALL_DIR          := $(PYTHON_SITE_PACKAGES)/uccl
@@ -52,7 +54,7 @@ $(PLUGIN_SO): $(CAPI_OBJECT) $(CORE_OBJECT) $(RDMA_HOME)/librdma_plugin.a
 	$(CXX) $(CAPI_OBJECT) $(CORE_OBJECT) $(RDMA_HOME)/librdma_plugin.a \
 	      -L$(CUDA_LIB) -lcudart -lcuda \
 	      -o $@ $(LDFLAGS) $(PYTHON_LDFLAGS) $(CXXFLAGS) \
-	      -Wl,-rpath,$(CUDA_LIB)
+	      -Wl,-rpath,$(CUDA_LIB) $(PYTHON_LIB) -libverbs -lz -lelf
 
 
 $(RDMA_HOME)/librdma.a: $(filter-out $(RDMA_HOME)/nccl_plugin.cc, $(wildcard $(RDMA_HOME)/*.cc)) $(RDMA_HOME)/*.h

--- a/p2p/uccl_engine.cc
+++ b/p2p/uccl_engine.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <functional>
 #include <future>
+#include <iostream>
 #include <mutex>
 #include <queue>
 #include <string>
@@ -129,7 +130,7 @@ void listener_thread_func(uccl_conn_t* conn) {
 
         {
           std::lock_guard<std::mutex> lock(fifo_item_map_mutex);
-          fifo_item_map[conn] = f_item;
+          fifo_item_map[conn+fifo_data.id] = f_item;
         }
         break;
       }
@@ -489,11 +490,11 @@ int uccl_engine_send_notif(uccl_conn_t* conn, notify_msg_t* notify_msg) {
   return send(conn->sock_fd, &md, sizeof(md_t), 0);
 }
 
-int uccl_engine_get_fifo_item(uccl_conn_t* conn, void* fifo_item) {
+int uccl_engine_get_fifo_item(uccl_conn_t* conn, int id, void* fifo_item) {
   if (!conn || !fifo_item) return -1;
 
   std::lock_guard<std::mutex> lock(fifo_item_map_mutex);
-  auto it = fifo_item_map.find(conn);
+  auto it = fifo_item_map.find(conn+id);
   if (it == fifo_item_map.end()) {
     return -1;
   }

--- a/p2p/uccl_engine.h
+++ b/p2p/uccl_engine.h
@@ -19,7 +19,9 @@ enum uccl_msg_type {
   UCCL_READ = 0,
   UCCL_WRITE = 1,
   UCCL_FIFO = 2,
-  UCCL_NOTIFY = 3
+  UCCL_NOTIFY = 3,
+  UCCL_VECTOR_READ = 4,
+  UCCL_VECTOR_WRITE = 5
 };
 
 typedef struct notify_msg {
@@ -36,12 +38,18 @@ typedef struct tx_msg {
   size_t data_size;   // Size of data to receive
 } tx_msg_t;
 
+typedef struct vector_msg {
+  size_t count;  // Number of items in the vector
+
+} vector_msg_t;
+
 typedef struct md {
   uccl_msg_type op;
   union {
     tx_msg_t tx_data;
     fifo_msg_t fifo_data;
     notify_msg_t notify_data;
+    vector_msg_t vector_data;
   } data;
 } md_t;
 
@@ -173,6 +181,16 @@ int uccl_engine_get_metadata(uccl_engine_t* engine, char** metadata_str);
  * @return              Number of bytes sent, or -1 on failure.
  */
 int uccl_engine_send_tx_md(uccl_conn_t* conn, md_t* md);
+
+/**
+ * Send multiple transfer metadata as a vector.
+ * @param conn          Connection handle.
+ * @param md_array      Array of transfer metadata.
+ * @param count         Number of metadata items in the array.
+ * @return              Number of bytes sent, or -1 on failure.
+ */
+int uccl_engine_send_tx_md_vector(uccl_conn_t* conn, md_t* md_array,
+                                  size_t count);
 
 /**
  * Get all notification messages and clear the list.

--- a/p2p/uccl_engine.h
+++ b/p2p/uccl_engine.h
@@ -30,6 +30,7 @@ typedef struct notify_msg {
 } notify_msg_t;
 
 typedef struct fifo_msg {
+  int id;
   char fifo_buf[MSG_SIZE];
 } fifo_msg_t;
 
@@ -122,8 +123,14 @@ uccl_mr_t* uccl_engine_reg(uccl_engine_t* engine, uintptr_t data, size_t size);
  */
 int uccl_engine_read(uccl_conn_t* conn, uccl_mr_t* mr, void const* data,
                      size_t size, void* slot_item, uint64_t* transfer_id);
-
-int uccl_engine_get_fifo_item(uccl_conn_t* conn, void* fifo_item);
+/**
+ * Get a FIFO item.
+ * @param conn          Connection handle.
+ * @param id            FIFO item ID.
+ * @param fifo_item     Pointer to the FIFO item.
+ * @return              0 on success, non-zero on failure.
+ */
+int uccl_engine_get_fifo_item(uccl_conn_t* conn, int id, void* fifo_item);
 
 /**
  * Send data (Non blocking).

--- a/p2p/uccl_engine.h
+++ b/p2p/uccl_engine.h
@@ -18,10 +18,10 @@ typedef struct uccl_mr uccl_mr_t;
 enum uccl_msg_type {
   UCCL_READ = 0,
   UCCL_WRITE = 1,
-  UCCL_FIFO = 2,
-  UCCL_NOTIFY = 3,
-  UCCL_VECTOR_READ = 4,
-  UCCL_VECTOR_WRITE = 5
+  UCCL_VECTOR_READ = 2,
+  UCCL_VECTOR_WRITE = 3,
+  UCCL_FIFO = 4,
+  UCCL_NOTIFY = 5
 };
 
 typedef struct notify_msg {


### PR DESCRIPTION
## Description
Batch sending of data_ptrs for read prep, by adding a new API `uccl_engine_send_tx_md_vector`. UCCL Backend of NIXL will be using this API to perform `PrepXfer` (https://github.com/praveingk/nixl-uccl/blob/15149bcc093133d4e6638c69f8dab2a0d4c5486c/src/plugins/uccl/uccl_backend.cpp#L427).
This optimization brings down the overall read time in vllm significantly by 80 ms. Overall, I observe UCCL latency is 15% lower than UCX.

Other change is to add static linking for uccl engine building for nixl's gtest.

**Item                  | UCCL   | UCX**
make_prep      | 5.02      | 4
Read launch    | 0.08      | 0.23
Read Transfer | 274       | 323
Total                 | 279.1.   | 327.23
Median TTFT  | 1098.    | 1145
Mean TTFT     | 1104.     | 1145


## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x ] Unit tests
- [] Integration tests
- [x ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
