### PR TITLE
fix(build): use container glibc for auditwheel repair symbol validation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -390,7 +390,7 @@ def initialize():
     fi
 
     auditwheel repair dist/uccl*.whl \
-      --plat "${UCCL_WHEEL_PLAT}" \
+      --plat "${AUDIT_PLAT}" \
       --exclude "libtorch*.so" \
       --exclude "libc10*.so" \
       --exclude "libibverbs.so.1" \


### PR DESCRIPTION
auditwheel repair was called with --plat "${UCCL_WHEEL_PLAT}", which uses the host's glibc version when UCCL_WHEEL_ENABLE_FORCE_RETAG=1. Since the binaries are compiled inside the container (Ubuntu 22.04, glibc 2.35), auditwheel rejects them when the host has an older glibc (e.g. 2.34) due to too-recent versioned symbols.

Fix: pass --plat "${AUDIT_PLAT}" (container glibc) to auditwheel so symbol validation passes. The existing filename rename step already handles retagging the wheel to the host platform tag afterwards.

Fixes: auditwheel: error: cannot repair to "manylinux_2_34_x86_64" ABI because of the presence of too-recent versioned symbols.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
