### PR TITLE
[EP] Remove `--pressure-test-mode=2` from `ll` mode in run_ep.sh

### DIFF
--- a/ep/bench/run_ep.sh
+++ b/ep/bench/run_ep.sh
@@ -11,7 +11,7 @@ if [ "$MODE" = "ll" ]; then
     torchrun --nnodes=$NNODES --nproc_per_node=8 --node_rank=$RANK \
         --master_addr=$MAIN_IP --master_port=12355 \
         test_low_latency.py --num-tokens=128 \
-        --hidden=7168 --num-topk=8 --num-experts=288 --pressure-test-mode=2
+        --hidden=7168 --num-topk=8 --num-experts=288
 elif [ "$MODE" = "ht" ]; then
     torchrun --nnodes=$NNODES --nproc_per_node=8 --node_rank=$RANK \
         --master_addr=$MAIN_IP --master_port=12355 \


### PR DESCRIPTION
Removed pressure test mode argument from low latency test.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
