### PR TITLE
Fix missing semicolon

### DIFF
--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -2022,7 +2022,7 @@ PYBIND11_MODULE(ep, m) {
     CUDA_CHECK(
         hipExtMallocWithFlags(&ptr, num_rdma_bytes, hipDeviceMallocUncached));
 #else
-    EP_HOST_ASSERT(false and "Please use torch.zeros instead on CUDA platform.")
+    EP_HOST_ASSERT(false and "Please use torch.zeros instead on CUDA platform.");
 #endif
     CUDA_CHECK(cudaMemset(ptr, 0, num_rdma_bytes));
     return torch::from_blob(ptr, {num_rdma_bytes},


### PR DESCRIPTION
Fixes
```
#33 35.23 In file included from /uccl/ep/include/ep_util.hpp:2,
#33 35.23                  from /uccl/ep/include/ep_config.hpp:3,
#33 35.23                  from /uccl/ep/src/uccl_ep.cc:5:
#33 35.23 /uccl/ep/src/uccl_ep.cc: In lambda function:
#33 35.23 /uccl/ep/include/exception.cuh:27:3: error: expected ‘;’ before ‘do’
#33 35.23    27 |   do {                                                                      \
#33 35.23       |   ^~
#33 35.23 /uccl/ep/include/exception.cuh:27:3: note: in definition of macro ‘CUDA_CHECK’
#33 35.23    27 |   do {                                                                      \
#33 35.23       |   ^~
```
cc @zhenhuang12 @YangZhou1997 @MaoZiming