### PR TITLE
[FIX] Replace std::cout with glog in nccl_plugin.cc

### DIFF
--- a/collective/rdma/nccl_plugin.cc
+++ b/collective/rdma/nccl_plugin.cc
@@ -83,7 +83,7 @@ struct ucclSendComm {
 };
 
 ncclResult_t pluginInit(ncclDebugLogger_t logFunction) {
-  std::cout << "Hello UCCL from PID: " << getpid() << std::endl;
+  LOG(INFO) << "UCCL RDMA Plugin initialized, PID: " << getpid();
 
   ep = std::make_shared<RDMAEndpoint>(ucclParamNUM_ENGINES());
 


### PR DESCRIPTION
## Summary
- Replace raw `std::cout` logging with `LOG(INFO)` in RDMA plugin initialization
- Uses same glog infrastructure as rest of codebase for consistent logging output

## Related Issue
Fixes #131

## Changes
- `collective/rdma/nccl_plugin.cc`: Changed `std::cout << "Hello UCCL from PID: " << getpid()` to `LOG(INFO) << "UCCL RDMA Plugin initialized, PID: " << getpid()`

## Test plan
- [ ] Build the RDMA plugin
- [ ] Verify log output uses glog format

🤖 Generated with [Claude Code](https://claude.com/claude-code)