### PR TITLE
collective(rdma and efa): Add Intel RDMA NIC support with conditional…

### DIFF
--- a/build_and_install.sh
+++ b/build_and_install.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# Build and install UCCL
+#
+# Usage:
+#   ./build_and_install.sh [cuda|rocm|therock] [all|ccl_rdma|ccl_efa|p2p|ep] [py_version] [rocm_index_url] [therock_base_image]
+#
+# Environment Variables:
+#   USE_INTEL_RDMA_NIC=1   Enable Intel RDMA NIC support
+#                          Example: USE_INTEL_RDMA_NIC=1 bash ./build_and_install.sh cuda ccl_efa
+
 TARGET=${1:-cuda}
 BUILD_TYPE=${2:-all}
 PY_VER=${3:-$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")}
@@ -14,7 +23,13 @@ if [[ $TARGET != cuda* && $TARGET != rocm* && $TARGET != "therock" ]]; then
 fi
 
 ARCH_SUFFIX=$(uname -m)
-./build.sh $TARGET $BUILD_TYPE $PY_VER $ROCM_IDX_URL $THEROCK_BASE_IMAGE
+
+# Pass through USE_INTEL_RDMA_NIC environment variable to build.sh
+if [[ "${USE_INTEL_RDMA_NIC:-0}" == "1" ]]; then
+  echo "Building with Intel RDMA NIC support (USE_INTEL_RDMA_NIC=1)"
+fi
+
+USE_INTEL_RDMA_NIC=${USE_INTEL_RDMA_NIC:-0} ./build.sh $TARGET $BUILD_TYPE $PY_VER $ROCM_IDX_URL $THEROCK_BASE_IMAGE
 pip install -r requirements.txt
 pip uninstall uccl -y || true
 if [[ $TARGET != "therock" ]]; then

--- a/collective/efa/Makefile
+++ b/collective/efa/Makefile
@@ -10,6 +10,12 @@ LIBS = -L ${CUDA_HOME}/lib64 -L ${EFA_HOME}/lib -libverbs -lefa -lcudart -lcuda 
 LIBS_SHARED = ${LIBS}
 # Added -MMD -MP for automatic dependency generation
 override CXXFLAGS += -O3 -g -std=c++17 -Wno-pointer-arith -Wno-interference-size -fPIC -DUSE_CUDA -MMD -MP
+
+# Add Intel RDMA NIC support if USE_INTEL_RDMA_NIC=1
+ifeq ($(USE_INTEL_RDMA_NIC),1)
+  override CXXFLAGS += -DINTEL_RDMA_NIC -DMTU_4096
+endif
+
 PLUGIN_SO = libnccl-net-efa.so
 
 lib_src = $(wildcard *.cc)

--- a/collective/efa/transport.h
+++ b/collective/efa/transport.h
@@ -65,7 +65,11 @@ class PollCtxPool : public BuffPool {
   ~PollCtxPool() = default;
 };
 
+#ifdef MTU_4096
+int const kMaxIovs = 256;
+#else
 int const kMaxIovs = 64;
+#endif
 
 enum ReqType {
   ReqTx,

--- a/collective/efa/transport_config.h
+++ b/collective/efa/transport_config.h
@@ -32,6 +32,11 @@ static_assert(
     "kSenderCCType and kReceiverCCType can not be kNone at the same time.");
 
 #define P4D
+// #define INTEL_RDMA_NIC
+
+#ifdef INTEL_RDMA_NIC
+#define MANAGED
+#endif
 
 static const uint32_t kNumVdevices = 8;        // # of vEFA/GPUs.
 static const uint32_t kNumEnginesPerVdev = 2;  // # of engines per vEFA/GPU.
@@ -42,20 +47,29 @@ static bool const kSplitSendRecvEngine =
 /// Interface configuration.
 #ifdef P4D
 static const uint8_t NUM_DEVICES = (kNumVdevices + 1) / 2;
+#ifdef INTEL_RDMA_NIC
+static const uint8_t EFA_GID_IDX = 1;
+static constexpr double kLinkBandwidth = 200.0 * 1e9 / 8;  // 200Gbps
+#else
 static const uint8_t EFA_GID_IDX = 0;
-
 static constexpr double kLinkBandwidth = 100.0 * 1e9 / 8;  // 100Gbps
 #endif
+#endif
 static const uint8_t EFA_PORT_NUM = 1;  // The port of EFA device to use.
+#ifdef INTEL_RDMA_NIC
+static const uint32_t EFA_MTU = 4096;  // Max frame on fabric, includng headers.
+static const uint32_t EFA_MAX_PAYLOAD = 4056;  // this excludes EFA_UD_ADDITION.
+#else
 static const uint32_t EFA_MTU = 9000;  // Max frame on fabric, includng headers.
 static const uint32_t EFA_MAX_PAYLOAD = 8928;  // this excludes EFA_UD_ADDITION.
+#endif
 static const uint32_t EFA_HDR_OVERHEAD = EFA_MTU - EFA_MAX_PAYLOAD;
 static const uint32_t EFA_MAX_QPS = 256;         // Max QPs per EFA device.
 static const uint32_t EFA_MAX_INLINE_SIZE = 32;  // Max inline data size.
 #ifdef USE_SRD
 static const uint32_t EFA_UD_ADDITION = 0;  // Auto-added by EFA during recv.
 #else
-static const uint32_t EFA_UD_ADDITION = 40;  // Auto-added by EFA during recv.
+static const uint32_t EFA_UD_ADDITION = 40;    // Auto-added by EFA during recv.
 #endif
 /// Interface configuration.
 static_assert(kNumEngines >= NUM_DEVICES * 2,
@@ -73,8 +87,13 @@ static const uint32_t PACER_CPU_START[2] = {
     ENGINE_CPU_START[1] + 8 /* 4 VDEV * 2 EnginePerVdev */};
 static const uint16_t BASE_PORT = 10000;
 static const uint64_t NUM_FRAMES = 4 * 65536;  // # of frames.
+#ifdef INTEL_RDMA_NIC
+static const uint32_t RECV_BATCH_SIZE = 512;
+static const uint32_t SEND_BATCH_SIZE = 256;
+#else
 static const uint32_t RECV_BATCH_SIZE = 32;
 static const uint32_t SEND_BATCH_SIZE = 16;
+#endif
 static const uint32_t QKEY = 0x12345;
 static const uint32_t SQ_PSN = 0x12345;
 static const uint64_t MAX_FLOW_ID = 1000000;
@@ -85,7 +104,11 @@ static const uint32_t kMaxRecvWr = 256;
 static const uint32_t kMaxSendRecvWrForCtrl = 1024;
 static const uint32_t kMaxSendRecvWrForCredit = 1024;
 static const uint32_t kMaxCqeTotal = 16384;
+#ifdef INTEL_RDMA_NIC
+static const uint32_t kMaxPollBatch = 512;
+#else
 static const uint32_t kMaxPollBatch = 32;
+#endif
 static const uint32_t kMaxRecvWrDeficit = 32;
 static const uint32_t kMaxChainedWr = 32;
 static const uint32_t kMaxUnconsumedRxMsgbufs = NUM_FRAMES / 16;
@@ -116,11 +139,19 @@ static_assert((kMaxSrcQP + kMaxSrcQPCtrl) * kNumEnginesPerVdev * 2 +
               EFA_MAX_QPS);
 
 // CC parameters.
+#ifdef INTEL_RDMA_NIC
+static double const kMaxUnackedPktsPP = 4u;
+#else
 static double const kMaxUnackedPktsPP = 1u;
+#endif
 static const uint32_t kMaxUnackedPktsPerEngine = kMaxUnackedPktsPP * kMaxPath;
 static const std::size_t kSackBitmapSize = 1024;
 static const std::size_t kFastRexmitDupAckThres = 128;
+#ifdef INTEL_RDMA_NIC
+static double const kMaxBwPP = 10.0 * 1e9 / 8;
+#else
 static double const kMaxBwPP = 5.0 * 1e9 / 8;
+#endif
 static const uint32_t kSwitchPathThres = 1u;
 static const uint32_t kMaxPktsInTimingWheel = 1024;
 static const uint32_t kMaxPathHistoryPerEngine = 4096;

--- a/collective/efa/util_efa.cc
+++ b/collective/efa/util_efa.cc
@@ -44,13 +44,21 @@ static void init_device_name_lists() {
         char const* name = ibv_get_device_name(list[i]);
         bool ok = false;
         if (name &&
+#ifdef INTEL_RDMA_NIC
+            strncmp(name, "irdma", 5) == 0) {
+#else
             (strncmp(name, "rdmap", 5) == 0 || strncmp(name, "efa", 3) == 0)) {
+#endif
           ok = true;
         }
         struct ibv_context* ctx = ibv_open_device(list[i]);
         if (ctx) {
           struct ibv_device_attr attr;
+#ifdef INTEL_RDMA_NIC
+          if (ibv_query_device(ctx, &attr) == 0 && attr.vendor_id == 0x8086) {
+#else
           if (ibv_query_device(ctx, &attr) == 0 && attr.vendor_id == 0x1d0f) {
+#endif
             ok = true;
           }
           ibv_close_device(ctx);
@@ -184,10 +192,18 @@ void EFAFactory::InitDev(int dev_idx) {
     goto close_device;
   }
 
+#ifdef INTEL_RDMA_NIC
+  if (port_attr.link_layer != IBV_LINK_LAYER_ETHERNET) {
+    fprintf(stderr, "Link layer %d not supported (expected ETHERNET)\n",
+            port_attr.link_layer);
+    goto close_device;
+  }
+#else
   if (port_attr.link_layer != IBV_LINK_LAYER_UNSPECIFIED) {
     fprintf(stderr, "EFA link layer is not supported\n");
     goto close_device;
   }
+#endif
 
   dev->dev_attr = dev_attr;
   dev->port_attr = port_attr;

--- a/collective/rdma/Makefile
+++ b/collective/rdma/Makefile
@@ -9,6 +9,12 @@ LIBS = -lglog -lgflags -lgtest -lz -lelf -libverbs -L /usr/local/cuda/lib64 -lcu
 LIBS_SHARED = -lglog -lgflags -lgtest -lz -lelf -libverbs
 # Added -MMD -MP for automatic dependency generation
 override CXXFLAGS += -O3 -g -std=c++17 -Wno-pointer-arith -Wno-interference-size -fPIC -DUSE_CUDA -MMD -MP
+
+# Add Intel RDMA NIC support if USE_INTEL_RDMA_NIC=1
+ifeq ($(USE_INTEL_RDMA_NIC),1)
+  override CXXFLAGS += -DINTEL_RDMA_NIC
+endif
+
 PLUGIN_SO = libnccl-net-uccl.so
 NCCL_INC:= -I$(NCCL_HOME)/build/include -I$(NCCL_HOME)/src/include -I$(CUDA_HOME)/include
 

--- a/thirdparty/nccl-sg/makefiles/common.mk
+++ b/thirdparty/nccl-sg/makefiles/common.mk
@@ -62,10 +62,17 @@ CXXFLAGS   := -DCUDA_MAJOR=$(CUDA_MAJOR) -DCUDA_MINOR=$(CUDA_MINOR) -fPIC -fvisi
               -Wall -Wno-unused-function -Wno-sign-compare -std=c++11 -Wvla \
               -I $(CUDA_INC) \
               $(CXXFLAGS)
+
+# Add Intel RDMA NIC support if USE_INTEL_RDMA_NIC=1
+ifeq ($(USE_INTEL_RDMA_NIC),1)
+  CXXFLAGS += -DINTEL_RDMA_NIC -DMTU_4096
+  NVCUFLAGS_EXTRA := -DINTEL_RDMA_NIC -DMTU_4096
+endif
+
 # Maxrregcount needs to be set accordingly to NCCL_MAX_NTHREADS (otherwise it will cause kernel launch errors)
 # 512 : 120, 640 : 96, 768 : 80, 1024 : 60
 # We would not have to set this if we used __launch_bounds__, but this only works on kernels, not on functions.
-NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -std=c++11 --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all
+NVCUFLAGS  := -ccbin $(CXX) $(NVCC_GENCODE) -std=c++11 --expt-extended-lambda -Xptxas -maxrregcount=96 -Xfatbin -compress-all $(NVCUFLAGS_EXTRA)
 # Use addprefix so that we can specify more than one path
 NVLDFLAGS  := -L${CUDA_LIB} -lcudart -lrt
 

--- a/thirdparty/nccl-sg/src/include/collectives.h
+++ b/thirdparty/nccl-sg/src/include/collectives.h
@@ -65,8 +65,12 @@ struct ncclConnFifo {
   void* ptr;
 };
 
-// Yang: 64 max scattered IOVs
+// Yang: 64 max scattered IOVs; 256 for MTU 4096
+#ifdef MTU_4096
+#define kMaxIovs 256
+#else
 #define kMaxIovs 64
+#endif
 struct alignas(8) iov {
   void* src_addrs[kMaxIovs];
   void* dst_addrs[kMaxIovs];

--- a/thirdparty/nccl-sg/src/include/sg_copy_if.h
+++ b/thirdparty/nccl-sg/src/include/sg_copy_if.h
@@ -21,8 +21,12 @@
 static constexpr int kNumThBlocks = 4;
 static constexpr int kNumThPerBlock = 512;
 
-// Yang: 64 max scattered IOVs
+// Yang: 64 max scattered IOVs; 256 for MTU 4096
+#ifdef MTU_4096
+#define kMaxIovs 256
+#else
 #define kMaxIovs 64
+#endif
 
 // Use shared memory for IOV when kMaxIovs is <= 64, otherwise use HBM pointer to avoid shared memory overflow
 #if kMaxIovs <= 64


### PR DESCRIPTION
… compilation

Add comprehensive support for Intel RDMA NICs (irdma driver, vendor 0x8086) with Intel-specific configurations controlled via USE_INTEL_RDMA_NIC=1 flag.

Changes:
- Add conditional INTEL_RDMA_NIC preprocessor flag throughout codebase
- Configure Intel-specific parameters in collective/efa:
  * kMaxIovs increased from 64 to 256 for Intel NICs
  * MTU reduced to 4096 (vs 9000 for EFA)
  * Higher bandwidth: 200 Gbps link for EFA
  * MANAGED mode for cudaMallocManaged support
- Add Intel device detection in util_efa.cc:
  * Accept only "irdma" device name
  * Verify vendor ID 0x8086
  * Require IBV_LINK_LAYER_ETHERNET
- Update build system to propagate USE_INTEL_RDMA_NIC flag:
  * build.sh and build_and_install.sh
  * Makefiles for collective/efa, collective/rdma, and nccl-sg
- Ensure consistent struct layout between host and device code

Usage: USE_INTEL_RDMA_NIC=1 ./build.sh cuda [ccl_efa|ccl_rdma]

Default behavior unchanged when USE_INTEL_RDMA_NIC is not set.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
