### PR TITLE
[P2P] Fix QP resource release.

### DIFF
--- a/p2p/rdma/rdma_channel.h
+++ b/p2p/rdma/rdma_channel.h
@@ -55,6 +55,11 @@ class RDMAChannel {
   RDMAChannel(RDMAChannel const&) = delete;
   RDMAChannel& operator=(RDMAChannel const&) = delete;
 
+  ~RDMAChannel() {
+    if (qp_) ibv_destroy_qp(qp_);
+    if (cq_ex_) ibv_destroy_cq(ibv_cq_ex_to_cq(cq_ex_));
+  }
+
   void establishChannel(ChannelMetaData const& remote_meta) {
     remote_meta_ = std::make_shared<ChannelMetaData>(remote_meta);
 #ifdef UCCL_P2P_USE_EFA


### PR DESCRIPTION
## Description

QP and CQ must be destroyed before destroying the RDMA context. Otherwise, we will see the following error:

```
ionic_rdma: context freed with active resources
```

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
