### PR TITLE
[P2P] Don't use inline for RDMA read.

### DIFF
--- a/p2p/rdma/rdma_channel.h
+++ b/p2p/rdma/rdma_channel.h
@@ -178,8 +178,9 @@ class RDMAChannel {
 
     struct ibv_sge sge[1];
     int num_sge = prepareSGEList(sge, req);
-    uint32_t max_inline = impl_->getMaxInlineData();
-    if (req->getLocalLen() <= max_inline) {
+
+    if (req->send_type != SendType::Read &&
+        req->getLocalLen() <= impl_->getMaxInlineData()) {
       qpx->wr_flags |= IBV_SEND_INLINE;
       ibv_wr_set_inline_data(qpx, (void*)req->getLocalAddress(),
                              req->getLocalLen());
@@ -247,8 +248,8 @@ class RDMAChannel {
       return -1;
     }
 
-    uint32_t max_inline = impl_->getMaxInlineData();
-    if (req->getLocalLen() <= max_inline) {
+    if (req->send_type != SendType::Read &&
+        req->getLocalLen() <= impl_->getMaxInlineData()) {
       wr.send_flags |= IBV_SEND_INLINE;
     }
 


### PR DESCRIPTION
## Description

RDMA READ does not support inline operations.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
