### PR TITLE
[EP]: extend TransferCmd WRITE offset range from 4 GiB to 64 GiB

### DIFF
--- a/ep/include/ring_buffer.cuh
+++ b/ep/include/ring_buffer.cuh
@@ -91,6 +91,17 @@ struct TransferCmd {
 static_assert(sizeof(TransferCmd) * 8 == 128, "TransferCmd must be 128 bits");
 #endif
 
+// WRITE command offsets (req_rptr, req_lptr) are always 16-byte aligned
+// (Int4-aligned). By storing them right-shifted by kWriteAddrShift bits in
+// the 32-bit fields, we extend the addressable range from 4 GiB to 64 GiB.
+// ATOMIC commands are unaffected (they use small offsets in a separate buffer).
+static constexpr int kWriteAddrShift = 4;
+
+// Decode a shifted WRITE offset back to a byte offset.
+inline uint64_t decode_write_offset(uint32_t shifted) {
+  return static_cast<uint64_t>(shifted) << kWriteAddrShift;
+}
+
 struct CopyTask {
   uint64_t wr_id;
   int dst_dev;

--- a/ep/include/uccl_ibgda.cuh
+++ b/ep/include/uccl_ibgda.cuh
@@ -58,8 +58,14 @@ __device__ __forceinline__ void nvshmemi_ibgda_put_nbi_warp(
     TransferCmd cmd{};
     cmd.cmd_type =
         make_cmd_type(CmdType::WRITE, is_combine, low_latency_buffer_idx);
-    cmd.req_rptr = rptr_val;
-    cmd.req_lptr = lptr_val;
+    // Store offsets shifted right by kWriteAddrShift (all WRITE offsets are
+    // 16-byte aligned) to support RDMA buffers larger than 4 GiB.
+    EP_DEVICE_ASSERT((rptr_val & 0xF) == 0 &&
+                     "req_rptr must be 16-byte aligned for shift");
+    EP_DEVICE_ASSERT((lptr_val & 0xF) == 0 &&
+                     "req_lptr must be 16-byte aligned for shift");
+    cmd.req_rptr = rptr_val >> kWriteAddrShift;
+    cmd.req_lptr = lptr_val >> kWriteAddrShift;
     cmd.bytes = bytes_val;
     cmd.dst_rank = dst_rank;
     if constexpr (use_normal_mode) {
@@ -92,8 +98,14 @@ __device__ __forceinline__ void nvshmemi_ibgda_put_nbi_warp(
       // NOTE(MaoZiming): cmd is needed for proxy to process the command.
       cmd.cmd_type =
           make_cmd_type(CmdType::WRITE, is_combine, low_latency_buffer_idx);
-      cmd.req_rptr = rptr_val;
-      cmd.req_lptr = lptr_val;
+      // Store offsets shifted right by kWriteAddrShift (all WRITE offsets are
+      // 16-byte aligned) to support RDMA buffers larger than 4 GiB.
+      EP_DEVICE_ASSERT((rptr_val & 0xF) == 0 &&
+                       "req_rptr must be 16-byte aligned for shift");
+      EP_DEVICE_ASSERT((lptr_val & 0xF) == 0 &&
+                       "req_lptr must be 16-byte aligned for shift");
+      cmd.req_rptr = rptr_val >> kWriteAddrShift;
+      cmd.req_lptr = lptr_val >> kWriteAddrShift;
       cmd.bytes = bytes_val;
       cmd.dst_rank = dst_rank;
       if (bytes_val >> 24) {

--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -1315,17 +1315,17 @@ static void post_rdma_async_batched_normal_mode(
         qpx->wr_flags = IBV_SEND_SIGNALED;
 
         uint64_t remote_addr =
-            ctx->remote_addr + (cmd.req_rptr ? cmd.req_rptr : 0);
+            ctx->remote_addr + decode_write_offset(cmd.req_rptr);
         uint64_t remote_end = ctx->remote_addr + ctx->remote_len;
 
         if (remote_addr < ctx->remote_addr ||
             remote_addr + cmd.bytes > remote_end) {
           fprintf(stderr,
                   "[ERROR] Remote write OOB: addr=0x%llx len=%u (base=0x%llx, "
-                  "size=%zu), cmd.req_rptr: 0x%llx\n",
+                  "size=%zu), offset: 0x%llx\n",
                   (unsigned long long)remote_addr, cmd.bytes,
                   (unsigned long long)ctx->remote_addr, (size_t)ctx->remote_len,
-                  (unsigned long long)cmd.req_rptr);
+                  (unsigned long long)decode_write_offset(cmd.req_rptr));
           cudaError_t err = cudaDeviceSynchronize();
           if (err != cudaSuccess) {
             fprintf(stderr, "cudaDeviceSynchronize failed: %s\n",
@@ -1369,8 +1369,8 @@ static void post_rdma_async_batched_normal_mode(
           ibv_wr_rdma_write(qpx, ctx->remote_rkey, remote_addr);
         }
 
-        uintptr_t laddr =
-            cmd.req_lptr + reinterpret_cast<uintptr_t>(ctx->mr->addr);
+        uintptr_t laddr = decode_write_offset(cmd.req_lptr) +
+                          reinterpret_cast<uintptr_t>(ctx->mr->addr);
         ibv_wr_set_ud_addr(qpx, ctx->dst_ah, dst_qpn, QKEY);
         ibv_wr_set_sge(qpx, ctx->mr->lkey, laddr,
                        static_cast<uint32_t>(cmd.bytes));
@@ -1406,7 +1406,7 @@ static void post_rdma_async_batched_normal_mode(
 
           // Remote address bounds check
           uint64_t remote_addr =
-              ctx->remote_addr + (cmd.req_rptr ? cmd.req_rptr : 0);
+              ctx->remote_addr + decode_write_offset(cmd.req_rptr);
           uint64_t remote_end = ctx->remote_addr + ctx->remote_len;
 
           if (remote_addr < ctx->remote_addr ||
@@ -1414,10 +1414,10 @@ static void post_rdma_async_batched_normal_mode(
             fprintf(
                 stderr,
                 "[ERROR] Remote write OOB: addr=0x%llx len=%u (base=0x%llx, "
-                "size=%zu), cmd.req_rptr: 0x%llx\n",
+                "size=%zu), offset: 0x%llx\n",
                 (unsigned long long)remote_addr, cmd.bytes,
                 (unsigned long long)ctx->remote_addr, (size_t)ctx->remote_len,
-                (unsigned long long)cmd.req_rptr);
+                (unsigned long long)decode_write_offset(cmd.req_rptr));
             cudaError_t err = cudaDeviceSynchronize();
             if (err != cudaSuccess) {
               fprintf(stderr, "cudaDeviceSynchronize failed: %s\n",
@@ -1427,8 +1427,8 @@ static void post_rdma_async_batched_normal_mode(
           }
 
           // Local SGE
-          uintptr_t laddr =
-              cmd.req_lptr + reinterpret_cast<uintptr_t>(ctx->mr->addr);
+          uintptr_t laddr = decode_write_offset(cmd.req_lptr) +
+                            reinterpret_cast<uintptr_t>(ctx->mr->addr);
 
 #ifdef USE_DMABUF
           // Split across chunk boundaries so each sub-WR stays within one
@@ -1553,7 +1553,7 @@ static void post_rdma_async_batched_normal_mode(
 
           // Remote address bounds check
           uint64_t remote_addr =
-              ctx->remote_addr + (cmd.req_rptr ? cmd.req_rptr : 0);
+              ctx->remote_addr + decode_write_offset(cmd.req_rptr);
           uint64_t remote_end = ctx->remote_addr + ctx->remote_len;
 
           if (remote_addr < ctx->remote_addr ||
@@ -1561,10 +1561,10 @@ static void post_rdma_async_batched_normal_mode(
             fprintf(
                 stderr,
                 "[ERROR] Remote write OOB: addr=0x%llx len=%u (base=0x%llx, "
-                "size=%zu), cmd.req_rptr: 0x%llx\n",
+                "size=%zu), offset: 0x%llx\n",
                 (unsigned long long)remote_addr, cmd.bytes,
                 (unsigned long long)ctx->remote_addr, (size_t)ctx->remote_len,
-                (unsigned long long)cmd.req_rptr);
+                (unsigned long long)decode_write_offset(cmd.req_rptr));
             cudaError_t err = cudaDeviceSynchronize();
             if (err != cudaSuccess) {
               fprintf(stderr, "cudaDeviceSynchronize failed: %s\n",
@@ -1574,8 +1574,8 @@ static void post_rdma_async_batched_normal_mode(
           }
 
           // Local SGE
-          uintptr_t laddr =
-              cmd.req_lptr + reinterpret_cast<uintptr_t>(ctx->mr->addr);
+          uintptr_t laddr = decode_write_offset(cmd.req_lptr) +
+                            reinterpret_cast<uintptr_t>(ctx->mr->addr);
 
 #ifdef USE_DMABUF
           // Split across chunk boundaries so each sub-WR stays within one
@@ -1739,17 +1739,17 @@ static void post_rdma_async_batched_fast_mode(
         qpx->wr_flags = IBV_SEND_SIGNALED;
 
         uint64_t remote_addr =
-            ctx->remote_addr + (cmd.req_rptr ? cmd.req_rptr : 0);
+            ctx->remote_addr + decode_write_offset(cmd.req_rptr);
         uint64_t remote_end = ctx->remote_addr + ctx->remote_len;
 
         if (remote_addr < ctx->remote_addr ||
             remote_addr + cmd.bytes > remote_end) {
           fprintf(stderr,
                   "[ERROR] Remote write OOB: addr=0x%llx len=%u (base=0x%llx, "
-                  "size=%zu), cmd.req_rptr: 0x%llx\n",
+                  "size=%zu), offset: 0x%llx\n",
                   (unsigned long long)remote_addr, cmd.bytes,
                   (unsigned long long)ctx->remote_addr, (size_t)ctx->remote_len,
-                  (unsigned long long)cmd.req_rptr);
+                  (unsigned long long)decode_write_offset(cmd.req_rptr));
           cudaError_t err = cudaDeviceSynchronize();
           if (err != cudaSuccess) {
             fprintf(stderr, "cudaDeviceSynchronize failed: %s\n",
@@ -1782,8 +1782,8 @@ static void post_rdma_async_batched_fast_mode(
         ibv_wr_rdma_write(qpx, ctx->remote_rkey, remote_addr);
       }
 #endif
-        uintptr_t laddr =
-            cmd.req_lptr + reinterpret_cast<uintptr_t>(ctx->mr->addr);
+        uintptr_t laddr = decode_write_offset(cmd.req_lptr) +
+                          reinterpret_cast<uintptr_t>(ctx->mr->addr);
         ibv_wr_set_ud_addr(qpx, ctx->dst_ah, ctx->dst_qpn, QKEY);
         ibv_wr_set_sge(qpx, ctx->mr->lkey, laddr,
                        static_cast<uint32_t>(cmd.bytes));
@@ -1813,19 +1813,20 @@ static void post_rdma_async_batched_fast_mode(
       auto const& cmd = cmds_to_post[i];
       wr_ids[j] = wrs_to_post[i];
 
-      uintptr_t laddr =
-          cmd.req_lptr + reinterpret_cast<uintptr_t>(ctx->mr->addr);
-      uint64_t remote_addr = ctx->remote_addr + cmd.req_rptr;
+      uintptr_t laddr = decode_write_offset(cmd.req_lptr) +
+                        reinterpret_cast<uintptr_t>(ctx->mr->addr);
+      uint64_t remote_addr =
+          ctx->remote_addr + decode_write_offset(cmd.req_rptr);
 
       uint64_t remote_end = ctx->remote_addr + ctx->remote_len;
       if (remote_addr < ctx->remote_addr ||
           remote_addr + cmd.bytes > remote_end) {
         fprintf(stderr,
                 "[ERROR] Remote write OOB: addr=0x%llx len=%u (base=0x%llx, "
-                "size=%zu), cmd.req_rptr: 0x%llx\n",
+                "size=%zu), offset: 0x%llx\n",
                 (unsigned long long)remote_addr, cmd.bytes,
                 (unsigned long long)ctx->remote_addr, (size_t)ctx->remote_len,
-                (unsigned long long)cmd.req_rptr);
+                (unsigned long long)decode_write_offset(cmd.req_rptr));
         cudaError_t err = cudaDeviceSynchronize();
         if (err != cudaSuccess) {
           fprintf(stderr, "cudaDeviceSynchronize failed: %s\n",


### PR DESCRIPTION
TransferCmd.req_rptr and req_lptr are uint32_t fields (max 4 GiB offset), but the RDMA buffer can exceed 4 GiB for large configs. For example, on a 2-node / 1-H100-per-node setup:
  - 32 experts, 4096 tokens, 7168 hidden → ~7 GiB buffer
  - 288 experts, 512 tokens, 7169 hidden → ~7.9 GiB buffer This caused silent truncation of offsets beyond 4 GiB, resulting in RDMA writes landing at wrong addresses and data corruption in the recv buffer. The corruption manifested as an AssertionError in test_low_latency.py (data mismatch at line 278) on rank 1, followed by a SIGSEGV (exitcode: -11) on rank 0.

Fix: all WRITE offsets are 16-byte aligned (Int4-aligned), so store them right-shifted by 4 bits on the GPU side and decode with left-shift on the proxy side. This extends the addressable range to 64 GiB without changing the 128-bit TransferCmd struct layout required for GPU atomic operations. ATOMIC command offsets are unaffected (small buffer, no overflow risk). Added EP_DEVICE_ASSERT checks to verify 16-byte alignment before the shift, catching any future violations early.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
