### PR TITLE
collective/rdma: Add Intel RDMA NIC support with conditional CQ confi…

### DIFF
--- a/collective/rdma/transport_config.h
+++ b/collective/rdma/transport_config.h
@@ -7,6 +7,7 @@
 #include <unistd.h>
 
 // #define STATS
+// #define INTEL_RDMA_NIC
 
 // Whether to pin the thread to the NUMA node.
 UCCL_PARAM(PIN_TO_NUMA, "PIN_TO_NUMA", 1);
@@ -210,7 +211,14 @@ static constexpr bool kTestConstantRate = false;
 // Test lossy network.
 static constexpr bool kTestLoss = false;
 static constexpr double kTestLossRate = 0.0;
+#ifdef INTEL_RDMA_NIC
+// Enable CQ ignore overrun flag.
+static constexpr bool kEnableCQIgnoreOverrun = false;
+// Enable CQ moderation.
+static constexpr bool kEnableCQModeration = false;
+#else
 // Enable CQ ignore overrun flag.
 static constexpr bool kEnableCQIgnoreOverrun = true;
 // Enable CQ moderation.
 static constexpr bool kEnableCQModeration = true;
+#endif


### PR DESCRIPTION
…guration

Introduce INTEL_RDMA_NIC preprocessor flag to conditionally disable CQ ignore overrun and CQ moderation features for Intel NICs. These features remain enabled by default for other RDMA adapters.

Changes:
- Add INTEL_RDMA_NIC define (commented out by default)
- Disable kEnableCQIgnoreOverrun when INTEL_RDMA_NIC is defined
- Disable kEnableCQModeration when INTEL_RDMA_NIC is defined

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
