### PR TITLE
[P2P] Deprecate num_cpus in Endpoint constructor.

### DIFF
--- a/p2p/README.md
+++ b/p2p/README.md
@@ -338,8 +338,8 @@ done
 from uccl import p2p
 import torch
 
-# Create endpoint with local GPU index and number of CPUs
-endpoint = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+# Create endpoint with local GPU index
+endpoint = p2p.Endpoint(local_gpu_idx=0)
 ```
 
 ### Client-Server Communication
@@ -473,13 +473,12 @@ assert success
 
 #### Constructor
 ```python
-Endpoint(local_gpu_idx, num_cpus)
+Endpoint(local_gpu_idx)
 ```
 Create a new RDMA endpoint instance.
 
 **Parameters:**
 - `local_gpu_idx` (int): GPU index for this endpoint
-- `num_cpus` (int): Number of CPU threads to use for RDMA operations
 
 #### Connection Management
 

--- a/p2p/benchmarks/benchmark_ray_p2p.py
+++ b/p2p/benchmarks/benchmark_ray_p2p.py
@@ -283,7 +283,6 @@ def _run_phase(args, ep, mode: str):
 def main():
     p = argparse.ArgumentParser("UCCL Ray P2P benchmark using transfer API")
     p.add_argument("--local-gpu-idx", type=int, default=0)
-    p.add_argument("--num-cpus", type=int, default=4)
     p.add_argument("--device", choices=["cpu", "gpu"], default="gpu")
     p.add_argument(
         "--sender-device",
@@ -372,7 +371,7 @@ def main():
     if torch.cuda.is_available():
         torch.cuda.set_device(f"cuda:{args.local_gpu_idx}")
 
-    ep = p2p.Endpoint(args.local_gpu_idx, args.num_cpus)
+    ep = p2p.Endpoint(args.local_gpu_idx)
     ep.start_passive_accept()
 
     _run_phase(args, ep, mode="write")

--- a/p2p/benchmarks/benchmark_uccl.py
+++ b/p2p/benchmarks/benchmark_uccl.py
@@ -781,7 +781,6 @@ def main():
         default=0,
         help="Local GPU index to bind buffers",
     )
-    p.add_argument("--num-cpus", type=int, default=4, help="#CPU threads for RDMA ops")
     p.add_argument(
         "--device",
         choices=["cpu", "gpu"],
@@ -920,7 +919,7 @@ def main():
         )
     torch.cuda.set_device(f"cuda:{args.local_gpu_idx}")
 
-    ep = p2p.Endpoint(args.local_gpu_idx, args.num_cpus)
+    ep = p2p.Endpoint(args.local_gpu_idx)
     local_metadata = ep.get_metadata()
 
     # This also serves as a barrier to guarantee both processes have created the endpoint

--- a/p2p/benchmarks/benchmark_uccl_allgather.py
+++ b/p2p/benchmarks/benchmark_uccl_allgather.py
@@ -283,9 +283,6 @@ def main():
         description="Benchmark UCCL Collective AllGather API"
     )
     parser.add_argument(
-        "--num-cpus", type=int, default=4, help="Number of CPU threads for RDMA ops"
-    )
-    parser.add_argument(
         "--sizes",
         type=parse_size_list,
         default=[
@@ -352,7 +349,7 @@ def main():
 
     try:
         # Initialize UCCL collective
-        collective.init_collective(args.num_cpus)
+        collective.init_collective()
 
         if rank == 0:
             print("=" * 60)

--- a/p2p/benchmarks/benchmark_uccl_alltoall.py
+++ b/p2p/benchmarks/benchmark_uccl_alltoall.py
@@ -257,7 +257,6 @@ def run_ring_p2p(
 
 def main():
     p = argparse.ArgumentParser(description="Benchmark UCCL Collective for Alltoall")
-    p.add_argument("--num-cpus", type=int, default=4, help="#CPU threads for RDMA ops")
 
     # 修改为支持多个 block-size
     p.add_argument(
@@ -297,7 +296,7 @@ def main():
     results = []
 
     try:
-        collective.init_collective(args.num_cpus)
+        collective.init_collective()
         print(f"[Rank {rank}] UCCL Collective initialized successfully")
         dist.barrier()
         global_rank = dist.get_rank()

--- a/p2p/benchmarks/benchmark_uccl_collective.py
+++ b/p2p/benchmarks/benchmark_uccl_collective.py
@@ -339,7 +339,6 @@ def main():
     p = argparse.ArgumentParser(
         description="Benchmark UCCL Collective API bandwidth (GPU only)"
     )
-    p.add_argument("--num-cpus", type=int, default=4, help="#CPU threads for RDMA ops")
     p.add_argument(
         "--sizes",
         type=parse_size_list,
@@ -403,7 +402,7 @@ def main():
 
     try:
         # Initialize UCCL collective context (local_gpu_idx auto-detected from torch.distributed)
-        collective.init_collective(args.num_cpus)
+        collective.init_collective()
 
         # Get the actual GPU index used by the collective
         ctx = collective.get_collective()

--- a/p2p/benchmarks/benchmark_uccl_compression.py
+++ b/p2p/benchmarks/benchmark_uccl_compression.py
@@ -378,7 +378,6 @@ def main():
     p = argparse.ArgumentParser(
         description="Benchmark UCCL Collective API bandwidth (GPU only)"
     )
-    p.add_argument("--num-cpus", type=int, default=4, help="#CPU threads for RDMA ops")
     p.add_argument(
         "--sizes",
         type=parse_size_list,
@@ -465,7 +464,7 @@ def main():
 
     try:
         # Initialize UCCL collective context (local_gpu_idx auto-detected from torch.distributed)
-        collective.init_collective(args.num_cpus)
+        collective.init_collective()
 
         # Get the actual GPU index used by the collective
         ctx = collective.get_collective()

--- a/p2p/benchmarks/benchmark_uccl_readwrite.py
+++ b/p2p/benchmarks/benchmark_uccl_readwrite.py
@@ -288,7 +288,6 @@ def main():
     )
     p.add_argument("--lazy", action="store_true")
     p.add_argument("--local-gpu-idx", type=int, default=0)
-    p.add_argument("--num-cpus", type=int, default=4)
     p.add_argument("--device", choices=["cpu", "gpu"], default="gpu")
     p.add_argument(
         "--sizes",
@@ -327,9 +326,9 @@ def main():
     assert world_size == 2, "This benchmark only supports 2 processes"
 
     if args.lazy:
-        ep = p2p.Endpoint(args.num_cpus)
+        ep = p2p.Endpoint()
     else:
-        ep = p2p.Endpoint(args.local_gpu_idx, args.num_cpus)
+        ep = p2p.Endpoint(args.local_gpu_idx)
     local_metadata = ep.get_metadata()
 
     if rank == 0:

--- a/p2p/collective.py
+++ b/p2p/collective.py
@@ -48,7 +48,6 @@ class CollectiveContext:
 
     def __init__(
         self,
-        num_cpus: int = 4,
         local_gpu_idx: Optional[int] = None,
         use_copy_engine_for_intra: Optional[bool] = False,
     ):
@@ -56,7 +55,6 @@ class CollectiveContext:
         Initialize collective context. Requires torch.distributed to be initialized.
 
         Args:
-            num_cpus: Number of CPU threads for RDMA operations
             local_gpu_idx: Optional override for local GPU index. If None, will be derived from torch.distributed
             use_copy_engine_for_intra: Whether to use the copy engine for intra-node communication
         """
@@ -68,7 +66,6 @@ class CollectiveContext:
         self.world_size = dist.get_world_size()
         self.rank = dist.get_rank()
         self.dist_backend = "gloo" if use_copy_engine_for_intra else "nccl"
-        self.num_cpus = num_cpus
         self.use_copy_engine_for_intra = use_copy_engine_for_intra
 
         # Derive local GPU index from distributed context
@@ -139,7 +136,7 @@ class CollectiveContext:
             return
 
         # Create endpoint
-        self.ep = p2p.Endpoint(self.local_gpu_idx, self.num_cpus)
+        self.ep = p2p.Endpoint(self.local_gpu_idx)
         print(f"[Rank {self.rank}] Created p2p.Endpoint on GPU {self.local_gpu_idx}")
         local_metadata = self.ep.get_metadata()
 
@@ -764,15 +761,12 @@ _default_context: Optional[CollectiveContext] = None
 
 
 def init_collective(
-    num_cpus: int = 4,
     local_gpu_idx: Optional[int] = None,
     use_copy_engine_for_intra: Optional[bool] = False,
 ):
     """Initialize the default collective context."""
     global _default_context
-    _default_context = CollectiveContext(
-        num_cpus, local_gpu_idx, use_copy_engine_for_intra
-    )
+    _default_context = CollectiveContext(local_gpu_idx, use_copy_engine_for_intra)
     _default_context.init()
 
 

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -175,12 +175,9 @@ uccl::UCCLLogLevel Endpoint::parse_log_level_from_env() {
 // The main P2P Endpoint class implementation
 // -----------------------------------------------------------------------------
 
-Endpoint::Endpoint(uint32_t const local_gpu_idx, uint32_t const num_cpus)
-    : local_gpu_idx_(local_gpu_idx),
-      num_cpus_(num_cpus),
-      passive_accept_(false) {
-  std::cout << "Creating Engine with GPU index: " << local_gpu_idx
-            << ", CPUs: " << num_cpus << std::endl;
+Endpoint::Endpoint(uint32_t const local_gpu_idx)
+    : local_gpu_idx_(local_gpu_idx), passive_accept_(false) {
+  std::cout << "Creating Engine with GPU index: " << local_gpu_idx << std::endl;
   int n_streams = std::max(1, (int)kNumGpuRtStreams);
 
   int ngpus = 0;
@@ -238,9 +235,8 @@ Endpoint::Endpoint(uint32_t const local_gpu_idx, uint32_t const num_cpus)
   std::cout << "Endpoint initialized successfully" << std::endl;
 }
 
-Endpoint::Endpoint(uint32_t const num_cpus)
-    : local_gpu_idx_(INVALID_GPU), num_cpus_(num_cpus), passive_accept_(false) {
-  std::cout << "Creating Engine with CPUs: " << num_cpus << std::endl;
+Endpoint::Endpoint() : local_gpu_idx_(INVALID_GPU), passive_accept_(false) {
+  std::cout << "Creating Engine" << std::endl;
   int n_streams = std::max(1, (int)kNumGpuRtStreams);
 
   int ngpus = 0;

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -262,14 +262,14 @@ class Endpoint {
  public:
   /* Create engine threads running in background for a single interface. It also
    * opens a TCP listening thread waiting for incoming connections. */
-  Endpoint(uint32_t const local_gpu_idx, uint32_t const num_cpus);
+  explicit Endpoint(uint32_t const local_gpu_idx);
 
   /* Create endpoint without intializing the engine. Lazy creation of engine is
    * done during  memory registration. Additionally, open a unified P2P socket
    * for metadata exchanges. If passive_accept is true, the endpoint will not
    * call accept() but delegate it to a background thread.
    */
-  Endpoint(uint32_t const num_cpus);
+  Endpoint();
 
   ~Endpoint();
 
@@ -473,7 +473,6 @@ class Endpoint {
 
  private:
   int local_gpu_idx_;
-  uint32_t num_cpus_;
   int numa_node_;
   RDMAEndPoint ep_;
   bool engine_initialized_ = false;

--- a/p2p/engine_api.cc
+++ b/p2p/engine_api.cc
@@ -181,20 +181,18 @@ NB_MODULE(p2p, m) {
   nb::class_<Endpoint>(m, "Endpoint")
       .def(
           "__init__",
-          [](Endpoint* self, uint32_t local_gpu_idx, uint32_t num_cpus) {
+          [](Endpoint* self, uint32_t local_gpu_idx) {
             nb::gil_scoped_release release;
             InsidePythonGuard guard;
-            new (self) Endpoint(local_gpu_idx, num_cpus);
+            new (self) Endpoint(local_gpu_idx);
           },
-          nb::arg("local_gpu_idx"), nb::arg("num_cpus"))
-      .def(
-          "__init__",
-          [](Endpoint* self, uint32_t num_cpus) {
-            nb::gil_scoped_release release;
-            InsidePythonGuard guard;
-            new (self) Endpoint(num_cpus);
-          },
-          nb::arg("num_cpus"))
+          nb::arg("local_gpu_idx"))
+      .def("__init__",
+           [](Endpoint* self) {
+             nb::gil_scoped_release release;
+             InsidePythonGuard guard;
+             new (self) Endpoint();
+           })
       .def(
           "start_passive_accept",
           [](Endpoint& self) { return self.start_passive_accept(); },

--- a/p2p/nccl_tcpx_endpoint.cc
+++ b/p2p/nccl_tcpx_endpoint.cc
@@ -99,7 +99,7 @@ bool fence_default_stream(int device, cudaStream_t stream) {
 }
 }  // namespace
 
-Endpoint::Endpoint(int /*num_cpus*/) {
+Endpoint::Endpoint() {
   ctrl_port_ = get_env_int("UCCL_TCPX_OOB_PORT", 28900);
   setup_listener_();
 }

--- a/p2p/nccl_tcpx_endpoint.h
+++ b/p2p/nccl_tcpx_endpoint.h
@@ -15,7 +15,7 @@ namespace nccl_tcpx {
 
 class Endpoint {
  public:
-  explicit Endpoint(int num_cpus);
+  Endpoint();
   ~Endpoint();
 
   bool connect(std::string ip_addr, int remote_gpu_idx, int remote_port,

--- a/p2p/tests/test_engine_metadata.py
+++ b/p2p/tests/test_engine_metadata.py
@@ -32,7 +32,7 @@ def test_local():
     meta_parent, meta_child = multiprocessing.Pipe()
 
     def server_process(q):
-        engine = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+        engine = p2p.Endpoint(local_gpu_idx=0)
         metadata = engine.get_metadata()
         ip, port, remote_gpu_idx = p2p.Endpoint.parse_metadata(metadata)
         print(f"Parsed IP: {ip}")
@@ -67,7 +67,7 @@ def test_local():
             f"Client parsed server IP: {ip}, port: {port}, remote_gpu_idx: {remote_gpu_idx}"
         )
 
-        engine = p2p.Endpoint(local_gpu_idx=1, num_cpus=4)
+        engine = p2p.Endpoint(local_gpu_idx=1)
         success, conn_id = engine.connect(
             remote_ip_addr=ip, remote_gpu_idx=remote_gpu_idx, remote_port=port
         )

--- a/p2p/tests/test_engine_nvlink.py
+++ b/p2p/tests/test_engine_nvlink.py
@@ -63,7 +63,7 @@ def test_local_ipc():
     # each rank binds its own visible GPU
     torch.cuda.set_device(0)
 
-    ep = p2p.Endpoint(local_gpu_idx=rank, num_cpus=4)
+    ep = p2p.Endpoint(local_gpu_idx=rank)
 
     # Rank 0: server
     if rank == 0:

--- a/p2p/tests/test_engine_nvlink_metadata.py
+++ b/p2p/tests/test_engine_nvlink_metadata.py
@@ -74,7 +74,7 @@ def test_local_dist():
     if rank == 0:
         print("Running test_local (server)…")
 
-        engine = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+        engine = p2p.Endpoint(local_gpu_idx=0)
 
         metadata = engine.get_metadata()
         ip, port, remote_gpu_idx = p2p.Endpoint.parse_metadata(metadata)
@@ -113,7 +113,7 @@ def test_local_dist():
             f"[client] Parsed server IP: {ip}, port: {port}, remote_gpu_idx: {remote_gpu_idx}"
         )
 
-        engine = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+        engine = p2p.Endpoint(local_gpu_idx=0)
         success, conn_id = engine.connect_local(remote_gpu_idx)
         assert success
         print(f"[client] Connected successfully: conn_id={conn_id}")

--- a/p2p/tests/test_engine_onesided_ipc.py
+++ b/p2p/tests/test_engine_onesided_ipc.py
@@ -383,7 +383,7 @@ def main():
     assert dist.get_world_size() == 2, "This test requires exactly 2 processes"
 
     torch.cuda.set_device(0)
-    ep = p2p.Endpoint(local_gpu_idx=rank, num_cpus=4)
+    ep = p2p.Endpoint(local_gpu_idx=rank)
 
     print(f"=== UCCL One-Sided IPC Tests (rank {rank}) ===")
 

--- a/p2p/tests/test_engine_read.py
+++ b/p2p/tests/test_engine_read.py
@@ -44,7 +44,7 @@ def test_local():
         ep_meta = ep_meta_q.recv()
         ip, port, r_gpu = parse_endpoint_meta(ep_meta)
 
-        ep = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+        ep = p2p.Endpoint(local_gpu_idx=0)
         ok, conn_id = ep.connect(ip, r_gpu, remote_port=port)
         assert ok, "connect failed"
         print(f"[Server] connected (conn_id={conn_id})")
@@ -65,7 +65,7 @@ def test_local():
         print("✓ Server read data correctly")
 
     def client_proc(ep_meta_q, fifo_meta_q):
-        ep = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+        ep = p2p.Endpoint(local_gpu_idx=0)
         ep_meta_q.send(bytes(ep.get_metadata()))
 
         ok, r_ip, r_gpu, conn_id = ep.accept()

--- a/p2p/tests/test_engine_send.py
+++ b/p2p/tests/test_engine_send.py
@@ -44,7 +44,7 @@ def test_local():
     meta_parent, meta_child = multiprocessing.Pipe()
 
     def server_process(meta_q):
-        engine = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+        engine = p2p.Endpoint(local_gpu_idx=0)
         meta_q.send(bytes(engine.get_metadata()))
 
         success, remote_ip_addr, remote_gpu_idx, conn_id = engine.accept()
@@ -68,7 +68,7 @@ def test_local():
         return True
 
     def client_process(meta_q):
-        engine = p2p.Endpoint(local_gpu_idx=1, num_cpus=4)
+        engine = p2p.Endpoint(local_gpu_idx=1)
         ep_meta = meta_q.recv()
 
         ip, r_port, r_gpu = parse_endpoint_meta(ep_meta)

--- a/p2p/tests/test_engine_write.py
+++ b/p2p/tests/test_engine_write.py
@@ -44,7 +44,7 @@ def test_local():
         ep_meta = ep_meta_q.recv()
         ip, port, r_gpu = parse_endpoint_meta(ep_meta)
 
-        ep = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+        ep = p2p.Endpoint(local_gpu_idx=0)
         ok, conn_id = ep.connect(ip, r_gpu, remote_port=port)
         assert ok, "connect failed"
         print(f"[Server] connected (conn_id={conn_id})")
@@ -65,7 +65,7 @@ def test_local():
         print("✓ Server write data correctly")
 
     def client_proc(ep_meta_q, fifo_meta_q):
-        ep = p2p.Endpoint(local_gpu_idx=0, num_cpus=4)
+        ep = p2p.Endpoint(local_gpu_idx=0)
         ep_meta_q.send(bytes(ep.get_metadata()))
 
         ok, r_ip, r_gpu, conn_id = ep.accept()

--- a/p2p/tests/test_ray_api.py
+++ b/p2p/tests/test_ray_api.py
@@ -33,8 +33,8 @@ def test_register_memory_basic():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Create a single tensor
     tensor = torch.ones(1024, dtype=torch.float32, device="cuda:0")
@@ -98,8 +98,8 @@ def test_register_memory_multiple():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Create multiple tensors with different sizes
     tensors = [
@@ -159,8 +159,8 @@ def test_register_memory_empty_list():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Register empty list
     descriptors = ep.register_memory([])
@@ -186,8 +186,8 @@ def test_register_memory_invalid_input():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Try to register a non-tensor object
     try:
@@ -215,8 +215,8 @@ def test_register_memory_mixed_valid_invalid():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Create valid tensor
     tensor = torch.ones(1024, dtype=torch.float32, device="cuda:0")
@@ -245,8 +245,8 @@ def test_register_memory_different_dtypes():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Create tensors with different dtypes
     tensors = [
@@ -293,8 +293,8 @@ def test_get_serialized_descs():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Create tensors
     tensors = [
@@ -329,8 +329,8 @@ def test_deserialize_descs():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Create tensors
     tensors = [
@@ -392,8 +392,8 @@ def test_serialize_deserialize_roundtrip():
         return True
 
     # Create endpoint
-    ep = p2p.Endpoint(4, True)
-    print(f"Created Endpoint with 4 CPUs")
+    ep = p2p.Endpoint(4)
+    print("Created Endpoint on GPU 4")
 
     # Create tensors with different sizes and dtypes
     # Note: Use ones/zeros instead of randn for integer types (randn doesn't support int types)
@@ -484,7 +484,7 @@ def test_transfer():
     if rank == 0:
         # Client side
         print("[Client] Creating endpoint...")
-        ep = p2p.Endpoint(4, True)
+        ep = p2p.Endpoint(4)
 
         # Get local metadata
         local_metadata = ep.get_metadata()
@@ -554,7 +554,8 @@ def test_transfer():
     elif rank == 1:
         # Server side
         print("[Server] Creating endpoint...")
-        ep = p2p.Endpoint(4, True)  # passive_accept=True
+        ep = p2p.Endpoint(4)
+        ep.start_passive_accept()
 
         # Get local metadata
         local_metadata = ep.get_metadata()
@@ -565,7 +566,7 @@ def test_transfer():
         _send_bytes(local_metadata, dst=0)
         print(f"[Server] Exchanged metadata with client")
 
-        # Server doesn't need to call accept (passive_accept=True handles it)
+        # Server doesn't need to call accept after start_passive_accept().
         # Wait a bit for connection to establish
         import time
 

--- a/p2p/tests/test_remove_remote_endpoint.py
+++ b/p2p/tests/test_remove_remote_endpoint.py
@@ -66,7 +66,7 @@ def test_remove_invalid_conn_id():
     print("Test: remove_remote_endpoint with invalid conn_id")
     print("=" * 60)
 
-    ep = p2p.Endpoint(0, 4)
+    ep = p2p.Endpoint(0)
     ep.start_passive_accept()
 
     result = ep.remove_remote_endpoint(999999)
@@ -89,7 +89,7 @@ def test_remove_double_remove():
     rank = dist.get_rank()
     peer = 1 - rank
 
-    ep = p2p.Endpoint(0, 4)
+    ep = p2p.Endpoint(0)
     ep.start_passive_accept()
 
     local_meta = ep.get_metadata()
@@ -136,7 +136,7 @@ def test_remove_after_add():
     rank = dist.get_rank()
     peer = 1 - rank
 
-    ep = p2p.Endpoint(0, 4)
+    ep = p2p.Endpoint(0)
     ep.start_passive_accept()
 
     local_meta = ep.get_metadata()
@@ -175,7 +175,7 @@ def test_remove_and_readd():
     rank = dist.get_rank()
     peer = 1 - rank
 
-    ep = p2p.Endpoint(0, 4)
+    ep = p2p.Endpoint(0)
     ep.start_passive_accept()
 
     local_meta = ep.get_metadata()
@@ -230,7 +230,7 @@ def test_remove_then_transfer_fails():
     rank = dist.get_rank()
     peer = 1 - rank
 
-    ep = p2p.Endpoint(0, 4)
+    ep = p2p.Endpoint(0)
     ep.start_passive_accept()
 
     local_meta = ep.get_metadata()

--- a/p2p/uccl_engine.cc
+++ b/p2p/uccl_engine.cc
@@ -128,9 +128,10 @@ void listener_thread_func(uccl_conn_t* conn) {
 }
 
 uccl_engine_t* uccl_engine_create(int num_cpus, bool in_python) {
+  (void)num_cpus;
   inside_python = in_python;
   uccl_engine_t* eng = new uccl_engine;
-  eng->endpoint = std::unique_ptr<Endpoint>(new Endpoint(num_cpus));
+  eng->endpoint = std::unique_ptr<Endpoint>(new Endpoint());
   return eng;
 }
 

--- a/p2p/uccl_engine.h
+++ b/p2p/uccl_engine.h
@@ -27,7 +27,7 @@ typedef struct md {
 
 /**
  * Create and initialize an engine instance.
- * @param num_cpus      The number of CPUs to use for the engine.
+ * @param num_cpus      Reserved for API compatibility. Currently unused.
  * @param in_python     Whether the engine is being created in Python.
  * @return              Pointer to the engine instance, or NULL on failure.
  */


### PR DESCRIPTION
## Description

This PR removes all `num_cpus` except for `uccl_engine_create`, as it is referenced by Nixl code. 

This PR was compiled successfully and checked by AI.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
