### PR TITLE
Change dest qpn from uint16_t to uint32_t

### DIFF
--- a/collective/efa/util_efa.h
+++ b/collective/efa/util_efa.h
@@ -89,7 +89,7 @@ class FrameDesc {
   uint32_t pkt_data_lkey_tx_;  // Tx buff may come from app.
 
   uint16_t src_qp_idx_;     // src QP to use for this frame.
-  uint16_t dest_qpn_;       // dest QPN to use for this frame.
+  uint32_t dest_qpn_;       // dest QPN to use for this frame.
   struct ibv_ah* dest_ah_;  // dest ah to use for this frame.
 
   uint64_t cpe_time_tsc_;  // Completion event time.
@@ -113,7 +113,7 @@ class FrameDesc {
         pkt_data_lkey_tx_(pkt_data_lkey_tx),
         msg_flags_(msg_flags) {
     src_qp_idx_ = UINT16_MAX;
-    dest_qpn_ = UINT16_MAX;
+    dest_qpn_ = UINT32_MAX;
     dest_ah_ = nullptr;
     next_ = nullptr;
     poll_ctx_ = nullptr;
@@ -155,8 +155,8 @@ class FrameDesc {
   uint16_t get_src_qp_idx() const { return src_qp_idx_; }
   void set_src_qp_idx(uint16_t src_qp_idx) { src_qp_idx_ = src_qp_idx; }
 
-  uint16_t get_dest_qpn() const { return dest_qpn_; }
-  void set_dest_qpn(uint16_t dest_qpn) { dest_qpn_ = dest_qpn; }
+  uint32_t get_dest_qpn() const { return dest_qpn_; }
+  void set_dest_qpn(uint32_t dest_qpn) { dest_qpn_ = dest_qpn; }
 
   struct ibv_ah* get_dest_ah() const {
     return dest_ah_;


### PR DESCRIPTION
## Description
Packet loss and RTO retransmissions were seen when testing with Intel RDMA NIC using UD QP with collective EFA.

The root cause was that RDMA QP numbers are 24-bit values (range 0 to 16,777,215), but dest_qpn_ was stored as a 16-bit uint16_t (range 0 to 65,535). When QP numbers exceeded 65,535 (like 121789 or 116470), they were truncated:

121789 stored in uint16_t truncated to 56253 (121789 & 0xFFFF) 116470 stored in uint16_t truncated to 50934 (116470 & 0xFFFF) Packets were being sent to these incorrect, truncated QP numbers, which didn't exist, causing 100% packet loss and RTO retransmissions.

Fixes # (issue)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] My code follows the style guidelines, e.g. `format.sh`.
- [x] I have run `build_and_install.sh` to verify compilation.
- [x] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
