### PR TITLE
[P2P] release bug fix

### DIFF
--- a/p2p/rdma/define.h
+++ b/p2p/rdma/define.h
@@ -563,7 +563,7 @@ typedef struct RDMARecvRequest {
 
   // Getter methods
   inline uint32_t getLocalKey() const {
-    return local_mem->getKeyByContextID(channel_id);
+    return local_mem->getKeyByChannelID(channel_id);
   }
 
   inline uint64_t getLocalAddress() const {
@@ -621,7 +621,8 @@ struct alignas(64) SendReqMeta {
     local_mem =
         *(rev_req->local_compression_mem ? rev_req->local_compression_mem
                                          : rev_req->local_mem);
-    float_type = rev_req->compress_ctx->getFloatType();
+    float_type = rev_req->compress_ctx ? rev_req->compress_ctx->getFloatType()
+                                       : uccl::FloatType::kUndefined;
     expected_chunk_count =
         ChunkSplitStrategy::getMessageChunkCount(local_mem.size);
     received_chunk_count = 0;

--- a/p2p/rdma/providers/efa/rdma_data_channel_impl_efa.cc
+++ b/p2p/rdma/providers/efa/rdma_data_channel_impl_efa.cc
@@ -66,19 +66,35 @@ inline void EFAChannelImpl::initQP(std::shared_ptr<RdmaContext> ctx,
   attr.port_num = kPortNum;
   attr.qkey = QKEY;
   attr.pkey_index = 0;
-  assert(ibv_modify_qp(*qp, &attr,
-                       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
-                           IBV_QP_QKEY) == 0);
+  int const init_qp_rc = ibv_modify_qp(*qp, &attr,
+                                       IBV_QP_STATE | IBV_QP_PKEY_INDEX |
+                                           IBV_QP_PORT | IBV_QP_QKEY);
+  if (unlikely(init_qp_rc != 0)) {
+    UCCL_LOG(ERROR) << "ibv_modify_qp INIT failed, rc=" << init_qp_rc
+                    << ", errno=" << errno << " (" << strerror(errno) << ")";
+    throw std::runtime_error("ibv_modify_qp INIT failed");
+  }
 
   memset(&attr, 0, sizeof(attr));
   attr.qp_state = IBV_QPS_RTR;
-  assert(ibv_modify_qp(*qp, &attr, IBV_QP_STATE) == 0);
+  int const rtr_rc = ibv_modify_qp(*qp, &attr, IBV_QP_STATE);
+  if (unlikely(rtr_rc != 0)) {
+    UCCL_LOG(ERROR) << "ibv_modify_qp RTR failed, rc=" << rtr_rc
+                    << ", errno=" << errno << " (" << strerror(errno) << ")";
+    throw std::runtime_error("ibv_modify_qp RTR failed");
+  }
 
   memset(&attr, 0, sizeof(attr));
   attr.qp_state = IBV_QPS_RTS;
   attr.rnr_retry = RNR_RETRY;
-  assert(ibv_modify_qp(*qp, &attr,
-                       IBV_QP_STATE | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN) == 0);
+  int const rts_rc = ibv_modify_qp(*qp, &attr,
+                                   IBV_QP_STATE | IBV_QP_RNR_RETRY |
+                                       IBV_QP_SQ_PSN);
+  if (unlikely(rts_rc != 0)) {
+    UCCL_LOG(ERROR) << "ibv_modify_qp RTS failed, rc=" << rts_rc
+                    << ", errno=" << errno << " (" << strerror(errno) << ")";
+    throw std::runtime_error("ibv_modify_qp RTS failed");
+  }
 
   local_meta->gid = ctx->detectGid(GID_INDEX_EFA);
   local_meta->qpn = (*qp)->qp_num;

--- a/p2p/rdma/providers/efa/rdma_data_channel_impl_efa.cc
+++ b/p2p/rdma/providers/efa/rdma_data_channel_impl_efa.cc
@@ -66,9 +66,8 @@ inline void EFAChannelImpl::initQP(std::shared_ptr<RdmaContext> ctx,
   attr.port_num = kPortNum;
   attr.qkey = QKEY;
   attr.pkey_index = 0;
-  int const init_qp_rc = ibv_modify_qp(*qp, &attr,
-                                       IBV_QP_STATE | IBV_QP_PKEY_INDEX |
-                                           IBV_QP_PORT | IBV_QP_QKEY);
+  int const init_qp_rc = ibv_modify_qp(
+      *qp, &attr, IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_QKEY);
   if (unlikely(init_qp_rc != 0)) {
     UCCL_LOG(ERROR) << "ibv_modify_qp INIT failed, rc=" << init_qp_rc
                     << ", errno=" << errno << " (" << strerror(errno) << ")";
@@ -87,9 +86,8 @@ inline void EFAChannelImpl::initQP(std::shared_ptr<RdmaContext> ctx,
   memset(&attr, 0, sizeof(attr));
   attr.qp_state = IBV_QPS_RTS;
   attr.rnr_retry = RNR_RETRY;
-  int const rts_rc = ibv_modify_qp(*qp, &attr,
-                                   IBV_QP_STATE | IBV_QP_RNR_RETRY |
-                                       IBV_QP_SQ_PSN);
+  int const rts_rc = ibv_modify_qp(
+      *qp, &attr, IBV_QP_STATE | IBV_QP_RNR_RETRY | IBV_QP_SQ_PSN);
   if (unlikely(rts_rc != 0)) {
     UCCL_LOG(ERROR) << "ibv_modify_qp RTS failed, rc=" << rts_rc
                     << ", errno=" << errno << " (" << strerror(errno) << ")";

--- a/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.cc
+++ b/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.cc
@@ -65,9 +65,9 @@ inline void IBChannelImpl::initQP(std::shared_ptr<RdmaContext> ctx,
   attr.pkey_index = 0;
   attr.qp_access_flags =
       IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
-  int const init_qp_rc = ibv_modify_qp(*qp, &attr,
-                                       IBV_QP_STATE | IBV_QP_PKEY_INDEX |
-                                           IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
+  int const init_qp_rc = ibv_modify_qp(
+      *qp, &attr,
+      IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
   if (unlikely(init_qp_rc != 0)) {
     UCCL_LOG(ERROR) << "ibv_modify_qp INIT failed, rc=" << init_qp_rc
                     << ", errno=" << errno << " (" << strerror(errno) << ")";

--- a/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.cc
+++ b/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.cc
@@ -65,9 +65,14 @@ inline void IBChannelImpl::initQP(std::shared_ptr<RdmaContext> ctx,
   attr.pkey_index = 0;
   attr.qp_access_flags =
       IBV_ACCESS_LOCAL_WRITE | IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_WRITE;
-  assert(ibv_modify_qp(*qp, &attr,
-                       IBV_QP_STATE | IBV_QP_PKEY_INDEX | IBV_QP_PORT |
-                           IBV_QP_ACCESS_FLAGS) == 0);
+  int const init_qp_rc = ibv_modify_qp(*qp, &attr,
+                                       IBV_QP_STATE | IBV_QP_PKEY_INDEX |
+                                           IBV_QP_PORT | IBV_QP_ACCESS_FLAGS);
+  if (unlikely(init_qp_rc != 0)) {
+    UCCL_LOG(ERROR) << "ibv_modify_qp INIT failed, rc=" << init_qp_rc
+                    << ", errno=" << errno << " (" << strerror(errno) << ")";
+    throw std::runtime_error("ibv_modify_qp INIT failed");
+  }
 
   local_meta->gid = ctx->detectGid(GID_INDEX_DEFAULT);
   local_meta->qpn = (*qp)->qp_num;
@@ -86,7 +91,12 @@ inline void IBChannelImpl::ibrcQP_rtr_rts(struct ibv_qp* qp,
   int flags = 0;
   struct ibv_qp_attr attr = {};
   struct ibv_port_attr port_attr;
-  assert(ibv_query_port(ctx->getCtx(), kPortNum, &port_attr) == 0);
+  int const query_port_rc = ibv_query_port(ctx->getCtx(), kPortNum, &port_attr);
+  if (unlikely(query_port_rc != 0)) {
+    UCCL_LOG(ERROR) << "ibv_query_port failed, rc=" << query_port_rc
+                    << ", errno=" << errno << " (" << strerror(errno) << ")";
+    throw std::runtime_error("ibv_query_port failed");
+  }
 
   // RTR
   memset(&attr, 0, sizeof(attr));
@@ -122,7 +132,12 @@ inline void IBChannelImpl::ibrcQP_rtr_rts(struct ibv_qp* qp,
 
   flags = IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_DEST_QPN | IBV_QP_RQ_PSN |
           IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER | IBV_QP_AV;
-  assert(ibv_modify_qp(qp, &attr, flags) == 0);
+  int const rtr_rc = ibv_modify_qp(qp, &attr, flags);
+  if (unlikely(rtr_rc != 0)) {
+    UCCL_LOG(ERROR) << "ibv_modify_qp RTR failed, rc=" << rtr_rc
+                    << ", errno=" << errno << " (" << strerror(errno) << ")";
+    throw std::runtime_error("ibv_modify_qp RTR failed");
+  }
 
   lazyPostRecvWrsN(qp, kMaxRecvWr, true);
 
@@ -136,7 +151,12 @@ inline void IBChannelImpl::ibrcQP_rtr_rts(struct ibv_qp* qp,
   attr.max_rd_atomic = MAX_RD_ATOMIC;
   flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
           IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC;
-  assert(ibv_modify_qp(qp, &attr, flags) == 0);
+  int const rts_rc = ibv_modify_qp(qp, &attr, flags);
+  if (unlikely(rts_rc != 0)) {
+    UCCL_LOG(ERROR) << "ibv_modify_qp RTS failed, rc=" << rts_rc
+                    << ", errno=" << errno << " (" << strerror(errno) << ")";
+    throw std::runtime_error("ibv_modify_qp RTS failed");
+  }
 }
 
 inline bool IBChannelImpl::pollOnce(struct ibv_cq_ex* cq_ex,
@@ -192,7 +212,12 @@ inline void IBChannelImpl::lazyPostRecvWrsN(struct ibv_qp* qp, uint32_t n,
   while (pending_post_recv_ >= kBatchPostRecvWr) {
     struct ibv_recv_wr* bad_wr = nullptr;
     pre_alloc_recv_wrs_[kBatchPostRecvWr - 1].next = nullptr;
-    assert(ibv_post_recv(qp, pre_alloc_recv_wrs_, &bad_wr) == 0);
+    int const post_recv_rc = ibv_post_recv(qp, pre_alloc_recv_wrs_, &bad_wr);
+    if (unlikely(post_recv_rc != 0)) {
+      UCCL_LOG(ERROR) << "ibv_post_recv failed, rc=" << post_recv_rc
+                      << ", errno=" << errno << " (" << strerror(errno) << ")";
+      throw std::runtime_error("ibv_post_recv failed");
+    }
     pre_alloc_recv_wrs_[kBatchPostRecvWr - 1].next =
         (kBatchPostRecvWr == kMaxRecvWr)
             ? nullptr
@@ -203,7 +228,12 @@ inline void IBChannelImpl::lazyPostRecvWrsN(struct ibv_qp* qp, uint32_t n,
   if (force && pending_post_recv_) {
     struct ibv_recv_wr* bad_wr = nullptr;
     pre_alloc_recv_wrs_[pending_post_recv_ - 1].next = nullptr;
-    assert(ibv_post_recv(qp, pre_alloc_recv_wrs_, &bad_wr) == 0);
+    int const post_recv_rc = ibv_post_recv(qp, pre_alloc_recv_wrs_, &bad_wr);
+    if (unlikely(post_recv_rc != 0)) {
+      UCCL_LOG(ERROR) << "ibv_post_recv failed, rc=" << post_recv_rc
+                      << ", errno=" << errno << " (" << strerror(errno) << ")";
+      throw std::runtime_error("ibv_post_recv failed");
+    }
     pre_alloc_recv_wrs_[pending_post_recv_ - 1].next =
         (pending_post_recv_ == kMaxRecvWr)
             ? nullptr

--- a/p2p/rdma/rdma_context.h
+++ b/p2p/rdma/rdma_context.h
@@ -55,7 +55,12 @@ class RdmaContext {
     if (!ctx_) throw std::runtime_error("Failed to open context");
 
     struct ibv_device_attr dev_attr;
-    assert(ibv_query_device(ctx_.get(), &dev_attr) == 0);
+    int const query_dev_rc = ibv_query_device(ctx_.get(), &dev_attr);
+    if (unlikely(query_dev_rc != 0)) {
+      UCCL_LOG(ERROR) << "ibv_query_device failed, rc=" << query_dev_rc
+                      << ", errno=" << errno << " (" << strerror(errno) << ")";
+      throw std::runtime_error("ibv_query_device failed");
+    }
     vendor_id_ = dev_attr.vendor_id;
 
     struct ibv_pd* pd = ibv_alloc_pd(ctx_.get());
@@ -212,7 +217,13 @@ class RdmaContext {
 
   uint16_t queryLid(int port = 1) const {
     struct ibv_port_attr port_attr;
-    assert(ibv_query_port(ctx_.get(), port, &port_attr) == 0);
+    int const query_port_rc = ibv_query_port(ctx_.get(), port, &port_attr);
+    if (unlikely(query_port_rc != 0)) {
+      UCCL_LOG(ERROR) << "ibv_query_port failed, port=" << port
+                      << ", rc=" << query_port_rc << ", errno=" << errno
+                      << " (" << strerror(errno) << ")";
+      throw std::runtime_error("ibv_query_port failed");
+    }
     return port_attr.lid;
   }
 

--- a/p2p/rdma/rdma_context.h
+++ b/p2p/rdma/rdma_context.h
@@ -220,8 +220,8 @@ class RdmaContext {
     int const query_port_rc = ibv_query_port(ctx_.get(), port, &port_attr);
     if (unlikely(query_port_rc != 0)) {
       UCCL_LOG(ERROR) << "ibv_query_port failed, port=" << port
-                      << ", rc=" << query_port_rc << ", errno=" << errno
-                      << " (" << strerror(errno) << ")";
+                      << ", rc=" << query_port_rc << ", errno=" << errno << " ("
+                      << strerror(errno) << ")";
       throw std::runtime_error("ibv_query_port failed");
     }
     return port_attr.lid;

--- a/p2p/rdma/rdma_endpoint.h
+++ b/p2p/rdma/rdma_endpoint.h
@@ -35,8 +35,14 @@ class NICEndpoint {
     oob_client_ = std::make_shared<EpollClient>();
 
     allocator_ = std::make_shared<MemoryAllocator>();
-    assert(oob_server_->start());
-    assert(oob_client_->start());
+    if (unlikely(!oob_server_->start())) {
+      UCCL_LOG(ERROR) << "Failed to start OOB server";
+      throw std::runtime_error("Failed to start OOB server");
+    }
+    if (unlikely(!oob_client_->start())) {
+      UCCL_LOG(ERROR) << "Failed to start OOB client";
+      throw std::runtime_error("Failed to start OOB client");
+    }
     initCompressor();
   }
   // Destructor


### PR DESCRIPTION
## Description
- This PR replaces all side-effectful assert usage in p2p/rdma with runtime checks, and audits the rest of p2p to confirm there are no other side-effectful assert cases.
- It also fixes one API misuse and one potential null-pointer access.

Fixes # (issue)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
