### PR TITLE
[EP] Add benchmarking option for FP8 dispatch.

### DIFF
--- a/ep/bench/test_low_latency.py
+++ b/ep/bench/test_low_latency.py
@@ -155,7 +155,9 @@ def test_main(
         for return_recv_hook in (False, True):
             for dispatch_use_fp8_case in (False, True):
                 for round_scale in (False,):
-                    for round_scale in (False, True) if dispatch_use_fp8_case else (False,):
+                    for round_scale in (
+                        (False, True) if dispatch_use_fp8_case else (False,)
+                    ):
                         for use_ue8m0 in (False, True) if round_scale else (False,):
                             print(
                                 "Start experiment with settings:"


### PR DESCRIPTION
Enable benchmarking with either FP8 dispatch or direct BF16 dispatch through a runtime flag for apples-to-apples performance comparison.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
