### PR TITLE
[P2P] Fix compiler warnings.

### DIFF
--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -1328,7 +1328,7 @@ bool Endpoint::recv_ipc(uint64_t conn_id, void* data, size_t size) {
   IpcTransferInfo info = {};
   info.size = size;
   info.operation = 1;
-  gpuIpcGetMemHandle(&info.handle, data);
+  GPU_RT_CHECK(gpuIpcGetMemHandle(&info.handle, data));
 
   // Getting the base address.
   void* base = nullptr;


### PR DESCRIPTION
## Description

See the following warnings when compiling on AMD GPUs, just add `GPU_RT_CHECK` to fix it.

```
engine.cc: In member function 'bool Endpoint::recv_ipc(uint64_t, void*, size_t)':
engine.cc:1331:21: warning: ignoring returned value of type 'hipError_t', declared with attribute 'nodiscard' [-Wunused-result]
 1331 |   gpuIpcGetMemHandle(&info.handle, data);
In file included from /opt/rocm/include/hip/hip_runtime.h:65,
                 from ../include/util/gpu_rt.h:76,
                 from ../include/util/util.h:5,
                 from rdma/define.h:3,
                 from rdma/rdma_endpoint.h:2,
                 from engine.h:4,
                 from engine.cc:1:
/opt/rocm/include/hip/hip_runtime_api.h:2395:12: note: in call to 'hipError_t hipIpcGetMemHandle(hipIpcMemHandle_t*, void*)', declared here
 2395 | hipError_t hipIpcGetMemHandle(hipIpcMemHandle_t* handle, void* devPtr);
      |            ^~~~~~~~~~~~~~~~~~
In file included from /opt/rocm/include/hip/hip_runtime.h:65,
                 from ../include/util/gpu_rt.h:76,
                 from ../include/util/util.h:5,
                 from rdma/define.h:3,
                 from rdma/rdma_endpoint.h:2,
                 from engine.h:4,
                 from engine.cc:1:
/opt/rocm/include/hip/hip_runtime_api.h:415:3: note: 'hipError_t' declared here
  415 | } hipError_t;
      |   ^~~~~~~~~~
```

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
