### PR TITLE
[EP] Handle zero-token intranode dispatch/combine paths

### DIFF
--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -914,7 +914,9 @@ class Buffer:
                 is_token_in_rank,
                 send_head,
             ) = handle
-            num_recv_tokens = int(rank_prefix_matrix[self.group_size - 1, self.rank].item())
+            num_recv_tokens = int(
+                rank_prefix_matrix[self.group_size - 1, self.rank].item()
+            )
             num_topk = 0
             num_scales = (
                 0
@@ -1198,7 +1200,9 @@ class Buffer:
         if num_x_rows == 0:
             x = x.new_empty((1, x.size(1)))
         if src_idx.size(0) == 0:
-            src_idx = src_idx.new_empty((1,), dtype=src_idx.dtype, device=src_idx.device)
+            src_idx = src_idx.new_empty(
+                (1,), dtype=src_idx.dtype, device=src_idx.device
+            )
         if topk_weights is not None and topk_weights.size(0) == 0:
             topk_weights = topk_weights.new_empty(
                 (1, num_topk), dtype=topk_weights.dtype, device=topk_weights.device

--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -914,7 +914,7 @@ class Buffer:
                 is_token_in_rank,
                 send_head,
             ) = handle
-            num_recv_tokens = recv_src_idx.size(0)
+            num_recv_tokens = int(rank_prefix_matrix[self.group_size - 1, self.rank].item())
             num_topk = 0
             num_scales = (
                 0
@@ -923,6 +923,7 @@ class Buffer:
             )
             scale_token_stride = 0 if x_scales is None else int(x_scales.stride(0))
             scale_hidden_stride = 0 if x_scales is None else int(x_scales.stride(1))
+            alloc_recv_tokens = max(num_recv_tokens, 1)
             alloc_ctx = (
                 torch.cuda.stream(self.get_comm_stream())
                 if allocate_on_comm_stream
@@ -930,16 +931,16 @@ class Buffer:
             )
             with alloc_ctx:
                 recv_x = torch.empty(
-                    (num_recv_tokens, x.size(1)), device=x.device, dtype=x.dtype
+                    (alloc_recv_tokens, x.size(1)), device=x.device, dtype=x.dtype
                 )
                 recv_x_scales = (
                     None
                     if x_scales is None
                     else torch.empty(
                         (
-                            (num_recv_tokens,)
+                            (alloc_recv_tokens,)
                             if x_scales.dim() == 1
-                            else (num_recv_tokens, num_scales)
+                            else (alloc_recv_tokens, num_scales)
                         ),
                         device=x.device,
                         dtype=x_scales.dtype,
@@ -977,6 +978,9 @@ class Buffer:
                 allocate_on_comm_stream,
                 self._ll_compute_stream_ptr(x.device),
             )
+            recv_x = recv_x[:num_recv_tokens]
+            if recv_x_scales is not None:
+                recv_x_scales = recv_x_scales[:num_recv_tokens]
             return (
                 (recv_x, recv_x_scales) if x_scales is not None else recv_x,
                 None,
@@ -1023,6 +1027,7 @@ class Buffer:
             )
             scale_token_stride = 0 if x_scales is None else int(x_scales.stride(0))
             scale_hidden_stride = 0 if x_scales is None else int(x_scales.stride(1))
+            alloc_recv_tokens = max(num_recv_tokens, 1)
             alloc_ctx = (
                 torch.cuda.stream(self.get_comm_stream())
                 if allocate_on_comm_stream
@@ -1030,10 +1035,10 @@ class Buffer:
             )
             with alloc_ctx:
                 recv_x = torch.empty(
-                    (num_recv_tokens, x.size(1)), device=x.device, dtype=x.dtype
+                    (alloc_recv_tokens, x.size(1)), device=x.device, dtype=x.dtype
                 )
                 recv_src_idx = torch.empty(
-                    (num_recv_tokens,), dtype=torch.int32, device=x.device
+                    (alloc_recv_tokens,), dtype=torch.int32, device=x.device
                 )
                 recv_channel_prefix_matrix = torch.empty(
                     (self.group_size, num_channels), dtype=torch.int32, device=x.device
@@ -1045,12 +1050,12 @@ class Buffer:
                 recv_topk_weights = None
                 if topk_idx is not None:
                     recv_topk_idx = torch.empty(
-                        (num_recv_tokens, topk_idx.size(1)),
+                        (alloc_recv_tokens, topk_idx.size(1)),
                         dtype=topk_idx.dtype,
                         device=x.device,
                     )
                     recv_topk_weights = torch.empty(
-                        (num_recv_tokens, topk_weights.size(1)),
+                        (alloc_recv_tokens, topk_weights.size(1)),
                         dtype=topk_weights.dtype,
                         device=x.device,
                     )
@@ -1059,9 +1064,9 @@ class Buffer:
                     if x_scales is None
                     else torch.empty(
                         (
-                            (num_recv_tokens,)
+                            (alloc_recv_tokens,)
                             if x_scales.dim() == 1
-                            else (num_recv_tokens, num_scales)
+                            else (alloc_recv_tokens, num_scales)
                         ),
                         device=x.device,
                         dtype=x_scales.dtype,
@@ -1099,11 +1104,21 @@ class Buffer:
                 allocate_on_comm_stream,
                 self._ll_compute_stream_ptr(x.device),
             )
+            recv_x = recv_x[:num_recv_tokens]
+            recv_src_idx = recv_src_idx[:num_recv_tokens]
+            if recv_topk_idx is not None:
+                recv_topk_idx = recv_topk_idx[:num_recv_tokens]
+            if recv_topk_weights is not None:
+                recv_topk_weights = recv_topk_weights[:num_recv_tokens]
+            if recv_x_scales is not None:
+                recv_x_scales = recv_x_scales[:num_recv_tokens]
             handle = (
                 rank_prefix_matrix,
                 channel_prefix_matrix,
                 recv_channel_prefix_matrix,
-                recv_src_idx,
+                # Cached combine expects a valid src_idx pointer even when the
+                # logical receive count is 0, so keep a 1-element sentinel.
+                recv_src_idx if num_recv_tokens > 0 else recv_src_idx.new_empty((1,)),
                 is_token_in_rank,
                 send_head,
             )
@@ -1179,6 +1194,16 @@ class Buffer:
         # Launch the kernel
         num_recv_tokens = send_head.size(0)
         num_topk = 0 if topk_weights is None else int(topk_weights.size(1))
+        num_x_rows = x.size(0)
+        if num_x_rows == 0:
+            x = x.new_empty((1, x.size(1)))
+        if src_idx.size(0) == 0:
+            src_idx = src_idx.new_empty((1,), dtype=src_idx.dtype, device=src_idx.device)
+        if topk_weights is not None and topk_weights.size(0) == 0:
+            topk_weights = topk_weights.new_empty(
+                (1, num_topk), dtype=topk_weights.dtype, device=topk_weights.device
+            )
+        alloc_recv_tokens = max(num_recv_tokens, 1)
         alloc_ctx = (
             torch.cuda.stream(self.get_comm_stream())
             if allocate_on_comm_stream
@@ -1186,20 +1211,20 @@ class Buffer:
         )
         with alloc_ctx:
             recv_x = torch.empty(
-                (num_recv_tokens, x.size(1)), device=x.device, dtype=x.dtype
+                (alloc_recv_tokens, x.size(1)), device=x.device, dtype=x.dtype
             )
             recv_topk_weights = (
                 None
                 if topk_weights is None
                 else torch.empty(
-                    (num_recv_tokens, num_topk),
+                    (alloc_recv_tokens, num_topk),
                     device=x.device,
                     dtype=topk_weights.dtype,
                 )
             )
         event = self.runtime.intranode_combine(
             x.data_ptr(),
-            x.size(0),
+            num_x_rows,
             x.size(1),
             Buffer._dtype_code(x.dtype),
             x.element_size(),
@@ -1220,6 +1245,9 @@ class Buffer:
             allocate_on_comm_stream,
             self._ll_compute_stream_ptr(x.device),
         )
+        recv_x = recv_x[:num_recv_tokens]
+        if recv_topk_weights is not None:
+            recv_topk_weights = recv_topk_weights[:num_recv_tokens]
         return recv_x, recv_topk_weights, EventOverlap(event)
 
     # noinspection PyTypeChecker

--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -910,13 +910,11 @@ class Buffer:
                 rank_prefix_matrix,
                 channel_prefix_matrix,
                 recv_channel_prefix_matrix,
+                num_recv_tokens,
                 recv_src_idx,
                 is_token_in_rank,
                 send_head,
             ) = handle
-            num_recv_tokens = int(
-                rank_prefix_matrix[self.group_size - 1, self.rank].item()
-            )
             num_topk = 0
             num_scales = (
                 0
@@ -1118,8 +1116,10 @@ class Buffer:
                 rank_prefix_matrix,
                 channel_prefix_matrix,
                 recv_channel_prefix_matrix,
-                # Cached combine expects a valid src_idx pointer even when the
-                # logical receive count is 0, so keep a 1-element sentinel.
+                # Keep the logical count separate from the storage tensor so
+                # cached dispatch avoids a GPU sync while cached combine still
+                # gets a valid src_idx pointer when the count is 0.
+                num_recv_tokens,
                 recv_src_idx if num_recv_tokens > 0 else recv_src_idx.new_empty((1,)),
                 is_token_in_rank,
                 send_head,
@@ -1187,6 +1187,7 @@ class Buffer:
             rank_prefix_matrix,
             _,
             channel_prefix_matrix,
+            _,
             src_idx,
             is_recv_token_in_rank,
             send_head,
@@ -1304,12 +1305,12 @@ class Buffer:
                 recv_rdma_rank_prefix_sum,
                 recv_gbl_channel_prefix_matrix,
                 recv_gbl_rank_prefix_sum,
+                num_recv_tokens,
+                num_rdma_recv_tokens,
                 recv_src_meta,
                 send_rdma_head,
                 send_nvl_head,
             ) = handle
-            num_recv_tokens = recv_src_meta.size(0)
-            num_rdma_recv_tokens = send_nvl_head.size(0)
             # Allocate at least 1 row so data_ptr() is never null (zero-token ranks
             # produce empty tensors whose data_ptr()==0, which trips C++ assertions).
             alloc_recv_tokens = max(num_recv_tokens, 1)
@@ -1549,6 +1550,8 @@ class Buffer:
                 recv_rdma_rank_prefix_sum,
                 recv_gbl_channel_prefix_matrix,
                 recv_gbl_rank_prefix_sum,
+                num_recv_tokens,
+                num_rdma_recv_tokens,
                 recv_src_meta,
                 send_rdma_head,
                 send_nvl_head,
@@ -1589,6 +1592,8 @@ class Buffer:
             rdma_rank_prefix_sum,
             gbl_channel_prefix_matrix,
             gbl_rank_prefix_sum,
+            _,
+            _,
             src_meta,
             send_rdma_head,
             send_nvl_head,

--- a/ep/bench/test_intranode.py
+++ b/ep/bench/test_intranode.py
@@ -181,14 +181,13 @@ def test_main(
         token_offsets = torch.arange(
             num_tokens, dtype=torch.int64, device="cuda"
         ).unsqueeze(1)
-        topk_offsets = torch.arange(num_topk, dtype=torch.int64, device="cuda").unsqueeze(
-            0
-        )
+        topk_offsets = torch.arange(
+            num_topk, dtype=torch.int64, device="cuda"
+        ).unsqueeze(0)
         zero_recv_topk_idx = (token_offsets + topk_offsets) % active_experts
-        zero_recv_topk_weights = (
-            torch.ones((num_tokens, num_topk), dtype=torch.float32, device="cuda")
-            * (rank + 1)
-        )
+        zero_recv_topk_weights = torch.ones(
+            (num_tokens, num_topk), dtype=torch.float32, device="cuda"
+        ) * (rank + 1)
 
         (
             zero_recv_num_tokens_per_rank,

--- a/ep/bench/test_intranode.py
+++ b/ep/bench/test_intranode.py
@@ -113,12 +113,159 @@ def test_main(
     # Test dispatch
     # noinspection PyShadowingNames
     def check_data(check_x, rank_prefix_matrix):
+        if check_x.size(0) == 0:
+            return
         assert torch.allclose(check_x.amin(dim=1), check_x.amax(dim=1))
         check_start = 0
         for i in range(num_ranks):
             check_end = rank_prefix_matrix[i][rank].item()
             assert (check_x[check_start:check_end, :].int() - i).sum().item() == 0
             check_start = check_end
+
+    def build_layout_metadata(current_topk_idx):
+        current_rank_idx = current_topk_idx // (num_experts // num_ranks)
+        current_rank_idx.masked_fill_(current_topk_idx == -1, -1)
+        inplace_unique(current_rank_idx, num_ranks)
+
+        current_num_tokens_per_expert = torch.zeros(
+            (num_experts,), dtype=torch.int, device="cuda"
+        )
+        for i in range(num_experts):
+            current_num_tokens_per_expert[i] = (current_topk_idx == i).sum()
+        current_gbl_num_tokens_per_expert = current_num_tokens_per_expert.clone()
+        dist.all_reduce(current_gbl_num_tokens_per_expert, group=group)
+
+        current_num_tokens_per_rank = torch.empty(
+            (num_ranks,), dtype=torch.int, device="cuda"
+        )
+        current_token_idx_in_rank = torch.full(
+            (num_ranks, num_tokens), -1, dtype=torch.long, device="cuda"
+        )
+        for i in range(num_ranks):
+            current_num_tokens_per_rank[i] = (current_rank_idx == i).sum()
+            token_sel = (current_rank_idx == i).max(dim=-1)[0]
+            count = token_sel.sum().item()
+            tokens = torch.sort(token_sel.to(torch.int), descending=True)[1]
+            tokens[:count] = torch.sort(tokens[:count])[0]
+            current_token_idx_in_rank[i][tokens[:count]] = torch.arange(
+                count, dtype=torch.long, device="cuda"
+            )
+        current_token_idx_in_rank = current_token_idx_in_rank.T.contiguous().to(
+            torch.int
+        )
+        current_is_token_in_rank = current_token_idx_in_rank >= 0
+        current_gbl_num_tokens_per_rank = current_num_tokens_per_rank.clone()
+        dist.all_reduce(current_gbl_num_tokens_per_rank, group=group)
+
+        return (
+            current_num_tokens_per_rank,
+            current_num_tokens_per_expert,
+            current_is_token_in_rank,
+            current_gbl_num_tokens_per_rank,
+            current_gbl_num_tokens_per_expert,
+        )
+
+    def run_zero_recv_rank_test():
+        if num_ranks < 2:
+            return
+
+        num_local_experts = num_experts // num_ranks
+        active_ranks = num_ranks - 1
+        active_experts = active_ranks * num_local_experts
+        assert active_experts >= num_topk
+
+        zero_recv_rank = num_ranks - 1
+        zero_recv_x = (
+            torch.ones((num_tokens, hidden), dtype=torch.bfloat16, device="cuda") * rank
+        )
+        token_offsets = torch.arange(
+            num_tokens, dtype=torch.int64, device="cuda"
+        ).unsqueeze(1)
+        topk_offsets = torch.arange(num_topk, dtype=torch.int64, device="cuda").unsqueeze(
+            0
+        )
+        zero_recv_topk_idx = (token_offsets + topk_offsets) % active_experts
+        zero_recv_topk_weights = (
+            torch.ones((num_tokens, num_topk), dtype=torch.float32, device="cuda")
+            * (rank + 1)
+        )
+
+        (
+            zero_recv_num_tokens_per_rank,
+            zero_recv_num_tokens_per_expert,
+            zero_recv_is_token_in_rank,
+            zero_recv_gbl_num_tokens_per_rank,
+            zero_recv_gbl_num_tokens_per_expert,
+        ) = build_layout_metadata(zero_recv_topk_idx.clone())
+
+        zero_recv_ranks = (
+            (zero_recv_gbl_num_tokens_per_rank == 0).nonzero(as_tuple=True)[0].tolist()
+        )
+        assert zero_recv_ranks == [zero_recv_rank], zero_recv_ranks
+
+        if local_rank == 0:
+            print(
+                f"[zero-recv-rank] forcing rank {zero_recv_rank} to receive 0 tokens ...",
+                flush=True,
+                end="",
+            )
+
+        (
+            recv_x,
+            recv_topk_idx,
+            recv_topk_weights,
+            recv_num_tokens_per_expert_list,
+            handle,
+            event,
+        ) = buffer.dispatch(
+            x=zero_recv_x,
+            topk_idx=zero_recv_topk_idx,
+            topk_weights=zero_recv_topk_weights,
+            num_tokens_per_rank=zero_recv_num_tokens_per_rank,
+            is_token_in_rank=zero_recv_is_token_in_rank,
+            num_tokens_per_expert=zero_recv_num_tokens_per_expert,
+            config=config,
+        )
+        rank_prefix_matrix = handle[0]
+        expected_recv_tokens = int(zero_recv_gbl_num_tokens_per_rank[rank].item())
+        assert recv_x.size(0) == expected_recv_tokens
+        assert (
+            zero_recv_gbl_num_tokens_per_expert.view(num_ranks, -1)[rank].tolist()
+            == recv_num_tokens_per_expert_list
+        )
+        check_data(recv_x, rank_prefix_matrix)
+
+        if rank == zero_recv_rank:
+            assert recv_x.size(0) == 0
+            assert recv_topk_idx.size(0) == 0
+            assert recv_topk_weights.size(0) == 0
+
+        cached_recv_x, _, _, _, _, cached_event = buffer.dispatch(
+            x=zero_recv_x,
+            handle=handle,
+            config=config,
+        )
+        assert torch.equal(cached_recv_x, recv_x)
+
+        combined_x, combined_topk_weights, combine_event = buffer.combine(
+            x=recv_x,
+            handle=handle,
+            topk_weights=recv_topk_weights,
+            config=config,
+        )
+
+        routed_rank_count = zero_recv_is_token_in_rank.sum(dim=1).unsqueeze(1)
+        check_x = combined_x.float() / routed_rank_count
+        assert calc_diff(check_x, zero_recv_x) < 5e-6
+
+        # Dispatch masks non-local expert weights to 0 on each rank, so combine
+        # reconstructs the original top-k weights by summing disjoint
+        # per-rank contributions rather than averaging duplicated payloads.
+        check_topk_weights = combined_topk_weights
+        assert calc_diff(check_topk_weights, zero_recv_topk_weights) < 1e-9
+
+        if local_rank == 0:
+            print(" passed", flush=True)
 
     for previous_mode in (False, True):
         for async_mode in (False, True):
@@ -304,6 +451,8 @@ def test_main(
                         print(" passed", flush=True)
     if local_rank == 0:
         print("", flush=True)
+
+    run_zero_recv_rank_test()
 
     # Tune dispatch performance
     best_dispatch_results = None

--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -729,7 +729,7 @@ class Buffer {
     EP_HOST_ASSERT(channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(recv_x_ptr != 0 && recv_channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(recv_src_idx_ptr != 0 && send_head_ptr != 0);
-    EP_HOST_ASSERT(num_tokens > 0 && hidden > 0 && num_recv_tokens > 0);
+    EP_HOST_ASSERT(num_tokens > 0 && hidden > 0 && num_recv_tokens >= 0);
     EP_HOST_ASSERT((hidden * x_element_size) % static_cast<int>(sizeof(int4)) ==
                    0);
 

--- a/thirdparty/DeepEP/csrc/deep_ep.cpp
+++ b/thirdparty/DeepEP/csrc/deep_ep.cpp
@@ -468,9 +468,11 @@ Buffer::intranode_dispatch(const torch::Tensor& x, const std::optional<torch::Te
         }
     }
 
-    // Allocate new tensors
-    auto recv_x = torch::empty({num_recv_tokens, hidden}, x.options());
-    auto recv_src_idx = torch::empty({num_recv_tokens}, dtype(torch::kInt32).device(torch::kCUDA));
+    // Allocate at least 1 row so data_ptr() remains valid even when the logical
+    // receive count is 0.
+    auto alloc_recv_tokens = std::max(num_recv_tokens, 1);
+    auto recv_x = torch::empty({alloc_recv_tokens, hidden}, x.options());
+    auto recv_src_idx = torch::empty({alloc_recv_tokens}, dtype(torch::kInt32).device(torch::kCUDA));
     auto recv_topk_idx = std::optional<torch::Tensor>(), recv_topk_weights = std::optional<torch::Tensor>(), recv_x_scales = std::optional<torch::Tensor>();
     auto recv_channel_prefix_matrix = torch::empty({num_ranks, num_channels}, dtype(torch::kInt32).device(torch::kCUDA));
     auto send_head = torch::empty({num_tokens, num_ranks}, dtype(torch::kInt32).device(torch::kCUDA));
@@ -480,15 +482,15 @@ Buffer::intranode_dispatch(const torch::Tensor& x, const std::optional<torch::Te
     float* recv_topk_weights_ptr = nullptr;
     float* recv_x_scales_ptr = nullptr;
     if (topk_idx.has_value()) {
-        recv_topk_idx = torch::empty({num_recv_tokens, num_topk}, topk_idx->options());
-        recv_topk_weights = torch::empty({num_recv_tokens, num_topk}, topk_weights->options());
+        recv_topk_idx = torch::empty({alloc_recv_tokens, num_topk}, topk_idx->options());
+        recv_topk_weights = torch::empty({alloc_recv_tokens, num_topk}, topk_weights->options());
         recv_topk_idx_ptr = recv_topk_idx->data_ptr<int64_t>();
         recv_topk_weights_ptr = recv_topk_weights->data_ptr<float>();
     }
     if (x_scales.has_value()) {
         recv_x_scales = x_scales->dim() == 1 ?
-                        torch::empty({num_recv_tokens}, x_scales->options()) :
-                        torch::empty({num_recv_tokens, num_scales}, x_scales->options());
+                        torch::empty({alloc_recv_tokens}, x_scales->options()) :
+                        torch::empty({alloc_recv_tokens, num_scales}, x_scales->options());
         recv_x_scales_ptr = static_cast<float*>(recv_x_scales->data_ptr());
     }
 
@@ -534,6 +536,16 @@ Buffer::intranode_dispatch(const torch::Tensor& x, const std::optional<torch::Te
     // Switch back compute stream
     if (allocate_on_comm_stream)
         at::cuda::setCurrentCUDAStream(compute_stream);
+
+    // Slice payload tensors back to the logical receive count.
+    recv_x = recv_x.slice(0, 0, num_recv_tokens);
+    recv_src_idx = recv_src_idx.slice(0, 0, num_recv_tokens);
+    if (recv_topk_idx.has_value())
+        recv_topk_idx = recv_topk_idx->slice(0, 0, num_recv_tokens);
+    if (recv_topk_weights.has_value())
+        recv_topk_weights = recv_topk_weights->slice(0, 0, num_recv_tokens);
+    if (recv_x_scales.has_value())
+        recv_x_scales = recv_x_scales->slice(0, 0, num_recv_tokens);
 
     // Return values
     return {recv_x, recv_x_scales, recv_topk_idx, recv_topk_weights, num_recv_tokens_per_expert_list, rank_prefix_matrix, channel_prefix_matrix, recv_channel_prefix_matrix, recv_src_idx, send_head, event};
@@ -581,13 +593,24 @@ Buffer::intranode_combine(const torch::Tensor& x, const std::optional<torch::Ten
     auto recv_topk_weights = std::optional<torch::Tensor>();
     float* topk_weights_ptr = nullptr;
     float* recv_topk_weights_ptr = nullptr;
+    auto num_x_rows = num_tokens;
+    auto x_kernel = x;
+    auto src_idx_kernel = src_idx;
+    if (num_x_rows == 0) {
+        x_kernel = torch::empty({1, hidden}, x.options());
+        src_idx_kernel = torch::empty({1}, src_idx.options());
+    }
+    auto topk_weights_kernel = topk_weights;
     if (topk_weights.has_value()) {
         EP_HOST_ASSERT(topk_weights->dim() == 2 and topk_weights->is_contiguous());
         EP_HOST_ASSERT(topk_weights->size(0) == num_tokens);
         EP_HOST_ASSERT(topk_weights->scalar_type() == torch::kFloat32);
         num_topk = static_cast<int>(topk_weights->size(1));
-        topk_weights_ptr = topk_weights->data_ptr<float>();
-        recv_topk_weights = torch::empty({num_recv_tokens, num_topk}, topk_weights->options());
+        if (num_x_rows == 0) {
+            topk_weights_kernel = torch::empty({1, num_topk}, topk_weights->options());
+        }
+        topk_weights_ptr = topk_weights_kernel->data_ptr<float>();
+        recv_topk_weights = torch::empty({std::max(num_recv_tokens, 1), num_topk}, topk_weights->options());
         recv_topk_weights_ptr = recv_topk_weights->data_ptr<float>();
     }
 
@@ -610,7 +633,7 @@ Buffer::intranode_combine(const torch::Tensor& x, const std::optional<torch::Ten
     }
 
     // Combine data
-    auto recv_x = torch::empty({num_recv_tokens, hidden}, x.options());
+    auto recv_x = torch::empty({std::max(num_recv_tokens, 1), hidden}, x.options());
     EP_HOST_ASSERT(num_channels * num_ranks * sizeof(int) * 2 +                                                      // Queue head and tail
                    num_channels * num_ranks * config.num_max_nvl_chunked_recv_tokens * hidden * x.element_size() +    // Data buffer
                    num_channels * num_ranks * config.num_max_nvl_chunked_recv_tokens * sizeof(int) +                  // Source index buffer
@@ -618,9 +641,9 @@ Buffer::intranode_combine(const torch::Tensor& x, const std::optional<torch::Ten
                    <= num_nvl_bytes);
     intranode::combine(at::cuda::ScalarTypeToCudaDataType(x.scalar_type()),
                        recv_x.data_ptr(), recv_topk_weights_ptr,
-                       x.data_ptr(), topk_weights_ptr, bias_ptrs[0], bias_ptrs[1],
-                       src_idx.data_ptr<int>(), rank_prefix_matrix.data_ptr<int>(), channel_prefix_matrix.data_ptr<int>(),
-                       send_head.data_ptr<int>(), num_tokens, num_recv_tokens, hidden, num_topk,
+                       x_kernel.data_ptr(), topk_weights_ptr, bias_ptrs[0], bias_ptrs[1],
+                       src_idx_kernel.data_ptr<int>(), rank_prefix_matrix.data_ptr<int>(), channel_prefix_matrix.data_ptr<int>(),
+                       send_head.data_ptr<int>(), num_x_rows, num_recv_tokens, hidden, num_topk,
                        buffer_ptrs_gpu, rank, num_ranks,
                        comm_stream, config.num_sms,
                        config.num_max_nvl_chunked_send_tokens, config.num_max_nvl_chunked_recv_tokens);
@@ -646,6 +669,10 @@ Buffer::intranode_combine(const torch::Tensor& x, const std::optional<torch::Ten
     // Switch back compute stream
     if (allocate_on_comm_stream)
         at::cuda::setCurrentCUDAStream(compute_stream);
+
+    recv_x = recv_x.slice(0, 0, num_recv_tokens);
+    if (recv_topk_weights.has_value())
+        recv_topk_weights = recv_topk_weights->slice(0, 0, num_recv_tokens);
 
     return {recv_x, recv_topk_weights, event};
 }

--- a/thirdparty/DeepEP/deep_ep/buffer.py
+++ b/thirdparty/DeepEP/deep_ep/buffer.py
@@ -351,8 +351,7 @@ class Buffer:
         x, x_scales = x if isinstance(x, tuple) else (x, None)
         if handle is not None:
             assert topk_idx is None and topk_weights is None
-            rank_prefix_matrix, channel_prefix_matrix, recv_channel_prefix_matrix, recv_src_idx, is_token_in_rank, send_head = handle
-            num_recv_tokens = recv_src_idx.size(0)
+            rank_prefix_matrix, channel_prefix_matrix, recv_channel_prefix_matrix, num_recv_tokens, recv_src_idx, is_token_in_rank, send_head = handle
             recv_x, recv_x_scales, _, _, _, _, _, _, _, _, event = self.runtime.intranode_dispatch(
                 x, x_scales, None, None,
                 None, is_token_in_rank, None, num_recv_tokens, rank_prefix_matrix, channel_prefix_matrix,
@@ -366,7 +365,7 @@ class Buffer:
                                                 num_tokens_per_rank, is_token_in_rank, num_tokens_per_expert, 0, None, None,
                                                 expert_alignment, num_worst_tokens, config,
                                                 getattr(previous_event, 'event', None), async_finish, allocate_on_comm_stream)
-            handle = (rank_prefix_matrix, channel_prefix_matrix, recv_channel_prefix_matrix, recv_src_idx, is_token_in_rank, send_head)
+            handle = (rank_prefix_matrix, channel_prefix_matrix, recv_channel_prefix_matrix, recv_src_idx.size(0), recv_src_idx, is_token_in_rank, send_head)
             return (recv_x, recv_x_scales) if x_scales is not None else recv_x, recv_topk_idx, recv_topk_weights, num_recv_tokens_per_expert_list, handle, EventOverlap(event)
 
     # noinspection PyTypeChecker
@@ -406,7 +405,7 @@ class Buffer:
             return self.internode_combine(x, handle, topk_weights, bias, config, previous_event, async_finish, allocate_on_comm_stream)
 
         # NOTES: the second `_` is for the sending side, so we should use the third one
-        rank_prefix_matrix, _, channel_prefix_matrix, src_idx, is_recv_token_in_rank, send_head = handle
+        rank_prefix_matrix, _, channel_prefix_matrix, _, src_idx, is_recv_token_in_rank, send_head = handle
         bias_0, bias_1 = Buffer._unpack_bias(bias)
 
         # Launch the kernel
@@ -440,9 +439,7 @@ class Buffer:
             is_token_in_rank, \
                 rdma_channel_prefix_matrix, gbl_channel_prefix_matrix, \
                 recv_rdma_channel_prefix_matrix, recv_rdma_rank_prefix_sum, recv_gbl_channel_prefix_matrix, recv_gbl_rank_prefix_sum, \
-                recv_src_meta, send_rdma_head, send_nvl_head = handle
-            num_recv_tokens = recv_src_meta.size(0)
-            num_rdma_recv_tokens = send_nvl_head.size(0)
+                num_recv_tokens, num_rdma_recv_tokens, recv_src_meta, send_rdma_head, send_nvl_head = handle
             recv_x, recv_x_scales, _, _, _, _, _, _, _, _, _, _, _, _, event = self.runtime.internode_dispatch(
                 x, x_scales, topk_idx, topk_weights,
                 None, None, is_token_in_rank, None,
@@ -464,7 +461,7 @@ class Buffer:
             handle = (is_token_in_rank,
                       rdma_channel_prefix_matrix, gbl_channel_prefix_matrix,
                       recv_rdma_channel_prefix_matrix, recv_rdma_rank_prefix_sum, recv_gbl_channel_prefix_matrix, recv_gbl_rank_prefix_sum,
-                      recv_src_meta, send_rdma_head, send_nvl_head)
+                      recv_src_meta.size(0), send_nvl_head.size(0), recv_src_meta, send_rdma_head, send_nvl_head)
             return (recv_x, recv_x_scales) if x_scales is not None else recv_x, recv_topk_idx, recv_topk_weights, num_recv_tokens_per_expert_list, handle, EventOverlap(event)
 
     # noinspection PyTypeChecker
@@ -485,7 +482,7 @@ class Buffer:
         is_combined_token_in_rank, \
             _, _, \
             rdma_channel_prefix_matrix, rdma_rank_prefix_sum, gbl_channel_prefix_matrix, gbl_rank_prefix_sum, \
-            src_meta, send_rdma_head, send_nvl_head = handle
+            _, _, src_meta, send_rdma_head, send_nvl_head = handle
         bias_0, bias_1 = Buffer._unpack_bias(bias)
 
         # Launch the kernel


### PR DESCRIPTION
## Description
Fix intranode dispatch/combine for cases where a rank logically receives 0 tokens.

This change keeps kernel pointer arguments valid in zero-recv cases by allocating a minimal backing buffer and then slicing returned tensors back to the logical size. It also adds a regression test that forces one rank to receive no tokens and verifies dispatch, cached dispatch, and combine still behave correctly.

Fixes # N/A

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 

- Added a regression test in `ep/bench/test_intranode.py` for a zero-recv rank path.
- Ran the intranode test on 8xH100 and it worked.
- Also exercised this in an external MoE model with imbalanced routing, including cases where some ranks received 0 tokens, and it worked there as well.

- [ ] Unit tests
- [x] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [x] I have added tests.