### PR TITLE
Fix p2p build regression for therock target.

### DIFF
--- a/p2p/Makefile.therock
+++ b/p2p/Makefile.therock
@@ -7,7 +7,7 @@ HIP_LIB  := $(HIP_HOME)/lib
 CONDA_LIB_HOME?=/usr/lib
 RDMA_HOME := ../collective/rdma
 CXX := g++
-CXXFLAGS := -O3 -shared -std=c++17 -fPIC -I../include -I$(RDMA_HOME) -I$(HIP_INC) \
+CXXFLAGS := -O3 -shared -std=c++17 -fPIC -I. -I./include -I../include -I$(RDMA_HOME) -I$(HIP_INC) \
 	-Wno-pointer-arith -Wno-sign-compare -Wno-unused-variable \
 	-I${CONDA_LIB_HOME}/../include -L${CONDA_LIB_HOME} -lz -lelf -libverbs -lpthread
 


### PR DESCRIPTION
Add '-I./include' to CFLAGS so p2p/include/common.h can be found.
Add '-I.' to CFLAGS so p2p/rdma/define.h can be found.

## Description

See commit message.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [x] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
