### PR TITLE
[EP] fix HIP __syncwarp compatibility on ROCm

### DIFF
--- a/ep/include/ep_utils.cuh
+++ b/ep/include/ep_utils.cuh
@@ -36,7 +36,6 @@ using f32_gptr = __attribute__((address_space(1))) float*;
 #define __shfl_sync(mask, var, srcLane) __shfl((var), (srcLane))
 #endif
 
-// HIP on AMD may not expose CUDA's __syncwarp; use wave barrier instead.
 #if defined(__HIP_PLATFORM_AMD__) || defined(__HIPCC__)
 #define __syncwarp(...) __builtin_amdgcn_wave_barrier()
 #endif


### PR DESCRIPTION
Map CUDA-style __syncwarp calls to AMD wavefront barrier under HIP so ROCm builds do not fail on toolchains where __syncwarp is unavailable.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
