### PR TITLE
[Build] Fix Makefile header dependency tracking

### DIFF
--- a/collective/efa/Makefile
+++ b/collective/efa/Makefile
@@ -8,8 +8,8 @@ EFA_HOME?=/opt/amazon/efa
 INC = -I./ -I$(CUDA_HOME)/include -I${EFA_HOME}/include -I$(ABS_REPO_ROOT)/include
 LIBS = -L ${CUDA_HOME}/lib64 -L ${EFA_HOME}/lib -libverbs -lefa -lcudart -lcuda -lpthread -lglog -lgflags -lgtest -lz -lelf
 LIBS_SHARED = ${LIBS}
-override CXXFLAGS += -O3 -g -std=c++17 -Wno-pointer-arith -Wno-interference-size -fPIC -DUSE_CUDA
-DEPS = *.h
+# Added -MMD -MP for automatic dependency generation
+override CXXFLAGS += -O3 -g -std=c++17 -Wno-pointer-arith -Wno-interference-size -fPIC -DUSE_CUDA -MMD -MP
 PLUGIN_SO = libnccl-net-efa.so
 
 lib_src = $(wildcard *.cc)
@@ -23,41 +23,45 @@ main_src = $(wildcard *_main.cc)
 main_src += $(wildcard *_test.cc)
 main_bin = $(main_src:.cc=)
 
+# Include automatically generated dependency files
+-include $(lib_obj:.o=.d)
+-include $(patsubst %,%.d,$(main_bin))
+
 .PHONY: build
 build: $(main_bin) $(PLUGIN_SO)
 
-transport_test: transport_test.cc $(DEPS) $(lib_obj)
+transport_test: transport_test.cc $(lib_obj)
 	g++ transport_test.cc -o transport_test $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
-util_efa_test: util_efa_test.cc $(DEPS) $(lib_obj)
+util_efa_test: util_efa_test.cc $(lib_obj)
 	g++ util_efa_test.cc -o util_efa_test $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
-util_efa_device_name_list_test: util_efa_device_name_list_test.cc util_efa.cc $(DEPS) $(filter-out util_efa.o,$(lib_obj))
+util_efa_device_name_list_test: util_efa_device_name_list_test.cc util_efa.cc $(filter-out util_efa.o,$(lib_obj))
 	g++ -DUCCL_TESTING util_efa_device_name_list_test.cc util_efa.cc -o util_efa_device_name_list_test $(filter-out util_efa.o,$(lib_obj)) $(INC) $(LIBS) $(CXXFLAGS) -lgtest_main
 
-timely_test: timely_test.cc $(DEPS) $(lib_obj)
+timely_test: timely_test.cc $(lib_obj)
 	g++ timely_test.cc -o timely_test $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
-timing_wheel_test: timing_wheel_test.cc $(DEPS) $(lib_obj)
+timing_wheel_test: timing_wheel_test.cc $(lib_obj)
 	g++ timing_wheel_test.cc -o timing_wheel_test $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
-util_lrpc_test: util_lrpc_test.cc $(DEPS) $(lib_obj)
+util_lrpc_test: util_lrpc_test.cc $(lib_obj)
 	g++ util_lrpc_test.cc -o util_lrpc_test $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
-scattered_memcpy_test: scattered_memcpy_test.cc $(DEPS) $(lib_obj)
+scattered_memcpy_test: scattered_memcpy_test.cc $(lib_obj)
 	g++ scattered_memcpy_test.cc -o scattered_memcpy_test $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
 scattered_memcpy.o: scattered_memcpy.cu scattered_memcpy.cuh
 	nvcc -c scattered_memcpy.cu -o scattered_memcpy.o -arch=sm_70 -Xcompiler -fPIC
 
-%.o: %.cc $(DEPS)
+%.o: %.cc
 	g++ -c $< -o $@ $(INC) $(CXXFLAGS)
 
 NCCL_INC:= -I$(NCCL_HOME)/build/include -I$(NCCL_HOME)/src/include -I$(CUDA_HOME)/include
 
-$(PLUGIN_SO): nccl_plugin.cc $(DEPS) $(lib_obj)
+$(PLUGIN_SO): nccl_plugin.cc $(lib_obj)
 	g++ $(NCCL_INC) -fPIC -shared -o $@ -Wl,-soname,$(PLUGIN_SO) nccl_plugin.cc $(lib_obj) $(INC) $(LIBS_SHARED) $(CXXFLAGS)
 
 .PHONY: clean
 clean:
-	rm -f *.o $(main_bin) $(PLUGIN_SO)
+	rm -f *.o *.d $(main_bin) $(PLUGIN_SO)

--- a/collective/rdma/Makefile
+++ b/collective/rdma/Makefile
@@ -7,8 +7,8 @@ CUDA_HOME?=/usr/local/cuda
 INC = -I./ -I$(CUDA_HOME)/include -I$(ABS_REPO_ROOT)/include
 LIBS = -lglog -lgflags -lgtest -lz -lelf -libverbs -L /usr/local/cuda/lib64 -lcudart -lpthread
 LIBS_SHARED = -lglog -lgflags -lgtest -lz -lelf -libverbs
-override CXXFLAGS += -O3 -g -std=c++17 -Wno-pointer-arith -Wno-interference-size -fPIC -DUSE_CUDA
-DEPS = *.h
+# Added -MMD -MP for automatic dependency generation
+override CXXFLAGS += -O3 -g -std=c++17 -Wno-pointer-arith -Wno-interference-size -fPIC -DUSE_CUDA -MMD -MP
 PLUGIN_SO = libnccl-net-uccl.so
 NCCL_INC:= -I$(NCCL_HOME)/build/include -I$(NCCL_HOME)/src/include -I$(CUDA_HOME)/include
 
@@ -21,18 +21,22 @@ lib_obj = $(lib_src:.cc=.o)
 test_src = $(wildcard *_test.cc)
 test_bin = $(test_src:.cc=)
 
+# Include automatically generated dependency files
+-include $(lib_obj:.o=.d)
+-include $(patsubst %,%.d,$(test_bin))
+
 .PHONY: build
 build: $(test_bin) $(lib_obj) $(PLUGIN_SO) librdma.a librdma_plugin.a
 
 azure: $(test_bin) $(lib_obj)
 
-%_test: %_test.cc $(DEPS) $(lib_obj)
+%_test: %_test.cc $(lib_obj)
 	g++ $< -o $@ $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
-%.o: %.cc $(DEPS)
+%.o: %.cc
 	g++ -c $< -o $@ $(INC) $(CXXFLAGS)
 
-$(PLUGIN_SO): nccl_plugin.cc $(DEPS) $(lib_obj)
+$(PLUGIN_SO): nccl_plugin.cc $(lib_obj)
 	g++ $(NCCL_INC) -fPIC -shared -o $@ -Wl,-soname,$(PLUGIN_SO) nccl_plugin.cc $(lib_obj) $(INC) $(LIBS_SHARED) $(CXXFLAGS)
 
 librdma.a: $(lib_obj)
@@ -43,4 +47,4 @@ librdma_plugin.a: $(lib_obj)
 
 .PHONY: clean
 clean:
-	rm -f *.o $(test_bin) $(PLUGIN_SO) librdma.a librdma_plugin.a
+	rm -f *.o *.d $(test_bin) $(PLUGIN_SO) librdma.a librdma_plugin.a

--- a/collective/rdma/Makefile.rocm
+++ b/collective/rdma/Makefile.rocm
@@ -8,8 +8,8 @@ CONDA_LIB_HOME?=/usr/lib
 INC = -I./ -I$(ABS_REPO_ROOT)/include -I$(HIP_HOME)/include -I${CONDA_LIB_HOME}/../include -L${CONDA_LIB_HOME}
 LIBS = -lglog -lgflags -lgtest -lz -lelf -libverbs -L ${HIP_HOME}/lib -lamdhip64 -lpthread -ldl
 LIBS_SHARED = -lglog -lgflags -lgtest -lz -lelf -libverbs -lpthread -ldl
-override CXXFLAGS += -O3 -g -std=c++17 -Wno-pointer-arith -Wno-interference-size -fPIC -D__HIP_PLATFORM_AMD__
-DEPS = *.h
+# Added -MMD -MP for automatic dependency generation
+override CXXFLAGS += -O3 -g -std=c++17 -Wno-pointer-arith -Wno-interference-size -fPIC -D__HIP_PLATFORM_AMD__ -MMD -MP
 PLUGIN_SO = librccl-net-uccl.so
 NCCL_INC:= -I$(RCCL_HOME)/build/release/include -I$(RCCL_HOME)/src/include -I$(HIP_HOME)/include
 
@@ -23,16 +23,20 @@ test_src = $(wildcard *_test.cc)
 test_src := $(filter-out rdma_test.cc,$(test_src))
 test_bin = $(test_src:.cc=)
 
+# Include automatically generated dependency files
+-include $(lib_obj:.o=.d)
+-include $(patsubst %,%.d,$(test_bin))
+
 .PHONY: build
 build: $(test_bin) $(lib_obj) $(PLUGIN_SO) librdma_hip.a
 
-%_test: %_test.cc $(DEPS) $(lib_obj)
+%_test: %_test.cc $(lib_obj)
 	g++ $< -o $@ $(lib_obj) $(INC) $(LIBS) $(CXXFLAGS)
 
-%.o: %.cc $(DEPS)
+%.o: %.cc
 	g++ -c $< -o $@ $(INC) $(CXXFLAGS)
 
-$(PLUGIN_SO): nccl_plugin.cc $(DEPS) $(lib_obj)
+$(PLUGIN_SO): nccl_plugin.cc $(lib_obj)
 	g++ $(NCCL_INC) -fPIC -shared -o $@ -Wl,-soname,$(PLUGIN_SO) nccl_plugin.cc $(lib_obj) $(INC) $(LIBS_SHARED) $(CXXFLAGS)
 
 librdma_hip.a: $(lib_obj)
@@ -40,4 +44,4 @@ librdma_hip.a: $(lib_obj)
 
 .PHONY: clean
 clean:
-	rm -f *.o $(test_bin) $(PLUGIN_SO) librdma_hip.a
+	rm -f *.o *.d $(test_bin) $(PLUGIN_SO) librdma_hip.a


### PR DESCRIPTION
## Summary

Fix Makefiles to properly track header file dependencies, including headers in the `include/` directory.

**Problem:** The existing `DEPS = *.h` pattern only matches headers in the current directory, not in `$(ABS_REPO_ROOT)/include/`. This means changes to shared headers like `util/net.h` or `util/util.h` don't trigger rebuilds.

**Solution:** Use GCC's automatic dependency generation (`-MMD -MP` flags) which creates `.d` files containing the complete dependency chain for each source file.

## Changes

- `collective/rdma/Makefile` - Add automatic dependency generation
- `collective/rdma/Makefile.rocm` - Add automatic dependency generation  
- `collective/efa/Makefile` - Add automatic dependency generation

### Key modifications:
1. Add `-MMD -MP` flags to `CXXFLAGS`
2. Include generated `.d` files with `-include` directive
3. Remove static `DEPS = *.h` variable
4. Add `*.d` to clean target

## How it works

The `-MMD` flag tells GCC to generate a `.d` file for each compiled source, listing all headers it depends on. For example, `transport.d` might contain:
```makefile
transport.o: transport.cc transport.h ../../../include/util/net.h ../../../include/util/util.h
```

Now when any header changes, Make knows which objects need rebuilding.

## Test Plan

- [ ] Verify `make clean && make` works correctly
- [ ] Modify a header in `include/` and verify dependent objects rebuild
- [ ] Verify `.d` files are generated and cleaned up properly

Fixes #135
