### PR TITLE
Fix wheel name parsing and python-packaged ROCm suffix.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -350,11 +350,15 @@ def initialize():
 
     # Add backend tag to wheel filename using local version identifier
     if [[ "$TARGET" == rocm* || "$TARGET" == "therock" ]]; then
+      # Adjust TARGET to the preferred wheel name suffix for python-packaged ROCm, e.g. "rocm7.9.0rc1"
+      if [[ "$TARGET" == "therock" ]]; then
+        TARGET="rocm$(rocm-sdk version)"
+      fi
       cd /io/${WHEEL_DIR}
       for wheel in uccl-*.whl; do
         if [[ -f "$wheel" ]]; then
           # Extract wheel name components: uccl-version-python-abi-platform.whl
-          if [[ "$wheel" =~ ^(uccl-)([^-]+)-([^-]+-[^-]+-[^.]+)(\.whl)$ ]]; then
+          if [[ "$wheel" =~ ^(uccl-)([^-]+)-([^-]+-[^-]+-.+)(\.whl)$ ]]; then
             name="${BASH_REMATCH[1]}"
             version="${BASH_REMATCH[2]}"
             python_abi_platform="${BASH_REMATCH[3]}"


### PR DESCRIPTION
## Description
Make wheel name parsing more robust to handle multiple signatures, e.g. "py3-none-manylinux_2_27_x86_64.manylinux_2_28_x86_64"

Also update the ROCm suffix for python-packaged ROCm builds to the pattern expected by TheRock project, e.g. "rocm7.9.0rc1"

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] My code follows the style guidelines, e.g. `format.sh`.
- [x] I have run `build_and_install.sh` to verify compilation.
- [x] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
