### PR TITLE
fix destory mr

### DIFF
--- a/p2p/uccl_engine.cc
+++ b/p2p/uccl_engine.cc
@@ -489,6 +489,7 @@ void uccl_engine_conn_destroy(uccl_conn_t* conn) {
 void uccl_engine_mr_destroy(uccl_mr_t* mr) {
   for (auto it = mem_reg_info.begin(); it != mem_reg_info.end(); ++it) {
     if (it->second == mr->mr_id) {
+      mr->engine->endpoint->dereg(mr->mr_id);
       mem_reg_info.erase(it);
       break;
     }


### PR DESCRIPTION
## Description
It seems we forgot to destroy the MR in uccl_engine.

Fixes # (issue)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
