### PR TITLE
EP: fix cached_notify when use num_sms>32 on amdgpu.

### DIFF
--- a/ep/src/internode.cu
+++ b/ep/src/internode.cu
@@ -1671,8 +1671,9 @@ __global__ void cached_notify(
     // NOTE(zhuang12): for support channel numbers >= WARP_SIZE, we need to
     // iterate over the channels in a warp-wise manner
     int remain_warp_id = warp_id;
-    for (int i = 0; i < num_channels; i += num_warps) {
-      warp_id = i * num_warps + remain_warp_id;
+    for (int channel_start = 0; channel_start < num_channels;
+         channel_start += num_warps) {
+      warp_id = channel_start + remain_warp_id;
 #endif
       if (lane_id < num_rdma_ranks and warp_id < num_channels) {
         int token_start_idx, token_end_idx;
@@ -1711,8 +1712,9 @@ __global__ void cached_notify(
     // NOTE(zhuang12): for support channel numbers >= WARP_SIZE, we need to
     // iterate over the channels in a warp-wise manner
     int remain_warp_id = warp_id;
-    for (int i = 0; i < num_channels; i += num_warps) {
-      warp_id = i * num_warps + remain_warp_id;
+    for (int channel_start = 0; channel_start < num_channels;
+         channel_start += num_warps) {
+      warp_id = channel_start + remain_warp_id;
 #endif
       if (warp_id < num_channels) {
         constexpr int tma_batch_size = kNumTMABytesPerWarp - sizeof(uint64_t);


### PR DESCRIPTION
## Description

 Fix channel loop: change `i * num_warps + remain_warp_id` to `channel_start + remain_warp_id` to correctly handle 32 or larger channels with 16 warps.

Fixes # (issue)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] My code follows the style guidelines, e.g. `format.sh`.
- [x] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
