### PR TITLE
[EP] Add Intel RDMA NIC support for UCCL EP

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -183,13 +183,17 @@ build_ep() {
   set -euo pipefail
   echo "[container] build_ep Target: $TARGET"
 
+  if [[ "${USE_INTEL_RDMA_NIC:-0}" == "1" ]]; then
+    echo "[container] Building EP with Intel RDMA NIC support (USE_INTEL_RDMA_NIC=1)"
+  fi
+
   if [[ "$TARGET" == "therock" ]]; then
     echo "Skipping GPU-driven build on therock (no GPU-driven support yet)."
   elif [[ "$TARGET" == rocm* || "$TARGET" == cuda* ]]; then
     cd ep
     # This may be needed if you traverse through different git commits
     # make clean && rm -r build || true
-    python3 setup.py build
+    USE_INTEL_RDMA_NIC=${USE_INTEL_RDMA_NIC:-0} python3 setup.py build
     cd ..
     echo "[container] Copying GPU-driven .so to uccl/"
     mkdir -p uccl/lib

--- a/ep/Makefile
+++ b/ep/Makefile
@@ -55,6 +55,12 @@ LDFLAGS := -lpthread -lglog -libverbs -lnl-3 -lnl-route-3 -lnuma -Xlinker -rpath
 NVCCFLAGS := -O3 -std=c++17 -Xcompiler "-Wall -pthread -fPIC -fvisibility=hidden" -ccbin /usr/bin/g++ --expt-relaxed-constexpr
 INCLUDES := -Iinclude -I$(CUDA_PATH)/include -I/usr/include -I../include 
 
+# Add Intel RDMA NIC support if USE_INTEL_RDMA_NIC=1
+ifeq ($(USE_INTEL_RDMA_NIC),1)
+  override CXXFLAGS += -DINTEL_RDMA_NIC
+  override NVCCFLAGS += -DINTEL_RDMA_NIC
+endif
+
 CXXFLAGS  += $(EFA_CFLAGS) $(GH_CFLAGS) $(NORMAL_CFLAGS)
 NVCCFLAGS += $(EFA_CFLAGS) $(GH_CFLAGS) $(NORMAL_CFLAGS)
 LDFLAGS   += $(EFA_LDFLAGS)

--- a/ep/bench/utils.py
+++ b/ep/bench/utils.py
@@ -251,10 +251,10 @@ class EventOverlap:
 
 
 def detect_ib_hca():
-    """Detect InfiniBand HCA device.
+    """Detect InfiniBand/RDMA HCA device.
 
-    Returns the first mlx5 device name found, or None if no InfiniBand
-    devices are available (e.g., on systems without IB).
+    Returns the first RDMA device name found (mlx5 for Mellanox, irdma for Intel),
+    or None if no InfiniBand devices are available.
     """
     try:
         devices = sorted(glob.glob("/sys/class/infiniband/*"))
@@ -265,12 +265,19 @@ def detect_ib_hca():
         # No InfiniBand devices found - this is okay on systems without RDMA
         return None
 
+    # Check for Mellanox devices first
     ib_devs = [
         os.path.basename(d) for d in devices if os.path.basename(d).startswith("mlx5")
     ]
-    if not ib_devs:
-        return None
-    return ib_devs[0]
+    if ib_devs:
+        return ib_devs[0]
+
+    # Check for Intel RDMA devices (irdma)
+    ib_devs = [
+        os.path.basename(d) for d in devices if os.path.basename(d).startswith("irdma")
+    ]
+    if ib_devs:
+        return ib_devs[0]
 
 
 def per_token_cast_back(x_fp8: torch.Tensor, x_scales: torch.Tensor):

--- a/ep/include/common.hpp
+++ b/ep/include/common.hpp
@@ -31,6 +31,18 @@ extern bool use_ll_sl;
 
 #define USE_MSCCLPP_FIFO_BACKEND
 // #define USE_SUBSET_BARRIER
+
+// Intel RDMA NIC support
+#ifdef INTEL_RDMA_NIC
+// Use DMA-BUF for GPU memory registration (avoids nvidia_peermem dependency).
+// Falls back to ibv_reg_mr_iova2 at runtime if DMA-BUF is unsupported.
+#define USE_DMABUF
+// Use pinned host memory for the atomic buffer instead of cudaMalloc.
+// Required for NICs without nvidia_peermem (e.g. Intel irdma) so that
+// ibv_reg_mr succeeds, and allows CPU proxy threads to do std::atomic ops.
+#define ATOMICS_USE_HOST_MEMORY
+#endif
+
 #define kAtomicBufferSize 81960
 #define kQueueSize 2048
 #define kQueueMask (kQueueSize - 1)

--- a/ep/include/rdma.hpp
+++ b/ep/include/rdma.hpp
@@ -352,6 +352,14 @@ void remote_poll_completions(ProxyCtx& S, int idx, CopyRingBuffer& g_ring,
                              bool use_normal_mode = false);
 void per_thread_rdma_init(ProxyCtx& S, void* gpu_buf, size_t bytes, int rank,
                           int thread_idx, int local_rank);
+
+#ifdef USE_DMABUF
+// Register GPU memory using DMA-BUF (no nvidia_peermem needed).
+// Falls back to ibv_reg_mr_iova2 if DMA-BUF is unsupported.
+ibv_mr* reg_mr_gpu_dmabuf(ibv_pd* pd, void* gpu_buf, size_t bytes,
+                          uint64_t iova, int access);
+#endif
+
 void remote_send_ack(ProxyCtx* ctx, struct ibv_qp* ack_qp, uint64_t& wr_id,
                      ibv_mr* local_ack_mr, uint64_t* ack_buf, int worker_idx);
 void local_post_ack_buf(ProxyCtx& S, int depth);

--- a/ep/setup.py
+++ b/ep/setup.py
@@ -183,6 +183,12 @@ if __name__ == "__main__":
             cxx_flags.append("-DUSE_GRACE_HOPPER")
             nvcc_flags.append("-DUSE_GRACE_HOPPER")
 
+        # Add Intel RDMA NIC support if USE_INTEL_RDMA_NIC=1
+        if int(os.getenv("USE_INTEL_RDMA_NIC", 0)):
+            print("Building with Intel RDMA NIC support (INTEL_RDMA_NIC)")
+            cxx_flags.append("-DINTEL_RDMA_NIC")
+            nvcc_flags.append("-DINTEL_RDMA_NIC")
+
         # Use auto-detected compute capability if available
         if detected_compute_cap:
             default_arch = detected_compute_cap

--- a/ep/src/uccl_proxy.cpp
+++ b/ep/src/uccl_proxy.cpp
@@ -64,7 +64,14 @@ UcclProxy::UcclProxy(int thread_idx, uintptr_t gpu_buffer_addr,
     cudaHostAlloc(&atomic_buffer_ptr_, kAtomicBufferSize,
                   cudaHostAllocMapped | cudaHostAllocWriteCombined);
 #else
+#ifdef ATOMICS_USE_HOST_MEMORY
+    // Pinned host memory: ibv_reg_mr works on NICs without nvidia_peermem
+    // (e.g. irdma), CPU proxy threads can do std::atomic ops, and GPU
+    // kernels can still access it via CUDA host-mapped addressing.
+    cudaHostAlloc(&atomic_buffer_ptr_, kAtomicBufferSize, cudaHostAllocMapped);
+#else
     cudaMalloc(&atomic_buffer_ptr_, kAtomicBufferSize);
+#endif
 #endif
     cudaMemset(atomic_buffer_ptr_, 0, kAtomicBufferSize);
     proxy_->set_atomic_buffer_ptr(atomic_buffer_ptr_);


### PR DESCRIPTION
Enable UCCL EP (Expert Parallelism) to work on Intel RDMA RoCEv2 NICs, which lack nvidia_peermem and have different RDMA capabilities than Mellanox ConnectX. All Intel-specific changes are gated behind the USE_INTEL_RDMA_NIC build flag, matching the pattern used in collective/rdma.

Build system:
- EP Makefile: USE_INTEL_RDMA_NIC=1 -> -DINTEL_RDMA_NIC compile flag
- EP setup.py: read USE_INTEL_RDMA_NIC env var -> -DINTEL_RDMA_NIC
- build.sh: pass USE_INTEL_RDMA_NIC to python3 setup.py build in build_ep()

DMA-BUF GPU memory registration (rdma.cpp, rdma.hpp):
- Add reg_mr_gpu_dmabuf() using cuMemGetHandleForAddressRange to obtain a DMA-BUF fd for GPU memory, then ibv_reg_dmabuf_mr to register it. This avoids the nvidia_peermem kernel module dependency.
- Handle PyTorch caching allocator suballocation by querying the real cudaMalloc base via cuMemGetAddressRange.
- Patch NULL mr->addr after ibv_reg_dmabuf_mr (irdma leaves it NULL, but downstream SGE calculations depend on it).
- Gate behind #ifdef USE_DMABUF with fallback to ibv_reg_mr_iova2.

Atomic buffer allocation (uccl_proxy.cpp):
- Use cudaHostAlloc (pinned host memory) instead of cudaMalloc for the atomic buffer, so ibv_reg_mr works on NICs without nvidia_peermem and CPU proxy threads can perform std::atomic operations on it.
- Gate behind #ifdef ATOMICS_USE_HOST_MEMORY.

Compile-time gating (common.hpp):
- #ifdef INTEL_RDMA_NIC enables USE_DMABUF and ATOMICS_USE_HOST_MEMORY.

HCA device detection (utils.py):
- Extend detect_ib_hca() to recognize irdma devices in addition to mlx5.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
