### PR TITLE
[P2P]Add uccl shared lib install

### DIFF
--- a/p2p/Makefile
+++ b/p2p/Makefile
@@ -137,18 +137,28 @@ nccl/%.o: nccl/%.cc
 DEPS := $(OBJECTS:.o=.d) $(CAPI_OBJECT:.o=.d)
 -include $(DEPS)
 
+define safe_install
+	@echo "Installing $(1) to $(2)..."
+	@install -m $(3) $(1) $(2)/ || \
+		{ echo "Warning: Unable to install $(1) to $(2)/"; \
+		  echo "  Make sure $(2) exists and you have write permissions (try sudo make install)"; \
+		  exit 0; }
+endef
+
 ifeq ($(USE_TCPX),1)
 install: $(P2P_SHARED_LIB)
-	install -m 755 $(P2P_SHARED_LIB) $(LIBDIR)/
-	install -m 644 $(CAPI_HEADER) $(INCDIR)/
+	$(call safe_install,$(P2P_SHARED_LIB),$(LIBDIR),755)
+	$(call safe_install,$(CAPI_HEADER),$(INCDIR),644)
+	@echo "Installation complete!"
 else
 install: $(P2P_PYTHON_EXT) $(P2P_SHARED_LIB)
 	$(MAKE) $(P2P_PYTHON_EXT)
 	@mkdir -p $(INSTALL_DIR)
 	@cp $(P2P_PYTHON_EXT) $(INSTALL_DIR)/
 	@echo "Installation complete. Module installed as: $(INSTALL_DIR)/$(P2P_PYTHON_EXT)"
-	install -m 755 $(P2P_SHARED_LIB) $(LIBDIR)/
-	install -m 644 $(CAPI_HEADER) $(INCDIR)/
+	$(call safe_install,$(P2P_SHARED_LIB),$(LIBDIR),755)
+	$(call safe_install,$(CAPI_HEADER),$(INCDIR),644)
+	@echo "Installation complete!"
 endif
 # Clean build artifacts
 clean:


### PR DESCRIPTION
## Description
These libs are required for NIXL installation. Can this be brought back? Without this, the NIXL will be unable to find the uccl plugin. @YangZhou1997 These were removed in https://github.com/uccl-project/uccl/commit/412500973e796aefcb03d154133cdded612c3da2#r177564539, and can be safely brought back.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
