### PR TITLE
[Build] support format.sh on macOS

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -27,8 +27,9 @@ if ! command -v "$CLANG_FORMAT" &> /dev/null; then
     exit 1
 fi
 
-# Ensure clang-format version is exactly 14
-INSTALLED_VERSION=$("$CLANG_FORMAT" --version | grep -oP '[0-9]+\.[0-9]+\.[0-9]+' | head -1 | cut -d. -f1)
+# Ensure clang-format version is exactly 14.
+# Use sed for portability (BSD grep on macOS does not support -P).
+INSTALLED_VERSION=$("$CLANG_FORMAT" --version | sed -nE 's/.*[Vv]ersion[[:space:]]+([0-9]+)(\.[0-9]+){1,2}.*/\1/p' | head -1)
 
 if [ "$INSTALLED_VERSION" != "$REQUIRED_VERSION" ]; then
     echo "clang-format version $REQUIRED_VERSION is required. Found version: $INSTALLED_VERSION ($CLANG_FORMAT)."


### PR DESCRIPTION
Replace GNU grep -P based version parsing with a portable sed expression so clang-format version checks work on macOS BSD toolchains.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
