### PR TITLE
[EP] fixing EP build CI on L40s by overwriting TORCH_CUDA_ARCH_LIST=9.0

### DIFF
--- a/.github/workflows/uccl-build-test.yml
+++ b/.github/workflows/uccl-build-test.yml
@@ -76,7 +76,7 @@ jobs:
             conda activate uccl
 
             cd /home/skytestuser/uccl-test
-            ./build.sh cuda all 3.12 --install 2>&1 | tee build.log
+            TORCH_CUDA_ARCH_LIST=9.0 ./build.sh cuda all 3.12 --install 2>&1 | tee build.log
 
             grep -q \"Successfully installed uccl-\" build.log
           "'


### PR DESCRIPTION
## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
