### PR TITLE
[EP] Fix ibv_create_cq_ex for Intel irdma NIC

### DIFF
--- a/ep/include/common.hpp
+++ b/ep/include/common.hpp
@@ -41,6 +41,8 @@ extern bool use_ll_sl;
 // Required for NICs without nvidia_peermem (e.g. Intel irdma) so that
 // ibv_reg_mr succeeds, and allows CPU proxy threads to do std::atomic ops.
 #define ATOMICS_USE_HOST_MEMORY
+// Ethernet-based RDMA (iWARP/RoCEv2) — no IB-specific CQ attributes.
+#define ETHERNET_RDMA
 #endif
 
 #define kAtomicBufferSize 81960

--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -633,7 +633,17 @@ ibv_cq* create_per_thread_cq(ProxyCtx& S) {
   cq_ex_attr.comp_vector = 0;
   cq_ex_attr.comp_mask = 0;
   cq_ex_attr.flags = 0;
+#ifdef ETHERNET_RDMA
+  // IBV_WC_EX_WITH_SLID and IBV_WC_EX_WITH_DLID_PATH_BITS which are set in
+  // IBV_WC_STANDARD_FLAGS are not supported by Ethernet-based RDMA NICs
+  // (iWARP/RoCEv2) because these attributes are specific to InfiniBand (IB)
+  // architecture.
+  cq_ex_attr.wc_flags = IBV_WC_EX_WITH_BYTE_LEN | IBV_WC_EX_WITH_IMM |
+                        IBV_WC_EX_WITH_QP_NUM | IBV_WC_EX_WITH_SRC_QP |
+                        IBV_WC_EX_WITH_SL;
+#else
   cq_ex_attr.wc_flags = IBV_WC_STANDARD_FLAGS;
+#endif
 
   S.cq_ex = ibv_create_cq_ex(S.context, &cq_ex_attr);
   if (!S.cq_ex) {


### PR DESCRIPTION
IBV_WC_EX_WITH_SLID and IBV_WC_EX_WITH_DLID_PATH_BITS which are set in IBV_WC_STANDARD_FLAGS are not supported by Intel irdma because these attributes are specific to InfiniBand (IB) architecture, whereas Intel NICs operate using Ethernet-based protocols (iWARP and RoCEv2).

Gate wc_flags under INTEL_RDMA_NIC to use only the supported subset: IBV_WC_EX_WITH_BYTE_LEN, IBV_WC_EX_WITH_IMM, IBV_WC_EX_WITH_QP_NUM, IBV_WC_EX_WITH_SRC_QP, and IBV_WC_EX_WITH_SL.

Fixes regression from cd4b0f53 ("[EP] AMD IONIC: Fix context freed with active resources") which replaced ibv_create_cq with ibv_create_cq_ex using IBV_WC_STANDARD_FLAGS unconditionally.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] My code follows the style guidelines, e.g. `format.sh`.
- [ ] I have run `build_and_install.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
