### PR TITLE
Fix missing install requirement on intervaltree.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         ],
     },
     license="Apache-2.0",
-    install_requires=[],
+    install_requires=["intervaltree"],
     classifiers=[
         "Programming Language :: Python :: 3",
     ],


### PR DESCRIPTION
## Description
Add install dependence on `intervaltree` module which is being imported in `uccl/utils.py` but is not currently listed as a dependence resulting in import failures.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] My code follows the style guidelines, e.g. `format.sh`.
- [x] I have run `build_and_install.sh` to verify compilation.
- [x] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
