### PR TITLE
[EP] Fix RoCE GID auto-detection for Broadcom bnxt_re NICs

### DIFF
--- a/ep/include/rdma_util.hpp
+++ b/ep/include/rdma_util.hpp
@@ -351,6 +351,37 @@ static bool ncclIbGetGidIndex(struct ibv_context* context, uint8_t portNum,
     }
   }
 
+  // Fallback: when the selected GID is link-local or unconfigured (e.g. on
+  // Broadcom bnxt_re where all GIDs are IPv6 ULA, not IPv4-mapped), the
+  // address-family filter above skips every candidate.  Retry without the
+  // address-family constraint, preferring valid + RoCE v2.
+  {
+    union ibv_gid selectedGid;
+    if (ibv_query_gid(context, portNum, *gidIndex, &selectedGid) == 0 &&
+        !validGid(&selectedGid)) {
+      char const* deviceName = ibv_get_device_name(context->device);
+      int bestIdx = -1;
+      for (int i = 0; i < gidTblLen; ++i) {
+        union ibv_gid gid;
+        if (ibv_query_gid(context, portNum, i, &gid) != 0) continue;
+        if (!validGid(&gid)) continue;
+        int ver = 0;
+        if (ncclIbRoceGetVersionNum(deviceName, portNum, i, &ver) &&
+            ver == userRoceVersion) {
+          bestIdx = i;
+          break;
+        }
+        if (bestIdx < 0) bestIdx = i;
+      }
+      if (bestIdx >= 0) *gidIndex = bestIdx;
+    }
+  }
+
+  char const* deviceName = ibv_get_device_name(context->device);
+  fprintf(stderr,
+          "[RDMA] Auto-detected GID index %d for %s (set UCCL_IB_GID_INDEX to "
+          "override)\n",
+          *gidIndex, deviceName ? deviceName : "unknown");
   return true;
 }
 


### PR DESCRIPTION
Found by manually setting UCCL_IB_GID_INDEX=3 which resolved the CQE errors on the Broadcom cluster. Solving #799.

## Reason: 
The existing GID auto-detection logic in ncclIbGetGidIndex defaults to AF_INET (IPv4-mapped) filtering. On Broadcom bnxt_re NICs (e.g. Thor-2) where all GIDs are IPv6 (link-local fe80:: and ULA fd93::), the filter skips every candidate and falls back to GID index 0, which is an unroutable link-local address. This causes IBV_WC_RETRY_EXC_ERR (status=12, vendor_err=0xa) on all RDMA operations.

## Fix:
Add a fallback that re-scans the GID table without the address-family constraint when the initially selected GID is invalid, preferring a valid RoCE v2 entry. Also log the auto-detected GID index to aid debugging.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
