### PR TITLE
[UK] oob refactor

### DIFF
--- a/experimental/ukernel/py/bench_p2p.py
+++ b/experimental/ukernel/py/bench_p2p.py
@@ -157,27 +157,29 @@ def _recv_bytes(src: int) -> bytes:
     return bytes(t.tolist())
 
 
-def _exchange_uccl_metadata(local_metadata: bytes, local_gpu_idx: int, rank: int):
+def _exchange_uccl_metadata(local_metadata: bytes, local_gpu_bdf: str, rank: int):
+    local_bdf_bytes = local_gpu_bdf.encode("utf-8")
     if rank == 0:
         _send_bytes(local_metadata, dst=1)
-        _send_i64(local_gpu_idx, dst=1)
+        _send_bytes(local_bdf_bytes, dst=1)
         remote_metadata = _recv_bytes(src=1)
-        remote_gpu_idx = _recv_i64(src=1)
+        remote_gpu_bdf = _recv_bytes(src=1).decode("utf-8")
     else:
         remote_metadata = _recv_bytes(src=0)
-        remote_gpu_idx = _recv_i64(src=0)
+        remote_gpu_bdf = _recv_bytes(src=0).decode("utf-8")
         _send_bytes(local_metadata, dst=0)
-        _send_i64(local_gpu_idx, dst=0)
-    return remote_metadata, remote_gpu_idx
+        _send_bytes(local_bdf_bytes, dst=0)
+    return remote_metadata, remote_gpu_bdf
 
 
-def _exchange_local_gpu_idx(local_gpu_idx: int, rank: int) -> int:
+def _exchange_local_gpu_bdf(local_gpu_bdf: str, rank: int) -> str:
+    local_bdf_bytes = local_gpu_bdf.encode("utf-8")
     if rank == 0:
-        _send_i64(local_gpu_idx, dst=1)
-        return _recv_i64(src=1)
-    remote_gpu_idx = _recv_i64(src=0)
-    _send_i64(local_gpu_idx, dst=0)
-    return remote_gpu_idx
+        _send_bytes(local_bdf_bytes, dst=1)
+        return _recv_bytes(src=1).decode("utf-8")
+    remote_gpu_bdf = _recv_bytes(src=0).decode("utf-8")
+    _send_bytes(local_bdf_bytes, dst=0)
+    return remote_gpu_bdf
 
 
 def _exchange_peer_i64(local_value: int, rank: int) -> int:
@@ -336,6 +338,9 @@ def main() -> None:
         uc_send_conn_id = None
         uc_recv_conn_id = None
         uc_ep = _create_uccl_endpoint(local_rank, rank)
+        local_meta = bytes(uc_ep.get_metadata())
+        _, _, local_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(local_meta)
+        local_gpu_bdf = str(local_gpu_bdf)
         if uc_mode == "ipc":
             required_ipc_api = ("connect_local", "accept_local", "send_ipc", "recv_ipc")
             missing = [name for name in required_ipc_api if not hasattr(uc_ep, name)]
@@ -343,31 +348,36 @@ def main() -> None:
                 raise RuntimeError(
                     f"[uccl] ipc mode requested but endpoint lacks API: {missing}"
                 )
-            remote_gpu_idx = _exchange_local_gpu_idx(local_rank, rank)
+            remote_gpu_bdf = _exchange_local_gpu_bdf(local_gpu_bdf, rank)
             if rank == 0:
-                ok, uc_send_conn_id = uc_ep.connect_local(remote_gpu_idx)
+                ok, uc_send_conn_id = uc_ep.connect_local(remote_gpu_bdf)
                 assert ok, "[uccl] connect_local(0->1) failed"
                 ok, _, uc_recv_conn_id = uc_ep.accept_local()
                 assert ok, "[uccl] accept_local(1->0) failed"
             else:
                 ok, _, uc_recv_conn_id = uc_ep.accept_local()
                 assert ok, "[uccl] accept_local(0->1) failed"
-                ok, uc_send_conn_id = uc_ep.connect_local(remote_gpu_idx)
+                ok, uc_send_conn_id = uc_ep.connect_local(remote_gpu_bdf)
                 assert ok, "[uccl] connect_local(1->0) failed"
         else:
-            local_meta = bytes(uc_ep.get_metadata())
-            remote_meta, remote_gpu_idx = _exchange_uccl_metadata(local_meta, local_rank, rank)
+            remote_meta, remote_gpu_bdf = _exchange_uccl_metadata(
+                local_meta, local_gpu_bdf, rank
+            )
+            ip, port, meta_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(remote_meta)
+            target_gpu_bdf = str(meta_gpu_bdf) if meta_gpu_bdf else remote_gpu_bdf
             if rank == 0:
-                ip, port, _ = uccl_p2p.Endpoint.parse_metadata(remote_meta)
-                ok, uc_send_conn_id = uc_ep.connect(ip, remote_gpu_idx, remote_port=port)
+                ok, uc_send_conn_id = uc_ep.connect(
+                    ip, target_gpu_bdf, remote_port=port
+                )
                 assert ok, "[uccl] connect(0->1) failed"
                 ok, _, _, uc_recv_conn_id = uc_ep.accept()
                 assert ok, "[uccl] accept(1->0) failed"
             else:
                 ok, _, _, uc_recv_conn_id = uc_ep.accept()
                 assert ok, "[uccl] accept(0->1) failed"
-                ip, port, _ = uccl_p2p.Endpoint.parse_metadata(remote_meta)
-                ok, uc_send_conn_id = uc_ep.connect(ip, remote_gpu_idx, remote_port=port)
+                ok, uc_send_conn_id = uc_ep.connect(
+                    ip, target_gpu_bdf, remote_port=port
+                )
                 assert ok, "[uccl] connect(1->0) failed"
         dist.barrier()
         if rank == 0:

--- a/experimental/ukernel/src/ccl/test/integration/run_ccl_multiprocess_suite.sh
+++ b/experimental/ukernel/src/ccl/test/integration/run_ccl_multiprocess_suite.sh
@@ -3,23 +3,19 @@ set -euo pipefail
 
 BIN="${1:-./test_multiprocess_collective}"
 
-# Edit these values locally when you want to change the test shape.
-NPROC_PER_NODE=4
+# Minimal functional config for local correctness checks.
 NPROC_PER_NODE=3
 NNODES=1
 NODE_RANK=0
 MASTER_ADDR=127.0.0.1
 TORCHRUN_MASTER_PORT=29500
 EXCHANGER_PORT_BASE=29600
-GPU_IDS=0,1,2,3
 GPU_IDS=0,6,7
 
-# Use auto by default so same-node runs exercise the IPC path directly.
 TRANSPORT=auto
-BASE_BYTES_PER_RANK=$((1 * 1024 * 1024))
-ALIGNMENT_BYTES=$((NPROC_PER_NODE * 4))
-BYTES_PER_RANK=$((BASE_BYTES_PER_RANK - (BASE_BYTES_PER_RANK % ALIGNMENT_BYTES)))
 TILE_BYTES=$((64 * 1024))
+# 15 * 64KB = 983040, divisible by tile_bytes and by (3 * sizeof(float)=12).
+BYTES_PER_RANK=$((15 * TILE_BYTES))
 NUM_FLOWS=2
 UHM_HOST_ID_OVERRIDE=${UHM_HOST_ID_OVERRIDE:-ccl-$(date +%s)-$$}
 
@@ -32,13 +28,20 @@ run_case() {
   local collective="$1"
   local exchanger_port="$2"
   local host_id_override="${UHM_HOST_ID_OVERRIDE}-${collective}"
+  local oob_namespace="ccl-oob-${host_id_override}-${exchanger_port}"
+
+  cleanup() {
+    cleanup_ipc_shm "${host_id_override}" || true
+  }
+  trap cleanup EXIT
 
   echo "[ccl suite] torchrun collective=${collective} nproc_per_node=${NPROC_PER_NODE} bytes_per_rank=${BYTES_PER_RANK} tile_bytes=${TILE_BYTES} num_flows=${NUM_FLOWS} transport=${TRANSPORT} torchrun_port=${TORCHRUN_MASTER_PORT} exchanger_port=${exchanger_port}"
 
   cleanup_ipc_shm "${host_id_override}"
-
   CUDA_VISIBLE_DEVICES="${GPU_IDS}" \
     UHM_HOST_ID_OVERRIDE="${host_id_override}" \
+    UHM_OOB_NAMESPACE="${oob_namespace}" \
+    UHM_OOB_CLEAN_START=0 \
     torchrun \
       --no-python \
       --nproc-per-node "${NPROC_PER_NODE}" \
@@ -55,7 +58,8 @@ run_case() {
       --exchanger-ip "${MASTER_ADDR}" \
       --exchanger-port "${exchanger_port}"
 
-  cleanup_ipc_shm "${host_id_override}"
+  trap - EXIT
+  cleanup
 }
 
 run_case allreduce "${EXCHANGER_PORT_BASE}"

--- a/experimental/ukernel/src/ccl/test/integration/run_transport_backend_suite.sh
+++ b/experimental/ukernel/src/ccl/test/integration/run_transport_backend_suite.sh
@@ -13,18 +13,26 @@ GPU_IDS=0,1
 TRANSPORT=auto
 BYTES=$((64 * 1024))
 UHM_HOST_ID_OVERRIDE=${UHM_HOST_ID_OVERRIDE:-ccl-transport-$(date +%s)-$$}
+UHM_OOB_NAMESPACE=${UHM_OOB_NAMESPACE:-ccl-transport-oob-${UHM_HOST_ID_OVERRIDE}-${EXCHANGER_PORT}}
 
 cleanup_ipc_shm() {
   local host_id_override="$1"
   rm -f /dev/shm/uk_t_oob_"${host_id_override}"_l*
 }
 
-echo "[transport backend suite] torchrun nproc_per_node=${NPROC_PER_NODE} bytes=${BYTES} transport=${TRANSPORT} torchrun_port=${TORCHRUN_MASTER_PORT} exchanger_port=${EXCHANGER_PORT}"
+cleanup() {
+  cleanup_ipc_shm "${UHM_HOST_ID_OVERRIDE}" || true
+}
+trap cleanup EXIT
 
 cleanup_ipc_shm "${UHM_HOST_ID_OVERRIDE}"
 
+echo "[transport backend suite] torchrun nproc_per_node=${NPROC_PER_NODE} bytes=${BYTES} transport=${TRANSPORT} torchrun_port=${TORCHRUN_MASTER_PORT} exchanger_port=${EXCHANGER_PORT}"
+
 CUDA_VISIBLE_DEVICES="${GPU_IDS}" \
   UHM_HOST_ID_OVERRIDE="${UHM_HOST_ID_OVERRIDE}" \
+  UHM_OOB_NAMESPACE="${UHM_OOB_NAMESPACE}" \
+  UHM_OOB_CLEAN_START=0 \
   torchrun \
     --no-python \
     --nproc-per-node "${NPROC_PER_NODE}" \
@@ -37,7 +45,5 @@ CUDA_VISIBLE_DEVICES="${GPU_IDS}" \
     --bytes "${BYTES}" \
     --exchanger-ip "${MASTER_ADDR}" \
     --exchanger-port "${EXCHANGER_PORT}"
-
-cleanup_ipc_shm "${UHM_HOST_ID_OVERRIDE}"
 
 echo "[transport backend suite] transport backend checks passed"

--- a/experimental/ukernel/src/ccl/test/integration/test_transport_backend.cc
+++ b/experimental/ukernel/src/ccl/test/integration/test_transport_backend.cc
@@ -97,7 +97,7 @@ int create_tcp_server(int port) {
   addr.sin_addr.s_addr = htonl(INADDR_ANY);
   addr.sin_port = htons(static_cast<uint16_t>(port));
   require(::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0,
-          "failed to bind barrier socket");
+          "failed to bind barrier socket on port " + std::to_string(port));
   require(::listen(fd, 16) == 0, "failed to listen on barrier socket");
   return fd;
 }
@@ -118,9 +118,10 @@ int connect_tcp_client(std::string const& ip, int port,
     }
     ::close(fd);
     if (std::chrono::steady_clock::now() >= deadline) {
-      fail("failed to connect barrier client");
+      fail("timed out connecting barrier client to " + ip + ":" +
+           std::to_string(port));
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
 }
 
@@ -164,7 +165,7 @@ void socket_barrier(std::string const& ip, int port, int rank, int nranks) {
     }
     ::close(server);
   } else {
-    int fd = connect_tcp_client(ip, port, std::chrono::seconds(5));
+    int fd = connect_tcp_client(ip, port, std::chrono::seconds(30));
     write_exact(fd, &kToken, sizeof(kToken));
     uint64_t token = 0;
     read_exact(fd, &token, sizeof(token));

--- a/experimental/ukernel/src/transport/README.md
+++ b/experimental/ukernel/src/transport/README.md
@@ -16,6 +16,47 @@ Run unit tests:
 make test-unit
 ```
 
+### OOB Testing
+
+Build the unit test binary:
+
+```bash
+cd experimental/ukernel/src/transport
+make -j$(nproc) test-unit
+```
+
+Run OOB serializer round-trip tests (`serialize_object` / `deserialize_object`):
+
+```bash
+./test_transport_unit oob-serde
+```
+
+Run `ShmExchanger` tests (`put/get/wait`, relay-state helpers):
+
+```bash
+./test_transport_unit oob-shm
+```
+
+Run `SocketExchanger` and `HierarchicalExchanger` tests:
+
+```bash
+./test_transport_unit oob-socket
+./test_transport_unit oob-socket-meta --world-size 4
+```
+
+Recommended OOB-only check on a server:
+
+```bash
+./test_transport_unit oob-serde && \
+./test_transport_unit oob-shm && \
+./test_transport_unit oob-socket && \
+./test_transport_unit oob-socket-meta --world-size 4
+```
+
+If you want only socket-layer behavior in manual debugging, use different
+`UHM_OOB_NAMESPACE` values between different node groups so same-host shared
+memory does not mask cross-node relay behavior.
+
 Optional manual SHM OOB case:
 
 ```bash
@@ -84,6 +125,7 @@ TRANSPORT_RUN_UCCL=1 make suite
 ## Notes
 
 - `test-unit` covers memory registry, socket OOB, peer session, host bounce pool, and TCP adapter.
+- OOB unit coverage includes `ShmExchanger`, `SocketExchanger`, and `HierarchicalExchanger`.
 - `test-integration` is a lightweight smoke target.
 - Multi-process communicator checks are manual by default.
 - Use `test_transport_integration communicator --role=server|client --case=exchange ...` for normal two-process transport bring-up.

--- a/experimental/ukernel/src/transport/adapter/ipc_adapter.cc
+++ b/experimental/ukernel/src/transport/adapter/ipc_adapter.cc
@@ -110,6 +110,7 @@ IpcAdapter::IpcAdapter(Communicator* comm, std::string ring_namespace,
     : ring_namespace_(ring_namespace),
       next_match_seq_per_peer_(comm->world_size(),
                                std::array<uint64_t, 2>{1, 1}),
+      peer_connect_mu_(comm->world_size()),
       shm_control_(std::make_shared<ShmRingExchanger>(
           comm->rank(), comm->world_size(), std::move(ring_namespace),
           self_local_id)),
@@ -275,20 +276,25 @@ bool IpcAdapter::accept_from(int rank) {
 
 bool IpcAdapter::ensure_peer(PeerConnectSpec const& spec) {
   if (spec.peer_rank < 0) return false;
-  if (has_peer(spec.peer_rank)) return true;
   if (!(std::holds_alternative<IpcPeerConnectSpec>(spec.detail) ||
         std::holds_alternative<std::monostate>(spec.detail))) {
     return false;
   }
   int peer_rank = spec.peer_rank;
+  if (peer_rank >= static_cast<int>(peer_connect_mu_.size())) return false;
+  std::lock_guard<std::mutex> peer_lk(
+      peer_connect_mu_[static_cast<size_t>(peer_rank)]);
+  if (has_peer(peer_rank)) return true;
 
   // Lower rank creates the done_seq SHM *before* the connection handshake so
   // the higher rank can open it by name right after the handshake completes.
   bool is_lower = (comm_->rank() < peer_rank);
   if (is_lower) setup_done_channel(peer_rank);
 
-  bool ok = (spec.type == PeerConnectType::Connect) ? connect_to(peer_rank)
-                                                    : accept_from(peer_rank);
+  // Keep peer handshake role deterministic to avoid connect/accept races when
+  // multiple request paths concurrently establish the same peer.
+  bool const use_connect = is_lower;
+  bool ok = use_connect ? connect_to(peer_rank) : accept_from(peer_rank);
   if (!ok) return false;
 
   if (!is_lower) {

--- a/experimental/ukernel/src/transport/adapter/ipc_adapter.h
+++ b/experimental/ukernel/src/transport/adapter/ipc_adapter.h
@@ -182,6 +182,7 @@ class IpcAdapter final : public TransportAdapter {
 
   std::string ring_namespace_;
   std::mutex match_seq_mu_;
+  std::vector<std::mutex> peer_connect_mu_;
   // Two directed-edge counters per peer:
   // dir=0 -> low-rank to high-rank, dir=1 -> high-rank to low-rank.
   std::vector<std::array<uint64_t, 2>> next_match_seq_per_peer_;

--- a/experimental/ukernel/src/transport/adapter/ipc_adapter.h
+++ b/experimental/ukernel/src/transport/adapter/ipc_adapter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../oob/oob.h"
+#include "../oob/shmring_exchanger.h"
 #include "../util/jring.h"
 #include "config.h"
 #include "gpu_rt.h"

--- a/experimental/ukernel/src/transport/adapter/tcp_adapter.cc
+++ b/experimental/ukernel/src/transport/adapter/tcp_adapter.cc
@@ -254,6 +254,7 @@ unsigned TcpTransportAdapter::send_async(int peer_rank, void* local_ptr,
                                          BounceBufferProvider bounce_provider) {
   (void)local_mr_id;
   (void)remote_hint;
+  if (!has_peer(peer_rank)) return 0;
 
   void* send_ptr = local_ptr;
   if (bounce_provider) {
@@ -283,6 +284,7 @@ unsigned TcpTransportAdapter::recv_async(int peer_rank, void* local_ptr,
                                          size_t len, uint64_t local_mr_id,
                                          BounceBufferProvider bounce_provider) {
   (void)local_mr_id;
+  if (!has_peer(peer_rank)) return 0;
   void* recv_ptr = local_ptr;
   if (bounce_provider) {
     BounceBufferInfo info = bounce_provider(len);

--- a/experimental/ukernel/src/transport/communicator.cc
+++ b/experimental/ukernel/src/transport/communicator.cc
@@ -914,6 +914,7 @@ bool Communicator::accept(int rank) {
     if (!ipc_adapter_->ensure_peer(spec)) {
       std::cerr << "[ERROR] Communicator " << global_rank_
                 << " IPC accept_from failed from rank " << rank << std::endl;
+      ipc_adapter_->close_peer(rank);
       return false;
     }
     mark_peer_path_ready(rank, PeerTransportKind::Ipc);

--- a/experimental/ukernel/src/transport/communicator.cc
+++ b/experimental/ukernel/src/transport/communicator.cc
@@ -329,9 +329,9 @@ void Communicator::exchange_peer_metas() {
   for (int i = 0; i < world_size_; i++) {
     if (i == global_rank_) continue;
     std::string key = "meta:" + std::to_string(i);
-    if (exchanger_client_->wait(key, remote, make_wait_options(
-                                                 bootstrap_timeout_ms(),
-                                                 kBootstrapPollDelayMs))) {
+    if (exchanger_client_->wait(
+            key, remote,
+            make_wait_options(bootstrap_timeout_ms(), kBootstrapPollDelayMs))) {
       std::lock_guard<std::mutex> lk(peer_mu_);
       auto& peer = peer_states_.at(static_cast<size_t>(i));
       peer.meta = remote;
@@ -1755,8 +1755,8 @@ bool Communicator::fetch_ipc_buffer(int remote_rank, uint32_t ipc_id,
                                       /*eager_open_direct_ptr=*/true);
     }
   }
-  if (!exchanger_client_->get(
-          ipc_buffer_key(remote_rank, global_rank_, ipc_id), info)) {
+  if (!exchanger_client_->get(ipc_buffer_key(remote_rank, global_rank_, ipc_id),
+                              info)) {
     return false;
   }
   if (info.valid && expected_binding_version != 0 &&

--- a/experimental/ukernel/src/transport/communicator.cc
+++ b/experimental/ukernel/src/transport/communicator.cc
@@ -1790,10 +1790,22 @@ void Communicator::try_open_remote_ipc_buffer(int remote_rank,
       [&]() { GPU_RT_CHECK(gpuSetDevice(original_device)); });
   GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
 
+  bool can_use_direct_peer = (state.device_idx == local_gpu_idx_);
+  if (!can_use_direct_peer && state.device_idx >= 0) {
+    int can_access_peer = 0;
+    GPU_RT_CHECK(gpuDeviceCanAccessPeer(&can_access_peer, local_gpu_idx_,
+                                        state.device_idx));
+    can_use_direct_peer = (can_access_peer != 0);
+  }
+  if (!can_use_direct_peer) return;
+
   void* direct_ptr = nullptr;
   gpuError_t open_err = gpuIpcOpenMemHandle(&direct_ptr, state.handle,
                                             gpuIpcMemLazyEnablePeerAccess);
-  if (open_err != gpuSuccess || direct_ptr == nullptr) return;
+  if (open_err != gpuSuccess || direct_ptr == nullptr) {
+    (void)gpuGetLastError();
+    return;
+  }
 
   IPCItem opened = state;
   opened.direct_ptr = direct_ptr;
@@ -1833,12 +1845,22 @@ bool Communicator::resolve_ipc_buffer_pointer(int remote_rank, uint32_t ipc_id,
       [&]() { GPU_RT_CHECK(gpuSetDevice(original_device)); });
   GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
 
+  bool can_use_direct_peer = (state.device_idx == local_gpu_idx_);
+  if (!can_use_direct_peer && state.device_idx >= 0) {
+    int can_access_peer = 0;
+    GPU_RT_CHECK(gpuDeviceCanAccessPeer(&can_access_peer, local_gpu_idx_,
+                                        state.device_idx));
+    can_use_direct_peer = (can_access_peer != 0);
+  }
+  if (!can_use_direct_peer) return false;
+
   if (state.direct_ptr == nullptr) {
     gpuError_t open_err = gpuIpcOpenMemHandle(&state.direct_ptr, state.handle,
                                               gpuIpcMemLazyEnablePeerAccess);
     if (open_err != gpuSuccess) {
       // Treat IPC open failure as recoverable here so upper layers can
       // fallback to host-bounce relay instead of aborting.
+      (void)gpuGetLastError();
       return false;
     }
     state.ipc_id = ipc_id;

--- a/experimental/ukernel/src/transport/communicator.cc
+++ b/experimental/ukernel/src/transport/communicator.cc
@@ -9,6 +9,7 @@
 #include <netinet/in.h>
 #include <algorithm>
 #include <array>
+#include <cerrno>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -55,6 +56,15 @@ std::string get_local_ip() {
   char buf[INET_ADDRSTRLEN];
   ::inet_ntop(AF_INET, &local.sin_addr, buf, sizeof(buf));
   return buf;
+}
+
+void notify_eventfd_nonblocking(int fd) {
+  if (fd < 0) return;
+  uint64_t one = 1;
+  ssize_t rc = 0;
+  do {
+    rc = ::write(fd, &one, sizeof(one));
+  } while (rc < 0 && errno == EINTR);
 }
 
 bool has_env_value(char const* name) {
@@ -141,6 +151,21 @@ int mr_timeout_ms() {
   return get_timeout_ms("UHM_MR_TIMEOUT_MS", kDefaultMrTimeoutMs);
 }
 
+Exchanger::WaitOptions make_wait_options(int timeout_ms, int delay_ms) {
+  return Exchanger::WaitOptions{timeout_to_retries(timeout_ms, delay_ms),
+                                delay_ms};
+}
+
+Exchanger::WaitOptions make_wait_options_until(
+    std::chrono::steady_clock::time_point deadline, int delay_ms) {
+  auto const now = std::chrono::steady_clock::now();
+  if (deadline <= now) return Exchanger::WaitOptions{0, delay_ms};
+  auto const remaining_ms = static_cast<int>(
+      std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)
+          .count());
+  return make_wait_options(remaining_ms, delay_ms);
+}
+
 std::string uccl_p2p_key(int src_rank, int dst_rank) {
   return "uccl_p2p_info_" + std::to_string(src_rank) + "_to_" +
          std::to_string(dst_rank);
@@ -163,6 +188,18 @@ std::string ipc_buffer_versioned_key(int src_rank, int dst_rank,
          std::to_string(binding_version);
 }
 
+IPCItem ipc_item_from_info(IpcBufferInfo const& info, uint32_t ipc_id) {
+  IPCItem state{};
+  state.handle = info.handle;
+  state.binding_version = info.binding_version;
+  state.base_offset = static_cast<uintptr_t>(info.base_offset);
+  state.bytes = static_cast<size_t>(info.bytes);
+  state.device_idx = info.device_idx;
+  state.valid = info.valid;
+  state.ipc_id = ipc_id;
+  return state;
+}
+
 void validate_dst_hint_for_transport(PeerTransportKind kind,
                                      std::optional<RemoteSlice> const& dst_hint,
                                      size_t src_bytes) {
@@ -180,31 +217,27 @@ void validate_dst_hint_for_transport(PeerTransportKind kind,
 }
 
 template <typename Info>
-bool publish_local_then_fetch_remote(Exchanger& exchanger,
-                                     std::string const& local_key,
-                                     Info const& local_info,
-                                     std::string const& remote_key,
-                                     Info& remote_info, int timeout_ms) {
-  if (!exchanger.publish(local_key, local_info)) return false;
-  return exchanger.wait_and_fetch(
-      remote_key, remote_info,
-      timeout_to_retries(timeout_ms, kBootstrapPollDelayMs),
-      kBootstrapPollDelayMs);
+bool publish_local_then_wait_remote(Exchanger& exchanger,
+                                    std::string const& local_key,
+                                    Info const& local_info,
+                                    std::string const& remote_key,
+                                    Info& remote_info, int timeout_ms) {
+  if (!exchanger.put(local_key, local_info)) return false;
+  return exchanger.wait(remote_key, remote_info,
+                        make_wait_options(timeout_ms, kBootstrapPollDelayMs));
 }
 
 template <typename Info>
-bool fetch_remote_then_publish_local(Exchanger& exchanger,
-                                     std::string const& remote_key,
-                                     Info& remote_info,
-                                     std::string const& local_key,
-                                     Info const& local_info, int timeout_ms) {
-  if (!exchanger.wait_and_fetch(
-          remote_key, remote_info,
-          timeout_to_retries(timeout_ms, kBootstrapPollDelayMs),
-          kBootstrapPollDelayMs)) {
+bool wait_remote_then_publish_local(Exchanger& exchanger,
+                                    std::string const& remote_key,
+                                    Info& remote_info,
+                                    std::string const& local_key,
+                                    Info const& local_info, int timeout_ms) {
+  if (!exchanger.wait(remote_key, remote_info,
+                      make_wait_options(timeout_ms, kBootstrapPollDelayMs))) {
     return false;
   }
-  return exchanger.publish(local_key, local_info);
+  return exchanger.put(local_key, local_info);
 }
 
 bool detect_local_rdma_capable() {
@@ -250,11 +283,12 @@ Communicator::Communicator(int gpu_id, int rank, int world_size,
   std::cout << "[INFO] Using socket-based bootstrap exchanger as "
             << (is_server ? "server" : "client") << " " << config_->exchanger_ip
             << std::endl;
-  exchanger_client_ = std::make_shared<SockExchanger>(
-      (global_rank_ == 0), config_->exchanger_ip, config_->exchanger_port);
+  exchanger_client_ = std::make_shared<HierarchicalExchanger>(
+      (global_rank_ == 0), config_->exchanger_ip, config_->exchanger_port,
+      /*timeout_ms=*/3000, /*max_line_bytes=*/1 * 1024 * 1024,
+      config_->local_id);
   if (!exchanger_client_->valid()) {
-    fprintf(stderr, "[ERROR] Failed to connect to Exchanger\n");
-    return;
+    throw std::runtime_error("failed to initialize hierarchical exchanger");
   }
 
   shm_manager_.emplace();
@@ -286,7 +320,7 @@ void Communicator::exchange_peer_metas() {
   }
 
   std::string meta_key = "meta:" + std::to_string(global_rank_);
-  if (!exchanger_client_->publish(meta_key, local)) {
+  if (!exchanger_client_->put(meta_key, local)) {
     fprintf(stderr, "[ERROR] Failed to publish local CommunicatorMeta \n");
   }
 
@@ -295,10 +329,9 @@ void Communicator::exchange_peer_metas() {
   for (int i = 0; i < world_size_; i++) {
     if (i == global_rank_) continue;
     std::string key = "meta:" + std::to_string(i);
-    if (exchanger_client_->wait_and_fetch(
-            key, remote,
-            timeout_to_retries(bootstrap_timeout_ms(), kBootstrapPollDelayMs),
-            kBootstrapPollDelayMs)) {
+    if (exchanger_client_->wait(key, remote, make_wait_options(
+                                                 bootstrap_timeout_ms(),
+                                                 kBootstrapPollDelayMs))) {
       std::lock_guard<std::mutex> lk(peer_mu_);
       auto& peer = peer_states_.at(static_cast<size_t>(i));
       peer.meta = remote;
@@ -324,10 +357,7 @@ Communicator::~Communicator() {
   if (progress_started_.load()) {
     progress_running_.store(false);
     progress_cv_.notify_all();
-    if (completion_event_fd_ >= 0) {
-      uint64_t one = 1;
-      (void)::write(completion_event_fd_, &one, sizeof(one));
-    }
+    notify_eventfd_nonblocking(completion_event_fd_);
     if (progress_thread_.joinable()) {
       progress_thread_.join();
     }
@@ -534,10 +564,7 @@ bool Communicator::dequeue_active_request(unsigned* out_req_id) {
 
 void Communicator::notify_request_completion() {
   completion_seq_.fetch_add(1, std::memory_order_release);
-  if (completion_event_fd_ >= 0) {
-    uint64_t one = 1;
-    (void)::write(completion_event_fd_, &one, sizeof(one));
-  }
+  notify_eventfd_nonblocking(completion_event_fd_);
 }
 
 UcclTransportAdapter& Communicator::ensure_uccl_adapter(
@@ -620,13 +647,12 @@ bool Communicator::try_fallback_tcp_connect(
                             tcp_adapter.get_listen_port());
   std::string p2p_key = tcp_p2p_key(global_rank_, rank);
   std::string peer_p2p_key = tcp_p2p_key(rank, global_rank_);
-  if (!exchanger_client_->publish(p2p_key, local_p2p_info)) return false;
+  if (!exchanger_client_->put(p2p_key, local_p2p_info)) return false;
 
   TcpP2PInfo remote_p2p_info;
-  if (!exchanger_client_->wait_and_fetch(
+  if (!exchanger_client_->wait(
           peer_p2p_key, remote_p2p_info,
-          timeout_to_retries(bootstrap_timeout_ms(), kBootstrapPollDelayMs),
-          kBootstrapPollDelayMs)) {
+          make_wait_options(bootstrap_timeout_ms(), kBootstrapPollDelayMs))) {
     return false;
   }
 
@@ -661,16 +687,15 @@ bool Communicator::try_fallback_tcp_accept(
   std::string peer_p2p_key = tcp_p2p_key(rank, global_rank_);
 
   TcpP2PInfo remote_p2p_info;
-  if (!exchanger_client_->wait_and_fetch(
+  if (!exchanger_client_->wait(
           peer_p2p_key, remote_p2p_info,
-          timeout_to_retries(bootstrap_timeout_ms(), kBootstrapPollDelayMs),
-          kBootstrapPollDelayMs)) {
+          make_wait_options(bootstrap_timeout_ms(), kBootstrapPollDelayMs))) {
     return false;
   }
 
   TcpP2PInfo local_p2p_info(tcp_adapter.get_listen_ip(),
                             tcp_adapter.get_listen_port());
-  if (!exchanger_client_->publish(p2p_key, local_p2p_info)) return false;
+  if (!exchanger_client_->put(p2p_key, local_p2p_info)) return false;
 
   PeerConnectSpec spec{};
   spec.peer_rank = rank;
@@ -737,7 +762,7 @@ bool Communicator::connect(int rank) {
       std::string p2p_key = uccl_p2p_key(global_rank_, rank);
       std::string peer_p2p_key = uccl_p2p_key(rank, global_rank_);
       UCCLP2PInfo remote_p2p_info;
-      if (!publish_local_then_fetch_remote(
+      if (!publish_local_then_wait_remote(
               *exchanger_client_, p2p_key, local_p2p_info, peer_p2p_key,
               remote_p2p_info, bootstrap_timeout_ms())) {
         return false;
@@ -783,7 +808,7 @@ bool Communicator::connect(int rank) {
       std::string p2p_key = tcp_p2p_key(global_rank_, rank);
       std::string peer_p2p_key = tcp_p2p_key(rank, global_rank_);
       TcpP2PInfo remote_p2p_info;
-      if (!publish_local_then_fetch_remote(
+      if (!publish_local_then_wait_remote(
               *exchanger_client_, p2p_key, local_p2p_info, peer_p2p_key,
               remote_p2p_info, bootstrap_timeout_ms())) {
         return false;
@@ -857,7 +882,7 @@ bool Communicator::accept(int rank) {
       std::string p2p_key = uccl_p2p_key(global_rank_, rank);
       std::string peer_p2p_key = uccl_p2p_key(rank, global_rank_);
       UCCLP2PInfo remote_p2p_info;
-      if (!fetch_remote_then_publish_local(
+      if (!wait_remote_then_publish_local(
               *exchanger_client_, peer_p2p_key, remote_p2p_info, p2p_key,
               local_p2p_info, bootstrap_timeout_ms())) {
         return false;
@@ -903,7 +928,7 @@ bool Communicator::accept(int rank) {
       TcpP2PInfo remote_p2p_info;
       TcpP2PInfo local_p2p_info(tcp_adapter.get_listen_ip(),
                                 tcp_adapter.get_listen_port());
-      if (!fetch_remote_then_publish_local(
+      if (!wait_remote_then_publish_local(
               *exchanger_client_, peer_p2p_key, remote_p2p_info, p2p_key,
               local_p2p_info, bootstrap_timeout_ms())) {
         return false;
@@ -1567,7 +1592,7 @@ bool Communicator::notify_named_mrs(int remote_rank, uint64_t generation,
   //             << " key=" << entry.mr.key << std::endl;
   // }
 
-  return exchanger_client_->publish(key, payload);
+  return exchanger_client_->put(key, payload);
 }
 
 bool Communicator::wait_named_mrs(int remote_rank, uint64_t generation,
@@ -1580,8 +1605,7 @@ bool Communicator::wait_named_mrs(int remote_rank, uint64_t generation,
                     std::to_string(global_rank_) + ":" +
                     std::to_string(generation);
   int timeout_ms = mr_timeout_ms();
-  if (!exchanger_client_->wait_and_fetch(
-          key, infos, timeout_to_retries(timeout_ms, 1), 1)) {
+  if (!exchanger_client_->wait(key, infos, make_wait_options(timeout_ms, 1))) {
     std::cerr << "[WARN] Timeout waiting for named MR table from rank "
               << remote_rank << std::endl;
     return false;
@@ -1657,11 +1681,10 @@ bool Communicator::notify_ipc_buffer(int remote_rank, uint32_t ipc_id,
   }
 
   auto const latest_key = ipc_buffer_key(global_rank_, remote_rank, ipc_id);
-  if (!exchanger_client_->publish(latest_key, info)) return false;
-  if (binding_version == 0) return true;
+  if (!exchanger_client_->put(latest_key, info)) return false;
   auto const versioned_key = ipc_buffer_versioned_key(global_rank_, remote_rank,
                                                       ipc_id, binding_version);
-  return exchanger_client_->publish(versioned_key, info);
+  return exchanger_client_->put(versioned_key, info);
 }
 
 IPCItem Communicator::export_local_ipc_buffer(void* local_buf, size_t len) {
@@ -1680,36 +1703,23 @@ bool Communicator::wait_ipc_buffer(int remote_rank, uint32_t ipc_id,
   if (!exchanger_client_ || !exchanger_client_->valid()) return false;
   IpcBufferInfo info{};
   auto const latest_key = ipc_buffer_key(remote_rank, global_rank_, ipc_id);
+  auto const deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(bootstrap_timeout_ms());
   if (expected_binding_version != 0) {
     auto const versioned_key = ipc_buffer_versioned_key(
         remote_rank, global_rank_, ipc_id, expected_binding_version);
     // Prefer deterministic versioned key to avoid stale latest-key reads.
-    if (exchanger_client_->wait_and_fetch(
+    if (exchanger_client_->wait(
             versioned_key, info,
-            timeout_to_retries(bootstrap_timeout_ms(), kBootstrapPollDelayMs),
-            kBootstrapPollDelayMs)) {
-      IPCItem state{};
-      state.handle = info.handle;
-      state.binding_version = info.binding_version;
-      state.base_offset = static_cast<uintptr_t>(info.base_offset);
-      state.bytes = static_cast<size_t>(info.bytes);
-      state.device_idx = info.device_idx;
-      state.valid = info.valid;
-      state.ipc_id = ipc_id;
-      bool ok = ipc_manager_.register_remote_ipc(remote_rank, state);
-      if (ok) {
-        try_open_remote_ipc_buffer(remote_rank, state);
-      }
-      return ok;
+            make_wait_options_until(deadline, kBootstrapPollDelayMs))) {
+      return register_remote_ipc_info(remote_rank, ipc_id, info,
+                                      /*eager_open_direct_ptr=*/true);
     }
   }
-  auto const deadline = std::chrono::steady_clock::now() +
-                        std::chrono::milliseconds(bootstrap_timeout_ms());
   while (true) {
-    if (!exchanger_client_->wait_and_fetch(
+    if (!exchanger_client_->wait(
             latest_key, info,
-            timeout_to_retries(bootstrap_timeout_ms(), kBootstrapPollDelayMs),
-            kBootstrapPollDelayMs)) {
+            make_wait_options_until(deadline, kBootstrapPollDelayMs))) {
       return false;
     }
     if (expected_binding_version == 0 ||
@@ -1723,19 +1733,9 @@ bool Communicator::wait_ipc_buffer(int remote_rank, uint32_t ipc_id,
         std::chrono::milliseconds(kBootstrapPollDelayMs));
   }
 
-  IPCItem state{};
-  state.handle = info.handle;
-  state.binding_version = info.binding_version;
-  state.base_offset = static_cast<uintptr_t>(info.base_offset);
-  state.bytes = static_cast<size_t>(info.bytes);
-  state.device_idx = info.device_idx;
-  state.valid = info.valid;
-  state.ipc_id = ipc_id;
-  bool ok = ipc_manager_.register_remote_ipc(remote_rank, state);
-  if (ok && expected_binding_version != 0) {
-    try_open_remote_ipc_buffer(remote_rank, state);
-  }
-  return ok;
+  bool const eager_open_direct_ptr = (expected_binding_version != 0);
+  return register_remote_ipc_info(remote_rank, ipc_id, info,
+                                  eager_open_direct_ptr);
 }
 
 bool Communicator::fetch_ipc_buffer(int remote_rank, uint32_t ipc_id,
@@ -1745,45 +1745,35 @@ bool Communicator::fetch_ipc_buffer(int remote_rank, uint32_t ipc_id,
   if (expected_binding_version != 0) {
     auto const versioned_key = ipc_buffer_versioned_key(
         remote_rank, global_rank_, ipc_id, expected_binding_version);
-    if (exchanger_client_->fetch(versioned_key, info)) {
-      IPCItem state{};
-      state.handle = info.handle;
-      state.binding_version = info.binding_version;
-      state.base_offset = static_cast<uintptr_t>(info.base_offset);
-      state.bytes = static_cast<size_t>(info.bytes);
-      state.device_idx = info.device_idx;
-      state.valid = info.valid;
-      if (state.valid && info.binding_version != expected_binding_version) {
+    if (exchanger_client_->get(versioned_key, info)) {
+      if (info.valid && info.binding_version != expected_binding_version) {
         invalidate_remote_ipc_buffer(remote_rank, ipc_id);
         return false;
       }
-      state.ipc_id = ipc_id;
-      bool ok = ipc_manager_.register_remote_ipc(remote_rank, state);
-      if (ok && expected_binding_version != 0) {
-        try_open_remote_ipc_buffer(remote_rank, state);
-      }
-      return ok;
+      return register_remote_ipc_info(remote_rank, ipc_id, info,
+                                      /*eager_open_direct_ptr=*/true);
     }
   }
-  if (!exchanger_client_->fetch(
+  if (!exchanger_client_->get(
           ipc_buffer_key(remote_rank, global_rank_, ipc_id), info)) {
     return false;
   }
-  IPCItem state{};
-  state.handle = info.handle;
-  state.binding_version = info.binding_version;
-  state.base_offset = static_cast<uintptr_t>(info.base_offset);
-  state.bytes = static_cast<size_t>(info.bytes);
-  state.device_idx = info.device_idx;
-  state.valid = info.valid;
-  if (state.valid && expected_binding_version != 0 &&
+  if (info.valid && expected_binding_version != 0 &&
       info.binding_version != expected_binding_version) {
     invalidate_remote_ipc_buffer(remote_rank, ipc_id);
     return false;
   }
-  state.ipc_id = ipc_id;
-  bool ok = ipc_manager_.register_remote_ipc(remote_rank, state);
-  if (ok && expected_binding_version != 0) {
+  bool const eager_open_direct_ptr = (expected_binding_version != 0);
+  return register_remote_ipc_info(remote_rank, ipc_id, info,
+                                  eager_open_direct_ptr);
+}
+
+bool Communicator::register_remote_ipc_info(int remote_rank, uint32_t ipc_id,
+                                            IpcBufferInfo const& info,
+                                            bool eager_open_direct_ptr) {
+  IPCItem state = ipc_item_from_info(info, ipc_id);
+  bool const ok = ipc_manager_.register_remote_ipc(remote_rank, state);
+  if (ok && eager_open_direct_ptr) {
     try_open_remote_ipc_buffer(remote_rank, state);
   }
   return ok;

--- a/experimental/ukernel/src/transport/communicator.h
+++ b/experimental/ukernel/src/transport/communicator.h
@@ -159,6 +159,9 @@ class Communicator {
   bool has_fresh_remote_ipc_buffer(int remote_rank, uint32_t ipc_id,
                                    uint64_t expected_binding_version) const;
   void invalidate_remote_ipc_buffer(int remote_rank, uint32_t ipc_id);
+  bool register_remote_ipc_info(int remote_rank, uint32_t ipc_id,
+                                IpcBufferInfo const& info,
+                                bool eager_open_direct_ptr);
   void try_open_remote_ipc_buffer(int remote_rank, IPCItem const& state);
   void cleanup_tracked_request(TrackedRequest& tracked);
   bool complete_host_bounce_recv(TrackedRequest& tracked, bool blocking);

--- a/experimental/ukernel/src/transport/oob/oob.cc
+++ b/experimental/ukernel/src/transport/oob/oob.cc
@@ -3,6 +3,29 @@
 namespace UKernel {
 namespace Transport {
 
+bool Exchanger::wait_raw(std::string_view key, std::string& value,
+                         WaitOptions const& options) {
+  if (options.max_retries == 0) {
+    return get_raw(key, value);
+  }
+
+  int const delay_ms = options.delay_ms > 0 ? options.delay_ms : 1;
+  if (options.max_retries > 0) {
+    for (int i = 0; i < options.max_retries; ++i) {
+      if (!valid()) return false;
+      if (get_raw(key, value)) return true;
+      std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+    }
+    return false;
+  }
+
+  while (valid()) {
+    if (get_raw(key, value)) return true;
+    std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
+  }
+  return false;
+}
+
 char const* peer_transport_kind_name(PeerTransportKind kind) {
   switch (kind) {
     case PeerTransportKind::Unknown:

--- a/experimental/ukernel/src/transport/oob/oob.h
+++ b/experimental/ukernel/src/transport/oob/oob.h
@@ -2,22 +2,28 @@
 
 #include "../../include/config.h"
 #include "../../include/gpu_rt.h"
-#include "../util/jring.h"
 #include <atomic>
+#include <algorithm>
 #include <chrono>
+#include <condition_variable>
 #include <cstdint>
 #include <cstring>
 #include <deque>
 #include <functional>
-#include <iomanip>
 #include <iostream>
-#include <map>
+#include <limits>
 #include <memory>
 #include <mutex>
+#include <pthread.h>
+#include <semaphore.h>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <thread>
+#include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace UKernel {
@@ -33,127 +39,64 @@ PeerTransportKind resolve_peer_transport_kind(
     CommunicatorConfig const& config, CommunicatorMeta const& local_meta,
     CommunicatorMeta const& peer_meta);
 
-struct Exchangeable {
-  virtual std::map<std::string, std::string> to_map() const = 0;
-  virtual void from_map(std::map<std::string, std::string> const& kv) = 0;
-  virtual ~Exchangeable() {}
-};
+template <typename T>
+bool serialize_object(T const& obj, std::string& out);
+template <typename T>
+bool deserialize_object(std::string const& in, T& obj);
 
-struct CommunicatorMeta : public Exchangeable {
+#define UK_OOB_SERDE_METHODS(Type)                                             \
+  bool serialize(std::string& out) const { return serialize_object(*this, out); } \
+  bool deserialize(std::string const& in) {                                    \
+    return deserialize_object(in, *this);                                      \
+  }
+
+struct CommunicatorMeta {
   std::string host_id;
   std::string ip;
   int local_id = -1;
   bool rdma_capable = false;
 
-  CommunicatorMeta() = default;
-
-  std::map<std::string, std::string> to_map() const override {
-    std::map<std::string, std::string> kv;
-    kv["host_id"] = host_id;
-    kv["ip"] = ip;
-    kv["local_id"] = std::to_string(local_id);
-    kv["rdma_capable"] = rdma_capable ? "1" : "0";
-    return kv;
-  }
-
-  void from_map(std::map<std::string, std::string> const& kv) override {
-    host_id = kv.at("host_id");
-    ip = kv.at("ip");
-    local_id = std::stoi(kv.at("local_id"));
-    auto it = kv.find("rdma_capable");
-    rdma_capable = (it != kv.end() && it->second == "1");
-  }
+  UK_OOB_SERDE_METHODS(CommunicatorMeta)
 };
 
 struct MR {
-  uint32_t id;
-  uint64_t address;
-  uint64_t length;
-  uint32_t lkey;
-  uint32_t key;
+  uint32_t id = 0;
+  uint64_t address = 0;
+  uint64_t length = 0;
+  uint32_t lkey = 0;
+  uint32_t key = 0;
+
+  UK_OOB_SERDE_METHODS(MR)
 };
 
 struct NamedMR {
   uint32_t buffer_id = 0;
   MR mr{};
+
+  UK_OOB_SERDE_METHODS(NamedMR)
 };
 
-struct NamedMRInfos : public Exchangeable {
+struct NamedMRInfos {
   uint64_t generation = 0;
   std::vector<NamedMR> entries;
 
-  std::map<std::string, std::string> to_map() const override {
-    std::map<std::string, std::string> kv;
-    kv["generation"] = std::to_string(generation);
-    kv["count"] = std::to_string(entries.size());
-    for (size_t i = 0; i < entries.size(); ++i) {
-      auto const& entry = entries[i];
-      kv["entry_" + std::to_string(i) + "_buffer_id"] =
-          std::to_string(entry.buffer_id);
-      kv["entry_" + std::to_string(i) + "_mr_id"] = std::to_string(entry.mr.id);
-
-      std::ostringstream oss;
-      oss << std::hex << std::setw(16) << std::setfill('0') << entry.mr.address;
-      kv["entry_" + std::to_string(i) + "_mr_addr"] = oss.str();
-
-      kv["entry_" + std::to_string(i) + "_mr_len"] =
-          std::to_string(entry.mr.length);
-      kv["entry_" + std::to_string(i) + "_mr_key"] =
-          std::to_string(entry.mr.key);
-    }
-    return kv;
-  }
-
-  void from_map(std::map<std::string, std::string> const& kv) override {
-    auto generation_it = kv.find("generation");
-    generation =
-        generation_it == kv.end() ? 0 : std::stoull(generation_it->second);
-    size_t count = std::stoul(kv.at("count"));
-    entries.resize(count);
-    for (size_t i = 0; i < count; ++i) {
-      auto& entry = entries[i];
-      entry.buffer_id = static_cast<uint32_t>(
-          std::stoul(kv.at("entry_" + std::to_string(i) + "_buffer_id")));
-      entry.mr.id = static_cast<uint32_t>(
-          std::stoul(kv.at("entry_" + std::to_string(i) + "_mr_id")));
-      entry.mr.address = std::stoull(
-          kv.at("entry_" + std::to_string(i) + "_mr_addr"), nullptr, 16);
-      entry.mr.length =
-          std::stoull(kv.at("entry_" + std::to_string(i) + "_mr_len"));
-      entry.mr.key = static_cast<uint32_t>(
-          std::stoul(kv.at("entry_" + std::to_string(i) + "_mr_key")));
-    }
-  }
+  UK_OOB_SERDE_METHODS(NamedMRInfos)
 };
 
-struct UCCLP2PInfo : public Exchangeable {
+struct UCCLP2PInfo {
   std::string ip;
-  uint16_t port;
-  int dev_idx;
-  int gpu_idx;
+  uint16_t port = 0;
+  int dev_idx = -1;
+  int gpu_idx = -1;
 
   UCCLP2PInfo() = default;
   UCCLP2PInfo(std::string ip_, uint16_t port_, int dev_idx_, int gpu_idx_)
       : ip(std::move(ip_)), port(port_), dev_idx(dev_idx_), gpu_idx(gpu_idx_) {}
 
-  std::map<std::string, std::string> to_map() const override {
-    std::map<std::string, std::string> kv;
-    kv["ip"] = ip;
-    kv["port"] = std::to_string(port);
-    kv["dev_idx"] = std::to_string(dev_idx);
-    kv["gpu_idx"] = std::to_string(gpu_idx);
-    return kv;
-  }
-
-  void from_map(std::map<std::string, std::string> const& kv) override {
-    ip = kv.at("ip");
-    port = static_cast<uint16_t>(std::stoul(kv.at("port")));
-    dev_idx = std::stoi(kv.at("dev_idx"));
-    gpu_idx = std::stoi(kv.at("gpu_idx"));
-  }
+  UK_OOB_SERDE_METHODS(UCCLP2PInfo)
 };
 
-struct TcpP2PInfo : public Exchangeable {
+struct TcpP2PInfo {
   std::string ip;
   uint16_t port = 0;
 
@@ -161,20 +104,10 @@ struct TcpP2PInfo : public Exchangeable {
   TcpP2PInfo(std::string ip_, uint16_t port_)
       : ip(std::move(ip_)), port(port_) {}
 
-  std::map<std::string, std::string> to_map() const override {
-    std::map<std::string, std::string> kv;
-    kv["ip"] = ip;
-    kv["port"] = std::to_string(port);
-    return kv;
-  }
-
-  void from_map(std::map<std::string, std::string> const& kv) override {
-    ip = kv.at("ip");
-    port = static_cast<uint16_t>(std::stoul(kv.at("port")));
-  }
+  UK_OOB_SERDE_METHODS(TcpP2PInfo)
 };
 
-struct IpcBufferInfo : public Exchangeable {
+struct IpcBufferInfo {
   uint32_t ipc_id = 0;
   uint64_t binding_version = 0;
   gpuIpcMemHandle_t handle{};
@@ -183,239 +116,448 @@ struct IpcBufferInfo : public Exchangeable {
   int32_t device_idx = -1;
   bool valid = false;
 
-  std::map<std::string, std::string> to_map() const override {
-    std::map<std::string, std::string> kv;
-    kv["ipc_id"] = std::to_string(ipc_id);
-    kv["binding_version"] = std::to_string(binding_version);
-    kv["base_offset"] = std::to_string(base_offset);
-    kv["bytes"] = std::to_string(bytes);
-    kv["device_idx"] = std::to_string(device_idx);
-    kv["valid"] = valid ? "1" : "0";
+  UK_OOB_SERDE_METHODS(IpcBufferInfo)
+};
 
-    std::ostringstream oss;
-    oss << std::hex << std::setfill('0');
-    auto const* data = reinterpret_cast<uint8_t const*>(&handle);
-    for (size_t i = 0; i < sizeof(gpuIpcMemHandle_t); ++i) {
-      oss << std::setw(2) << static_cast<unsigned>(data[i]);
-    }
-    kv["handle_hex"] = oss.str();
-    return kv;
-  }
+#define UK_OOB_DEFINE_VISIT_FIELDS(Type, BODY)                                 \
+  template <class F>                                                           \
+  inline void visit_fields(Type& v, F&& f) { BODY }                            \
+  template <class F>                                                           \
+  inline void visit_fields(Type const& v, F&& f) { BODY }
 
-  void from_map(std::map<std::string, std::string> const& kv) override {
-    ipc_id = static_cast<uint32_t>(std::stoul(kv.at("ipc_id")));
-    auto it_binding_version = kv.find("binding_version");
-    if (it_binding_version == kv.end()) {
-      // Backward-compatible fallback for older peers/tests.
-      auto it_generation = kv.find("generation");
-      binding_version =
-          (it_generation == kv.end()) ? 0 : std::stoull(it_generation->second);
-    } else {
-      binding_version = std::stoull(it_binding_version->second);
-    }
-    base_offset = std::stoull(kv.at("base_offset"));
-    bytes = std::stoull(kv.at("bytes"));
-    device_idx = std::stoi(kv.at("device_idx"));
-    valid = (kv.at("valid") == "1");
-    std::memset(&handle, 0, sizeof(handle));
-    auto const& hex = kv.at("handle_hex");
-    auto* data = reinterpret_cast<uint8_t*>(&handle);
-    size_t nbytes = std::min(sizeof(gpuIpcMemHandle_t), hex.size() / 2);
-    for (size_t i = 0; i < nbytes; ++i) {
-      data[i] =
-          static_cast<uint8_t>(std::stoul(hex.substr(i * 2, 2), nullptr, 16));
-    }
+UK_OOB_DEFINE_VISIT_FIELDS(CommunicatorMeta, f("host_id", v.host_id);
+                           f("ip", v.ip); f("local_id", v.local_id);
+                           f("rdma_capable", v.rdma_capable);)
+UK_OOB_DEFINE_VISIT_FIELDS(MR, f("id", v.id); f("address", v.address);
+                           f("length", v.length); f("lkey", v.lkey);
+                           f("key", v.key);)
+UK_OOB_DEFINE_VISIT_FIELDS(NamedMR, f("buffer_id", v.buffer_id);
+                           f("mr", v.mr);)
+UK_OOB_DEFINE_VISIT_FIELDS(NamedMRInfos, f("generation", v.generation);
+                           f("entries", v.entries);)
+UK_OOB_DEFINE_VISIT_FIELDS(UCCLP2PInfo, f("ip", v.ip); f("port", v.port);
+                           f("dev_idx", v.dev_idx); f("gpu_idx", v.gpu_idx);)
+UK_OOB_DEFINE_VISIT_FIELDS(TcpP2PInfo, f("ip", v.ip); f("port", v.port);)
+UK_OOB_DEFINE_VISIT_FIELDS(IpcBufferInfo, f("ipc_id", v.ipc_id);
+                           f("binding_version", v.binding_version);
+                           f("handle", v.handle);
+                           f("base_offset", v.base_offset);
+                           f("bytes", v.bytes);
+                           f("device_idx", v.device_idx); f("valid", v.valid);)
+
+#undef UK_OOB_DEFINE_VISIT_FIELDS
+#undef UK_OOB_SERDE_METHODS
+
+namespace detail {
+
+template <typename T>
+struct is_vector : std::false_type {};
+template <typename T, typename A>
+struct is_vector<std::vector<T, A>> : std::true_type {};
+
+struct ByteWriter {
+  std::string out;
+  bool ok = true;
+
+  void append(void const* src, size_t n) {
+    if (!ok) return;
+    auto const* p = reinterpret_cast<char const*>(src);
+    out.append(p, n);
   }
 };
+
+struct ByteReader {
+  std::string const& in;
+  size_t pos = 0;
+  bool ok = true;
+
+  explicit ByteReader(std::string const& src) : in(src) {}
+
+  bool take(void* dst, size_t n) {
+    if (!ok || pos > in.size() || n > in.size() - pos) {
+      ok = false;
+      return false;
+    }
+    std::memcpy(dst, in.data() + pos, n);
+    pos += n;
+    return true;
+  }
+};
+
+template <typename T>
+void write_value(ByteWriter& w, T const& value);
+
+template <typename T>
+void read_value(ByteReader& r, T& value);
+
+template <typename T>
+void write_pod(ByteWriter& w, T const& value) {
+  static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+  w.append(&value, sizeof(T));
+}
+
+template <typename T>
+void read_pod(ByteReader& r, T& value) {
+  static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+  (void)r.take(&value, sizeof(T));
+}
+
+inline void write_u32(ByteWriter& w, uint32_t value) { write_pod(w, value); }
+inline void read_u32(ByteReader& r, uint32_t& value) { read_pod(r, value); }
+
+template <typename T>
+void write_value(ByteWriter& w, T const& value) {
+  if constexpr (std::is_same_v<std::decay_t<T>, std::string>) {
+    if (value.size() > static_cast<size_t>(UINT32_MAX)) {
+      w.ok = false;
+      return;
+    }
+    write_u32(w, static_cast<uint32_t>(value.size()));
+    w.append(value.data(), value.size());
+  } else if constexpr (std::is_same_v<std::decay_t<T>, bool>) {
+    uint8_t v = value ? 1 : 0;
+    write_pod(w, v);
+  } else if constexpr (std::is_enum_v<std::decay_t<T>>) {
+    using U = std::underlying_type_t<std::decay_t<T>>;
+    write_pod(w, static_cast<U>(value));
+  } else if constexpr (std::is_arithmetic_v<std::decay_t<T>> ||
+                       std::is_same_v<std::decay_t<T>, gpuIpcMemHandle_t>) {
+    write_pod(w, value);
+  } else if constexpr (is_vector<std::decay_t<T>>::value) {
+    if (value.size() > static_cast<size_t>(UINT32_MAX)) {
+      w.ok = false;
+      return;
+    }
+    write_u32(w, static_cast<uint32_t>(value.size()));
+    for (auto const& item : value) {
+      write_value(w, item);
+      if (!w.ok) return;
+    }
+  } else {
+    visit_fields(value, [&](char const*, auto const& field) {
+      write_value(w, field);
+    });
+  }
+}
+
+template <typename T>
+void read_value(ByteReader& r, T& value) {
+  if constexpr (std::is_same_v<std::decay_t<T>, std::string>) {
+    uint32_t size = 0;
+    read_u32(r, size);
+    if (!r.ok || size > r.in.size() - r.pos) {
+      r.ok = false;
+      return;
+    }
+    value.assign(r.in.data() + r.pos, r.in.data() + r.pos + size);
+    r.pos += size;
+  } else if constexpr (std::is_same_v<std::decay_t<T>, bool>) {
+    uint8_t v = 0;
+    read_pod(r, v);
+    if (!r.ok) return;
+    value = (v != 0);
+  } else if constexpr (std::is_enum_v<std::decay_t<T>>) {
+    using U = std::underlying_type_t<std::decay_t<T>>;
+    U raw{};
+    read_pod(r, raw);
+    if (!r.ok) return;
+    value = static_cast<T>(raw);
+  } else if constexpr (std::is_arithmetic_v<std::decay_t<T>> ||
+                       std::is_same_v<std::decay_t<T>, gpuIpcMemHandle_t>) {
+    read_pod(r, value);
+  } else if constexpr (is_vector<std::decay_t<T>>::value) {
+    uint32_t n = 0;
+    read_u32(r, n);
+    if (!r.ok) return;
+    value.clear();
+    value.resize(n);
+    for (auto& item : value) {
+      read_value(r, item);
+      if (!r.ok) return;
+    }
+  } else {
+    visit_fields(value, [&](char const*, auto& field) { read_value(r, field); });
+  }
+}
+
+}  // namespace detail
+
+template <typename T>
+inline bool serialize_object(T const& obj, std::string& out) {
+  detail::ByteWriter writer;
+  constexpr uint32_t kSerdeMagic = 0x4F4F4253;  // "OOBS"
+  constexpr uint32_t kSerdeVersion = 1;
+  detail::write_u32(writer, kSerdeMagic);
+  detail::write_u32(writer, kSerdeVersion);
+  detail::write_value(writer, obj);
+  if (!writer.ok) return false;
+  out.swap(writer.out);
+  return true;
+}
+
+template <typename T>
+inline bool deserialize_object(std::string const& in, T& obj) {
+  detail::ByteReader reader(in);
+  uint32_t magic = 0;
+  uint32_t version = 0;
+  detail::read_u32(reader, magic);
+  detail::read_u32(reader, version);
+  if (!reader.ok) return false;
+  if (magic != 0x4F4F4253 || version != 1) return false;
+  detail::read_value(reader, obj);
+  return reader.ok && reader.pos == in.size();
+}
 
 class Exchanger {
  public:
+  struct WaitOptions {
+    WaitOptions(int max_retries_ = -1, int delay_ms_ = 100)
+        : max_retries(max_retries_), delay_ms(delay_ms_) {}
+    int max_retries;  // <0 means wait until available or invalid.
+    int delay_ms;
+  };
+
   virtual ~Exchanger() = default;
 
   virtual bool valid() const = 0;
-  virtual bool publish(std::string const& key, Exchangeable const& obj) = 0;
-  virtual bool fetch(std::string const& key, Exchangeable& obj) = 0;
-  virtual bool wait_and_fetch(std::string const& key, Exchangeable& obj,
-                              int max_retries = 50, int delay_ms = 100) = 0;
+  template <typename T,
+            typename std::enable_if<
+                !std::is_same<typename std::decay<T>::type, std::string>::value,
+                int>::type = 0>
+  bool put(std::string_view key, T const& obj) {
+    std::string encoded;
+    if (!serialize_object(obj, encoded)) return false;
+    return put_raw(key, encoded);
+  }
+  template <typename T,
+            typename std::enable_if<
+                !std::is_same<typename std::decay<T>::type, std::string>::value,
+                int>::type = 0>
+  bool get(std::string_view key, T& obj) {
+    std::string encoded;
+    if (!get_raw(key, encoded)) return false;
+    return deserialize_object(encoded, obj);
+  }
+  template <typename T,
+            typename std::enable_if<
+                !std::is_same<typename std::decay<T>::type, std::string>::value,
+                int>::type = 0>
+  bool wait(std::string_view key, T& obj,
+            WaitOptions const& options = WaitOptions{}) {
+    std::string encoded;
+    if (!wait_raw(key, encoded, options)) return false;
+    return deserialize_object(encoded, obj);
+  }
+
+ protected:
+  virtual bool wait_raw(std::string_view key, std::string& value,
+                        WaitOptions const& options = WaitOptions{});
+  virtual bool put_raw(std::string_view key, std::string_view value) = 0;
+  virtual bool get_raw(std::string_view key, std::string& value) = 0;
 };
 
-class SockExchanger : public Exchanger {
+class ShmExchanger : public Exchanger {
  public:
-  SockExchanger(bool is_server, std::string const& host, int port,
-                int timeout_ms = 3000, size_t max_line_bytes = 1 * 1024 * 1024);
-  ~SockExchanger();
+  explicit ShmExchanger(std::string kv_namespace);
+  ~ShmExchanger() override;
 
   bool valid() const override;
-  bool publish(std::string const& key, Exchangeable const& obj) override;
-  bool fetch(std::string const& key, Exchangeable& obj) override;
-  bool wait_and_fetch(std::string const& key, Exchangeable& obj,
-                      int max_retries = -1, int delay_ms = 100) override;
+  bool apply_remote(std::string_view key, std::string_view value);
+  bool reset_for_new_run();
+  size_t collect_unrelayed(
+      std::vector<std::pair<std::string, std::string>>& out,
+      size_t max_items = 32);
+  size_t collect_all(std::vector<std::pair<std::string, std::string>>& out,
+                     size_t max_items = 32) const;
+  bool mark_relayed(std::string_view key);
+
+ protected:
+  bool wait_raw(std::string_view key, std::string& value,
+                WaitOptions const& options) override;
+  bool put_raw(std::string_view key, std::string_view value) override;
+  bool get_raw(std::string_view key, std::string& value) override;
 
  private:
-  bool start_server();
-  bool connect_client();
-  bool send_cmd_and_recv(std::string const& cmd, std::string& resp);
+  static constexpr uint32_t kShmMagic = 0x554B4F42;  // "UKOB"
+  static constexpr uint32_t kShmVersion = 4;
+  static constexpr uint32_t kMaxSlots = 1024;
+  static constexpr uint32_t kMaxKeyBytes = 256;
+  static constexpr uint32_t kMaxValueBytes = 8192;
+  static constexpr uint8_t kSlotEmpty = 0;
+  static constexpr uint8_t kSlotUsed = 1;
 
-  int sock_fd_;
-  std::string host_;
-  int port_;
-  int timeout_ms_;
-  bool is_server_;
-  int listen_fd_;
-  std::atomic<bool> running_;
-  size_t max_line_bytes_;
-
-  std::unordered_map<std::string, std::map<std::string, std::string>> store_;
-  std::mutex store_mutex_;
-  std::thread server_thread_;
-  std::mutex conn_threads_mutex_;
-  std::vector<std::thread> conn_threads_;
-
-  friend void handle_connection(
-      int, std::unordered_map<std::string, std::map<std::string, std::string>>&,
-      std::mutex&, std::atomic<bool>&, size_t,
-      std::function<void(std::thread&&)>);
-};
-
-static constexpr uint16_t kTypeIpcCache = 1;
-static constexpr uint16_t kTypeAck = 2;
-
-#pragma pack(push, 1)
-struct IpcCacheWire {
-  gpuIpcMemHandle_t handle;
-  uint8_t is_send;
-  uint64_t offset;
-  uint64_t size;
-  uint32_t remote_gpu_idx_;
-  uint8_t use_bounce_buffer = 0;
-  char bounce_shm_name[128] = {};
-};
-#pragma pack(pop)
-
-struct AckWire {
-  uint32_t status;
-  uint32_t reserved;
-};
-
-enum class ShmCtrlMsgType : uint32_t {
-  Connect = 0,
-  ConnectAck = 1,
-  IpcCache = 2,
-  Ack = 3,
-  IpcCacheReq = 4,
-};
-
-struct ShmCtrlMsg {
-  uint32_t from_rank = 0;
-  uint32_t to_rank = 0;
-  ShmCtrlMsgType type = ShmCtrlMsgType::Connect;
-  uint32_t reserved = 0;
-  uint64_t seq = 0;
-  union {
-    IpcCacheWire cache;
-    AckWire ack;
+  struct KvSlot {
+    uint8_t state = kSlotEmpty;
+    uint8_t relayed = 0;
+    uint16_t reserved0 = 0;
+    uint64_t write_seq = 0;
+    uint32_t key_len = 0;
+    uint32_t value_len = 0;
+    char key[kMaxKeyBytes] = {};
+    char value[kMaxValueBytes] = {};
   };
 
-  ShmCtrlMsg() : cache{} {}
+  struct KvShmHeader {
+    uint32_t magic = 0;
+    uint32_t version = 0;
+    uint64_t recovery_epoch = 0;
+    uint64_t write_seq = 0;
+    uint32_t owner_pid = 0;
+    uint32_t slot_capacity = 0;
+    uint32_t used_slots = 0;
+    uint32_t first_free_hint = 0;
+    uint32_t reserved0 = 0;
+    pthread_mutex_t mu;
+    sem_t notify_sem;
+    KvSlot slots[kMaxSlots];
+  };
+
+  bool init_shared_store();
+  void close_shared_store();
+  bool put_encoded(std::string_view key, std::string_view value,
+                   bool mark_relayed);
+  size_t collect_entries(std::vector<std::pair<std::string, std::string>>& out,
+                         size_t max_items, size_t start_index,
+                         bool only_unrelayed) const;
+  bool wait_for_update(int delay_ms) const;
+  int find_slot_locked(std::string_view key) const;
+  int find_free_slot_locked() const;
+  void rebuild_metadata_locked();
+  bool lock_store() const;
+  void unlock_store() const;
+  void maybe_post_sem() const;
+
+ friend class HierarchicalExchanger;
+
+  std::string kv_namespace_;
+  int shm_fd_ = -1;
+  KvShmHeader* shm_ = nullptr;
+  size_t next_unrelayed_scan_index_ = 0;
+  mutable std::unordered_map<std::string, uint32_t> slot_index_cache_;
 };
 
-class ShmRingExchanger {
+class SocketExchanger : public Exchanger {
  public:
-  ShmRingExchanger(int self_rank, int world_size, std::string ring_namespace,
-                   int self_local_id = -1);
-  ~ShmRingExchanger();
+  using ReceiveCallback =
+      std::function<void(std::string const&, std::string const&)>;
 
-  void set_peer_local_id(int peer_rank, int local_id);
-  bool ensure_server_started();
-  bool connect_to(int peer_rank, int timeout_ms = 30000);
-  bool accept_from(int peer_rank, int timeout_ms = 30000);
+  SocketExchanger(bool is_root, std::string host, int port, int timeout_ms,
+                  size_t max_line_bytes, ReceiveCallback on_receive);
+  ~SocketExchanger() override;
 
-  bool send(int peer_rank, uint16_t type, uint64_t seq, void const* payload,
-            uint32_t bytes);
-  bool send_ipc_cache(int peer_rank, uint64_t seq, IpcCacheWire const& cache);
-  bool send_ipc_cache_req(int peer_rank, uint64_t seq);
-  bool recv_ipc_cache(int peer_rank, IpcCacheWire& out_cache,
-                      uint64_t* out_seq = nullptr, int timeout_ms = 30000,
-                      uint64_t expected_seq = UINT64_MAX);
-  bool recv_ipc_cache_req(int peer_rank, uint64_t* out_seq = nullptr,
-                          int timeout_ms = 30000,
-                          uint64_t expected_seq = UINT64_MAX);
-  bool send_ack(int peer_rank, uint64_t seq, uint32_t status = 1);
-  bool recv_ack(int peer_rank, uint32_t* out_status = nullptr,
-                uint64_t* out_seq = nullptr, int timeout_ms = 30000,
-                uint64_t expected_seq = UINT64_MAX);
+  bool valid() const override;
+  bool start();
+  uint64_t connection_epoch() const;
 
-  void close_peer(int peer_rank);
-  bool is_peer_connected(int peer_rank) const;
+ protected:
+  bool put_raw(std::string_view key, std::string_view value) override;
+  bool get_raw(std::string_view key, std::string& value) override;
 
  private:
-  struct ShmRingHandle {
-    jring_t* ring = nullptr;
-    int shm_fd = -1;
-    size_t shm_size = 0;
-    std::string shm_name;
-    bool attached = false;
-    bool creator = false;
-  };
-
-  struct PendingIpcCacheMsg {
-    uint64_t seq = 0;
-    IpcCacheWire cache{};
-  };
-
-  struct PendingAckMsg {
-    uint64_t seq = 0;
-    AckWire ack{};
-  };
-
-  struct PeerState {
+  struct PeerConn {
+    int fd = -1;
     std::mutex send_mu;
-    std::mutex recv_mu;
-    ShmRingHandle local_inbox;
-    ShmRingHandle remote_inbox;
-    bool connected = false;
+    std::string read_buffer;
+    std::string write_buffer;
   };
 
-  std::string ring_name(int from_rank, int to_rank) const;
-  bool ensure_local_ring(int peer_rank);
-  bool ensure_remote_ring_attached(int peer_rank, int timeout_ms);
-  bool try_recv_one_locked(int peer_rank, ShmCtrlMsg& msg);
-  bool try_take_connect_locked(int peer_rank, uint64_t* out_seq = nullptr);
-  bool try_take_cached_connect_ack_locked(int peer_rank, uint64_t expected_seq,
-                                          uint64_t* out_seq);
-  bool try_take_cached_ipc_cache_locked(int peer_rank, uint64_t expected_seq,
-                                        IpcCacheWire& out_cache,
-                                        uint64_t* out_seq);
-  bool try_take_cached_ipc_cache_req_locked(int peer_rank,
-                                            uint64_t expected_seq,
-                                            uint64_t* out_seq);
-  bool try_take_cached_ack_locked(int peer_rank, uint64_t expected_seq,
-                                  AckWire& out_ack, uint64_t* out_seq);
-  void cache_connect_message(int peer_rank, uint64_t seq);
-  void cache_connect_ack_message(int peer_rank, uint64_t seq);
-  void cache_ipc_cache_message(int peer_rank, uint64_t seq,
-                               IpcCacheWire const& cache);
-  void cache_ipc_cache_req_message(int peer_rank, uint64_t seq);
-  void cache_ack_message(int peer_rank, uint64_t seq, AckWire const& ack);
-  bool send_msg(int peer_rank, ShmCtrlMsg const& msg);
+  bool start_root_server();
+  void stop_root_server();
+  void root_accept_loop();
+  void root_broadcast_pub(std::string const& key, std::string const& value,
+                          int exclude_fd);
+  void close_root_peer(int fd);
+  void queue_root_peer_write_interest(int fd);
+  void drain_root_peer_write_interest(std::vector<int>& fds);
+  bool notify_root_wakeup() const;
+  bool enqueue_frame_locked(std::string& write_buffer,
+                            std::string const& frame) const;
+  bool flush_write_buffer_locked(int fd, std::string& write_buffer) const;
+  bool recv_frame_buffered(int fd, std::string& buffer, std::string& frame,
+                           int timeout_ms) const;
+  bool connect_upstream_locked();
+  void close_upstream_locked();
+  void upstream_loop();
+  void handle_publish(std::string const& key, std::string const& value,
+                      bool broadcast_from_root, int exclude_fd);
+  void snapshot_entries(std::vector<std::pair<std::string, std::string>>& out);
+  bool wait_until_ready(int timeout_ms);
 
-  int self_rank_;
-  int world_size_;
-  int self_local_id_;
-  std::string ring_namespace_;
+  friend class HierarchicalExchanger;
+
+  std::string host_;
+  int port_ = 0;
+  int timeout_ms_ = 0;
+  bool is_root_ = false;
+  size_t max_line_bytes_ = 0;
+  ReceiveCallback on_receive_;
+
   std::atomic<bool> running_{false};
+  std::atomic<bool> started_{false};
+  std::atomic<bool> ready_{false};
+  std::atomic<uint64_t> connection_epoch_{0};
 
-  mutable std::mutex mu_;
-  std::vector<std::shared_ptr<PeerState>> peers_;
-  std::vector<int> peer_local_ids_;
-  mutable std::mutex pending_mu_;
-  std::unordered_map<int, std::deque<uint64_t>> pending_connect_;
-  std::unordered_map<int, std::deque<uint64_t>> pending_connect_acks_;
-  std::unordered_map<int, std::deque<PendingIpcCacheMsg>>
-      rank_to_pending_ipc_cache_;
-  std::unordered_map<int, std::deque<uint64_t>> rank_to_pending_ipc_cache_req_;
-  std::unordered_map<int, std::deque<PendingAckMsg>> rank_to_pending_acks_;
-  std::vector<uint64_t> next_connect_seq_;
+  mutable std::mutex entries_mu_;
+  std::unordered_map<std::string, std::string> entries_;
+
+  int listen_fd_ = -1;
+  int root_wakeup_read_fd_ = -1;
+  int root_wakeup_write_fd_ = -1;
+  std::thread server_thread_;
+  std::mutex peers_mu_;
+  std::unordered_map<int, std::shared_ptr<PeerConn>> peers_;
+  std::mutex root_pending_mu_;
+  std::deque<int> root_pending_write_interest_;
+  std::unordered_set<int> root_pending_write_interest_set_;
+
+  mutable std::mutex upstream_mu_;
+  int upstream_fd_ = -1;
+  std::thread upstream_thread_;
+  std::string upstream_read_buffer_;
+  std::string upstream_write_buffer_;
+  std::atomic<bool> upstream_sync_complete_{false};
+
+  std::mutex pending_mu_;
+  std::condition_variable pending_cv_;
+  std::deque<std::pair<std::string, std::string>> pending_pubs_;
+
+  std::mutex ready_mu_;
+  std::condition_variable ready_cv_;
+};
+
+class HierarchicalExchanger : public Exchanger {
+ public:
+  HierarchicalExchanger(bool is_server, std::string const& host, int port,
+                        int timeout_ms = 3000,
+                        size_t max_line_bytes = 1 * 1024 * 1024,
+                        int local_id = -1);
+  ~HierarchicalExchanger();
+
+  bool valid() const override;
+
+ private:
+  bool is_node_leader() const;
+  void relay_loop();
+  void replay_local_state();
+  std::string kv_namespace() const;
+  void apply_remote_entry(std::string const& key, std::string const& value);
+
+  bool wait_raw(std::string_view key, std::string& value,
+                WaitOptions const& options) override;
+  bool put_raw(std::string_view key, std::string_view value) override;
+  bool get_raw(std::string_view key, std::string& value) override;
+
+  std::string host_;
+  int port_ = 0;
+  bool is_server_ = false;
+  int local_id_ = -1;
+  bool node_leader_ = false;
+  std::atomic<bool> running_{false};
+  uint64_t last_replayed_epoch_ = 0;
+
+  std::unique_ptr<ShmExchanger> shm_;
+  std::unique_ptr<SocketExchanger> socket_;
+  std::thread relay_thread_;
 };
 
 }  // namespace Transport

--- a/experimental/ukernel/src/transport/oob/oob.h
+++ b/experimental/ukernel/src/transport/oob/oob.h
@@ -358,12 +358,15 @@ class Exchanger {
 
 class ShmExchanger : public Exchanger {
  public:
-  explicit ShmExchanger(std::string kv_namespace);
+  explicit ShmExchanger(std::string kv_namespace, bool create_if_missing = true,
+                        int open_timeout_ms = 30000);
   ~ShmExchanger() override;
 
   bool valid() const override;
   bool apply_remote(std::string_view key, std::string_view value);
-  bool reset_for_new_run();
+  bool begin_leader_run();
+  bool mark_run_ready();
+  bool wait_until_ready(int timeout_ms) const;
   size_t collect_unrelayed(
       std::vector<std::pair<std::string, std::string>>& out,
       size_t max_items = 32);
@@ -382,7 +385,7 @@ class ShmExchanger : public Exchanger {
     static uint64_t hash_key(std::string_view key);
   };
   static constexpr uint32_t kShmMagic = 0x554B4F42;  // "UKOB"
-  static constexpr uint32_t kShmVersion = 4;
+  static constexpr uint32_t kShmVersion = 6;
   static constexpr uint32_t kMaxSlots = 1024;
   static constexpr uint32_t kMaxKeyBytes = 256;
   static constexpr uint32_t kMaxValueBytes = 8192;
@@ -403,9 +406,10 @@ class ShmExchanger : public Exchanger {
   struct KvShmHeader {
     uint32_t magic = 0;
     uint32_t version = 0;
-    uint64_t recovery_epoch = 0;
     uint64_t write_seq = 0;
     uint32_t owner_pid = 0;
+    uint32_t init_done = 0;
+    uint64_t owner_start_ticks = 0;
     uint32_t slot_capacity = 0;
     uint32_t used_slots = 0;
     uint32_t first_free_hint = 0;
@@ -430,9 +434,11 @@ class ShmExchanger : public Exchanger {
   void unlock_store() const;
   void maybe_post_sem() const;
 
- friend class HierarchicalExchanger;
+  friend class HierarchicalExchanger;
 
   std::string kv_namespace_;
+  bool create_if_missing_ = true;
+  int open_timeout_ms_ = 30000;
   int shm_fd_ = -1;
   KvShmHeader* shm_ = nullptr;
   size_t next_unrelayed_scan_index_ = 0;

--- a/experimental/ukernel/src/transport/oob/oob.h
+++ b/experimental/ukernel/src/transport/oob/oob.h
@@ -2,8 +2,8 @@
 
 #include "../../include/config.h"
 #include "../../include/gpu_rt.h"
-#include <atomic>
 #include <algorithm>
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -14,8 +14,6 @@
 #include <limits>
 #include <memory>
 #include <mutex>
-#include <pthread.h>
-#include <semaphore.h>
 #include <sstream>
 #include <string>
 #include <string_view>
@@ -25,6 +23,8 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include <pthread.h>
+#include <semaphore.h>
 
 namespace UKernel {
 namespace Transport {
@@ -44,10 +44,12 @@ bool serialize_object(T const& obj, std::string& out);
 template <typename T>
 bool deserialize_object(std::string const& in, T& obj);
 
-#define UK_OOB_SERDE_METHODS(Type)                                             \
-  bool serialize(std::string& out) const { return serialize_object(*this, out); } \
-  bool deserialize(std::string const& in) {                                    \
-    return deserialize_object(in, *this);                                      \
+#define UK_OOB_SERDE_METHODS(Type)          \
+  bool serialize(std::string& out) const {  \
+    return serialize_object(*this, out);    \
+  }                                         \
+  bool deserialize(std::string const& in) { \
+    return deserialize_object(in, *this);   \
   }
 
 struct CommunicatorMeta {
@@ -119,11 +121,15 @@ struct IpcBufferInfo {
   UK_OOB_SERDE_METHODS(IpcBufferInfo)
 };
 
-#define UK_OOB_DEFINE_VISIT_FIELDS(Type, BODY)                                 \
-  template <class F>                                                           \
-  inline void visit_fields(Type& v, F&& f) { BODY }                            \
-  template <class F>                                                           \
-  inline void visit_fields(Type const& v, F&& f) { BODY }
+#define UK_OOB_DEFINE_VISIT_FIELDS(Type, BODY)     \
+  template <class F>                               \
+  inline void visit_fields(Type& v, F&& f) {       \
+    BODY                                           \
+  }                                                \
+  template <class F>                               \
+  inline void visit_fields(Type const& v, F&& f) { \
+    BODY                                           \
+  }
 
 UK_OOB_DEFINE_VISIT_FIELDS(CommunicatorMeta, f("host_id", v.host_id);
                            f("ip", v.ip); f("local_id", v.local_id);
@@ -131,8 +137,7 @@ UK_OOB_DEFINE_VISIT_FIELDS(CommunicatorMeta, f("host_id", v.host_id);
 UK_OOB_DEFINE_VISIT_FIELDS(MR, f("id", v.id); f("address", v.address);
                            f("length", v.length); f("lkey", v.lkey);
                            f("key", v.key);)
-UK_OOB_DEFINE_VISIT_FIELDS(NamedMR, f("buffer_id", v.buffer_id);
-                           f("mr", v.mr);)
+UK_OOB_DEFINE_VISIT_FIELDS(NamedMR, f("buffer_id", v.buffer_id); f("mr", v.mr);)
 UK_OOB_DEFINE_VISIT_FIELDS(NamedMRInfos, f("generation", v.generation);
                            f("entries", v.entries);)
 UK_OOB_DEFINE_VISIT_FIELDS(UCCLP2PInfo, f("ip", v.ip); f("port", v.port);
@@ -141,8 +146,7 @@ UK_OOB_DEFINE_VISIT_FIELDS(TcpP2PInfo, f("ip", v.ip); f("port", v.port);)
 UK_OOB_DEFINE_VISIT_FIELDS(IpcBufferInfo, f("ipc_id", v.ipc_id);
                            f("binding_version", v.binding_version);
                            f("handle", v.handle);
-                           f("base_offset", v.base_offset);
-                           f("bytes", v.bytes);
+                           f("base_offset", v.base_offset); f("bytes", v.bytes);
                            f("device_idx", v.device_idx); f("valid", v.valid);)
 
 #undef UK_OOB_DEFINE_VISIT_FIELDS
@@ -192,13 +196,15 @@ void read_value(ByteReader& r, T& value);
 
 template <typename T>
 void write_pod(ByteWriter& w, T const& value) {
-  static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+  static_assert(std::is_trivially_copyable_v<T>,
+                "T must be trivially copyable");
   w.append(&value, sizeof(T));
 }
 
 template <typename T>
 void read_pod(ByteReader& r, T& value) {
-  static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
+  static_assert(std::is_trivially_copyable_v<T>,
+                "T must be trivially copyable");
   (void)r.take(&value, sizeof(T));
 }
 
@@ -234,9 +240,8 @@ void write_value(ByteWriter& w, T const& value) {
       if (!w.ok) return;
     }
   } else {
-    visit_fields(value, [&](char const*, auto const& field) {
-      write_value(w, field);
-    });
+    visit_fields(
+        value, [&](char const*, auto const& field) { write_value(w, field); });
   }
 }
 
@@ -276,7 +281,8 @@ void read_value(ByteReader& r, T& value) {
       if (!r.ok) return;
     }
   } else {
-    visit_fields(value, [&](char const*, auto& field) { read_value(r, field); });
+    visit_fields(value,
+                 [&](char const*, auto& field) { read_value(r, field); });
   }
 }
 

--- a/experimental/ukernel/src/transport/oob/oob.h
+++ b/experimental/ukernel/src/transport/oob/oob.h
@@ -378,6 +378,9 @@ class ShmExchanger : public Exchanger {
   bool get_raw(std::string_view key, std::string& value) override;
 
  private:
+  struct SlotCacheHash {
+    static uint64_t hash_key(std::string_view key);
+  };
   static constexpr uint32_t kShmMagic = 0x554B4F42;  // "UKOB"
   static constexpr uint32_t kShmVersion = 4;
   static constexpr uint32_t kMaxSlots = 1024;
@@ -433,7 +436,7 @@ class ShmExchanger : public Exchanger {
   int shm_fd_ = -1;
   KvShmHeader* shm_ = nullptr;
   size_t next_unrelayed_scan_index_ = 0;
-  mutable std::unordered_map<std::string, uint32_t> slot_index_cache_;
+  mutable std::unordered_map<uint64_t, uint32_t> slot_index_cache_;
 };
 
 class SocketExchanger : public Exchanger {
@@ -454,11 +457,27 @@ class SocketExchanger : public Exchanger {
   bool get_raw(std::string_view key, std::string& value) override;
 
  private:
+  struct PeerConn;
+
+  struct RootReactorState {
+    int listen_fd = -1;
+    int wakeup_read_fd = -1;
+    int wakeup_write_fd = -1;
+    std::thread thread;
+    std::mutex peers_mu;
+    std::unordered_map<int, std::shared_ptr<PeerConn>> peers;
+    std::mutex pending_mu;
+    std::deque<int> pending_write_interest;
+    std::unordered_set<int> pending_write_interest_set;
+  };
+
   struct PeerConn {
     int fd = -1;
     std::mutex send_mu;
     std::string read_buffer;
+    size_t read_offset = 0;
     std::string write_buffer;
+    size_t write_offset = 0;
   };
 
   bool start_root_server();
@@ -472,9 +491,10 @@ class SocketExchanger : public Exchanger {
   bool notify_root_wakeup() const;
   bool enqueue_frame_locked(std::string& write_buffer,
                             std::string const& frame) const;
-  bool flush_write_buffer_locked(int fd, std::string& write_buffer) const;
-  bool recv_frame_buffered(int fd, std::string& buffer, std::string& frame,
-                           int timeout_ms) const;
+  bool flush_write_buffer_locked(int fd, std::string& write_buffer,
+                                 size_t& write_offset) const;
+  bool recv_frame_buffered(int fd, std::string& buffer, size_t& read_offset,
+                           std::string& frame, int timeout_ms) const;
   bool connect_upstream_locked();
   void close_upstream_locked();
   void upstream_loop();
@@ -500,21 +520,15 @@ class SocketExchanger : public Exchanger {
   mutable std::mutex entries_mu_;
   std::unordered_map<std::string, std::string> entries_;
 
-  int listen_fd_ = -1;
-  int root_wakeup_read_fd_ = -1;
-  int root_wakeup_write_fd_ = -1;
-  std::thread server_thread_;
-  std::mutex peers_mu_;
-  std::unordered_map<int, std::shared_ptr<PeerConn>> peers_;
-  std::mutex root_pending_mu_;
-  std::deque<int> root_pending_write_interest_;
-  std::unordered_set<int> root_pending_write_interest_set_;
+  RootReactorState root_;
 
   mutable std::mutex upstream_mu_;
   int upstream_fd_ = -1;
   std::thread upstream_thread_;
   std::string upstream_read_buffer_;
+  size_t upstream_read_offset_ = 0;
   std::string upstream_write_buffer_;
+  size_t upstream_write_offset_ = 0;
   std::atomic<bool> upstream_sync_complete_{false};
 
   std::mutex pending_mu_;

--- a/experimental/ukernel/src/transport/oob/oob_shm.cc
+++ b/experimental/ukernel/src/transport/oob/oob_shm.cc
@@ -1,6 +1,7 @@
 #include "../util/utils.h"
-#include "oob.h"
+#include "shmring_exchanger.h"
 #include <chrono>
+#include <cstring>
 #include <thread>
 #include <fcntl.h>
 #include <sys/mman.h>

--- a/experimental/ukernel/src/transport/oob/oob_socket.cc
+++ b/experimental/ukernel/src/transport/oob/oob_socket.cc
@@ -21,9 +21,22 @@ namespace Transport {
 
 namespace {
 
-constexpr int kRootAcceptPollMs = 100;
 constexpr int kSocketPollMs = 200;
 constexpr int kRelayWaitMs = 50;
+constexpr size_t kBufferCompactMinPrefix = 4096;
+
+void compact_prefixed_buffer(std::string& buffer, size_t& offset) {
+  if (offset == 0) return;
+  if (offset == buffer.size()) {
+    buffer.clear();
+    offset = 0;
+    return;
+  }
+  if (offset >= kBufferCompactMinPrefix && offset * 2 >= buffer.size()) {
+    buffer.erase(0, offset);
+    offset = 0;
+  }
+}
 
 enum class SocketFrameType : uint8_t {
   SyncRequest = 1,
@@ -164,6 +177,16 @@ bool decode_socket_frame(std::string const& payload, SocketFrame& frame) {
 }
 
 }  // namespace
+
+uint64_t ShmExchanger::SlotCacheHash::hash_key(std::string_view key) {
+  // 64-bit FNV-1a, stable and allocation-free for small key caching.
+  uint64_t h = 1469598103934665603ULL;
+  for (unsigned char c : key) {
+    h ^= static_cast<uint64_t>(c);
+    h *= 1099511628211ULL;
+  }
+  return h;
+}
 
 ShmExchanger::ShmExchanger(std::string kv_namespace)
     : kv_namespace_(std::move(kv_namespace)) {
@@ -388,8 +411,6 @@ bool ShmExchanger::put_encoded(std::string_view key, std::string_view value,
   slot.write_seq = ++shm_->write_seq;
   slot.key_len = static_cast<uint32_t>(key.size());
   slot.value_len = static_cast<uint32_t>(value.size());
-  std::memset(slot.key, 0, sizeof(slot.key));
-  std::memset(slot.value, 0, sizeof(slot.value));
   std::memcpy(slot.key, key.data(), key.size());
   std::memcpy(slot.value, value.data(), value.size());
   if (is_new_slot) {
@@ -399,7 +420,7 @@ bool ShmExchanger::put_encoded(std::string_view key, std::string_view value,
     shm_->first_free_hint = static_cast<uint32_t>((slot_idx + 1) %
                                                   shm_->slot_capacity);
   }
-  slot_index_cache_[std::string(key)] = static_cast<uint32_t>(slot_idx);
+  slot_index_cache_[SlotCacheHash::hash_key(key)] = static_cast<uint32_t>(slot_idx);
   unlock_store();
   maybe_post_sem();
   return true;
@@ -456,7 +477,8 @@ bool ShmExchanger::wait_for_update(int delay_ms) const {
 
 int ShmExchanger::find_slot_locked(std::string_view key) const {
   if (!shm_) return -1;
-  auto const cache_it = slot_index_cache_.find(std::string(key));
+  uint64_t const key_hash = SlotCacheHash::hash_key(key);
+  auto const cache_it = slot_index_cache_.find(key_hash);
   if (cache_it != slot_index_cache_.end()) {
     uint32_t const idx = cache_it->second;
     if (idx < shm_->slot_capacity) {
@@ -472,7 +494,7 @@ int ShmExchanger::find_slot_locked(std::string_view key) const {
     auto const& slot = shm_->slots[i];
     if (slot.state != kSlotUsed || slot.key_len != key.size()) continue;
     if (std::memcmp(slot.key, key.data(), key.size()) == 0) {
-      slot_index_cache_[std::string(key)] = i;
+      slot_index_cache_[key_hash] = i;
       return static_cast<int>(i);
     }
   }
@@ -505,7 +527,8 @@ void ShmExchanger::rebuild_metadata_locked() {
       continue;
     }
     shm_->used_slots += 1;
-    slot_index_cache_[std::string(slot.key, slot.key + slot.key_len)] = i;
+    slot_index_cache_[SlotCacheHash::hash_key(
+        std::string_view(slot.key, slot.key_len))] = i;
     if (slot.write_seq > max_write_seq) max_write_seq = slot.write_seq;
   }
   if (!found_free_slot) {
@@ -552,8 +575,8 @@ SocketExchanger::~SocketExchanger() {
   ready_cv_.notify_all();
   pending_cv_.notify_all();
   (void)notify_root_wakeup();
-  if (listen_fd_ >= 0) {
-    ::shutdown(listen_fd_, SHUT_RDWR);
+  if (root_.listen_fd >= 0) {
+    ::shutdown(root_.listen_fd, SHUT_RDWR);
   }
   {
     std::lock_guard<std::mutex> lk(upstream_mu_);
@@ -562,7 +585,7 @@ SocketExchanger::~SocketExchanger() {
     }
   }
   if (upstream_thread_.joinable()) upstream_thread_.join();
-  if (server_thread_.joinable()) server_thread_.join();
+  if (root_.thread.joinable()) root_.thread.join();
   stop_root_server();
 
   {
@@ -571,8 +594,8 @@ SocketExchanger::~SocketExchanger() {
   }
 
   {
-    std::lock_guard<std::mutex> lk(peers_mu_);
-    for (auto const& [fd, _] : peers_) {
+    std::lock_guard<std::mutex> lk(root_.peers_mu);
+    for (auto const& [fd, _] : root_.peers) {
       (void)_;
       ::shutdown(fd, SHUT_RDWR);
     }
@@ -654,32 +677,32 @@ bool SocketExchanger::get_raw(std::string_view key, std::string& value) {
 }
 
 bool SocketExchanger::start_root_server() {
-  listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
-  if (listen_fd_ < 0) return false;
+  root_.listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (root_.listen_fd < 0) return false;
 
   int opt = 1;
-  (void)::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-  (void)::fcntl(listen_fd_, F_SETFL, O_NONBLOCK);
+  (void)::setsockopt(root_.listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+  (void)::fcntl(root_.listen_fd, F_SETFL, O_NONBLOCK);
 
   sockaddr_in addr {};
   addr.sin_family = AF_INET;
   addr.sin_addr.s_addr = INADDR_ANY;
   addr.sin_port = htons(static_cast<uint16_t>(port_));
-  if (::bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) !=
+  if (::bind(root_.listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) !=
       0) {
-    ::close(listen_fd_);
-    listen_fd_ = -1;
+    ::close(root_.listen_fd);
+    root_.listen_fd = -1;
     return false;
   }
-  if (::listen(listen_fd_, 64) != 0) {
-    ::close(listen_fd_);
-    listen_fd_ = -1;
+  if (::listen(root_.listen_fd, 64) != 0) {
+    ::close(root_.listen_fd);
+    root_.listen_fd = -1;
     return false;
   }
   int wake_pipe[2] = {-1, -1};
   if (::pipe(wake_pipe) != 0) {
-    ::close(listen_fd_);
-    listen_fd_ = -1;
+    ::close(root_.listen_fd);
+    root_.listen_fd = -1;
     return false;
   }
   int const wake_read_flags = ::fcntl(wake_pipe[0], F_GETFL, 0);
@@ -689,14 +712,14 @@ bool SocketExchanger::start_root_server() {
       ::fcntl(wake_pipe[1], F_SETFL, wake_write_flags | O_NONBLOCK) != 0) {
     ::close(wake_pipe[0]);
     ::close(wake_pipe[1]);
-    ::close(listen_fd_);
-    listen_fd_ = -1;
+    ::close(root_.listen_fd);
+    root_.listen_fd = -1;
     return false;
   }
-  root_wakeup_read_fd_ = wake_pipe[0];
-  root_wakeup_write_fd_ = wake_pipe[1];
+  root_.wakeup_read_fd = wake_pipe[0];
+  root_.wakeup_write_fd = wake_pipe[1];
   try {
-    server_thread_ = std::thread(&SocketExchanger::root_accept_loop, this);
+    root_.thread = std::thread(&SocketExchanger::root_accept_loop, this);
   } catch (...) {
     stop_root_server();
     return false;
@@ -705,18 +728,18 @@ bool SocketExchanger::start_root_server() {
 }
 
 void SocketExchanger::stop_root_server() {
-  if (root_wakeup_write_fd_ >= 0) {
-    ::close(root_wakeup_write_fd_);
-    root_wakeup_write_fd_ = -1;
+  if (root_.wakeup_write_fd >= 0) {
+    ::close(root_.wakeup_write_fd);
+    root_.wakeup_write_fd = -1;
   }
-  if (root_wakeup_read_fd_ >= 0) {
-    ::close(root_wakeup_read_fd_);
-    root_wakeup_read_fd_ = -1;
+  if (root_.wakeup_read_fd >= 0) {
+    ::close(root_.wakeup_read_fd);
+    root_.wakeup_read_fd = -1;
   }
-  if (listen_fd_ >= 0) {
-    ::shutdown(listen_fd_, SHUT_RDWR);
-    ::close(listen_fd_);
-    listen_fd_ = -1;
+  if (root_.listen_fd >= 0) {
+    ::shutdown(root_.listen_fd, SHUT_RDWR);
+    ::close(root_.listen_fd);
+    root_.listen_fd = -1;
   }
 }
 
@@ -747,25 +770,8 @@ void SocketExchanger::root_accept_loop() {
     return set_peer_events(peer->fd, want_write);
   };
 
-  auto process_pending_interests = [&]() {
-    std::vector<int> pending_interest_fds;
-    drain_root_peer_write_interest(pending_interest_fds);
-    for (int pending_fd : pending_interest_fds) {
-      std::shared_ptr<PeerConn> pending_peer;
-      {
-        std::lock_guard<std::mutex> lk(peers_mu_);
-        auto it = peers_.find(pending_fd);
-        if (it != peers_.end()) pending_peer = it->second;
-      }
-      if (!pending_peer) continue;
-      if (!sync_peer_interest(pending_peer)) {
-        close_root_peer(pending_fd);
-      }
-    }
-  };
-
-  if (listen_fd_ < 0 || root_wakeup_read_fd_ < 0 || !add_epoll_in(listen_fd_) ||
-      !add_epoll_in(root_wakeup_read_fd_)) {
+  if (root_.listen_fd < 0 || root_.wakeup_read_fd < 0 ||
+      !add_epoll_in(root_.listen_fd) || !add_epoll_in(root_.wakeup_read_fd)) {
     ::close(epoll_fd);
     return;
   }
@@ -773,10 +779,7 @@ void SocketExchanger::root_accept_loop() {
   constexpr int kMaxEvents = 64;
   epoll_event events[kMaxEvents];
   while (running_.load(std::memory_order_acquire)) {
-    process_pending_interests();
-
-    int const ready_count =
-        ::epoll_wait(epoll_fd, events, kMaxEvents, kRootAcceptPollMs);
+    int const ready_count = ::epoll_wait(epoll_fd, events, kMaxEvents, -1);
     if (ready_count < 0) {
       if (errno == EINTR) continue;
       break;
@@ -784,12 +787,12 @@ void SocketExchanger::root_accept_loop() {
     for (int i = 0; i < ready_count; ++i) {
       int const fd = events[i].data.fd;
       uint32_t const ev = events[i].events;
-      if (fd == listen_fd_) {
+      if (fd == root_.listen_fd) {
         while (running_.load(std::memory_order_acquire)) {
           sockaddr_in cli {};
           socklen_t len = sizeof(cli);
           int conn_fd =
-              ::accept(listen_fd_, reinterpret_cast<sockaddr*>(&cli), &len);
+              ::accept(root_.listen_fd, reinterpret_cast<sockaddr*>(&cli), &len);
           if (conn_fd < 0) {
             if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
               break;
@@ -806,8 +809,8 @@ void SocketExchanger::root_accept_loop() {
           auto peer = std::make_shared<PeerConn>();
           peer->fd = conn_fd;
           {
-            std::lock_guard<std::mutex> lk(peers_mu_);
-            peers_[conn_fd] = peer;
+            std::lock_guard<std::mutex> lk(root_.peers_mu);
+            root_.peers[conn_fd] = peer;
           }
           if (!add_epoll_in(conn_fd)) {
             close_root_peer(conn_fd);
@@ -816,11 +819,24 @@ void SocketExchanger::root_accept_loop() {
         }
         continue;
       }
-      if (fd == root_wakeup_read_fd_) {
+      if (fd == root_.wakeup_read_fd) {
         char buf[128];
-        while (::read(root_wakeup_read_fd_, buf, sizeof(buf)) > 0) {
+        while (::read(root_.wakeup_read_fd, buf, sizeof(buf)) > 0) {
         }
-        process_pending_interests();
+        std::vector<int> pending_interest_fds;
+        drain_root_peer_write_interest(pending_interest_fds);
+        for (int pending_fd : pending_interest_fds) {
+          std::shared_ptr<PeerConn> pending_peer;
+          {
+            std::lock_guard<std::mutex> lk(root_.peers_mu);
+            auto it = root_.peers.find(pending_fd);
+            if (it != root_.peers.end()) pending_peer = it->second;
+          }
+          if (!pending_peer) continue;
+          if (!sync_peer_interest(pending_peer)) {
+            close_root_peer(pending_fd);
+          }
+        }
         continue;
       }
 
@@ -832,9 +848,9 @@ void SocketExchanger::root_accept_loop() {
 
       std::shared_ptr<PeerConn> peer;
       {
-        std::lock_guard<std::mutex> lk(peers_mu_);
-        auto it = peers_.find(fd);
-        if (it != peers_.end()) peer = it->second;
+        std::lock_guard<std::mutex> lk(root_.peers_mu);
+        auto it = root_.peers.find(fd);
+        if (it != root_.peers.end()) peer = it->second;
       }
       if (!peer) continue;
 
@@ -842,7 +858,8 @@ void SocketExchanger::root_accept_loop() {
       if (ev & EPOLLOUT) {
         std::lock_guard<std::mutex> send_lk(peer->send_mu);
         if (!peer->write_buffer.empty() &&
-            !flush_write_buffer_locked(fd, peer->write_buffer) &&
+            !flush_write_buffer_locked(fd, peer->write_buffer,
+                                       peer->write_offset) &&
             errno != EAGAIN && errno != EWOULDBLOCK) {
           close_peer_now = true;
         }
@@ -854,8 +871,8 @@ void SocketExchanger::root_accept_loop() {
 
       for (;;) {
         std::string frame;
-        bool const got_frame =
-            recv_frame_buffered(fd, peer->read_buffer, frame, 0);
+        bool const got_frame = recv_frame_buffered(
+            fd, peer->read_buffer, peer->read_offset, frame, 0);
         if (!got_frame) {
           if (errno == EAGAIN || errno == EWOULDBLOCK) break;
           close_peer_now = true;
@@ -867,7 +884,6 @@ void SocketExchanger::root_accept_loop() {
           std::vector<std::pair<std::string, std::string>> snapshot;
           snapshot_entries(snapshot);
           bool snapshot_ok = true;
-          bool need_write_interest = false;
           {
             std::lock_guard<std::mutex> send_lk(peer->send_mu);
             for (auto const& entry : snapshot) {
@@ -888,15 +904,6 @@ void SocketExchanger::root_accept_loop() {
                             enqueue_frame_locked(peer->write_buffer,
                                                  sync_done_frame);
             }
-            if (snapshot_ok && !peer->write_buffer.empty() &&
-                !flush_write_buffer_locked(fd, peer->write_buffer) &&
-                errno != EAGAIN && errno != EWOULDBLOCK) {
-              snapshot_ok = false;
-            }
-            need_write_interest = !peer->write_buffer.empty();
-          }
-          if (snapshot_ok && need_write_interest) {
-            queue_root_peer_write_interest(peer->fd);
           }
           if (!snapshot_ok) {
             close_peer_now = true;
@@ -923,9 +930,9 @@ void SocketExchanger::root_accept_loop() {
 
   std::vector<int> stale_fds;
   {
-    std::lock_guard<std::mutex> lk(peers_mu_);
-    stale_fds.reserve(peers_.size());
-    for (auto const& [fd, _] : peers_) stale_fds.push_back(fd);
+    std::lock_guard<std::mutex> lk(root_.peers_mu);
+    stale_fds.reserve(root_.peers.size());
+    for (auto const& [fd, _] : root_.peers) stale_fds.push_back(fd);
   }
   for (int fd : stale_fds) {
     close_root_peer(fd);
@@ -940,9 +947,9 @@ void SocketExchanger::root_broadcast_pub(std::string const& key,
   std::vector<int> stale_fds;
   std::vector<int> activate_write_fds;
   {
-    std::lock_guard<std::mutex> lk(peers_mu_);
-    peers.reserve(peers_.size());
-    for (auto const& [fd, peer] : peers_) {
+    std::lock_guard<std::mutex> lk(root_.peers_mu);
+    peers.reserve(root_.peers.size());
+    for (auto const& [fd, peer] : root_.peers) {
       if (fd == exclude_fd) continue;
       peers.push_back(peer);
     }
@@ -957,12 +964,6 @@ void SocketExchanger::root_broadcast_pub(std::string const& key,
     std::lock_guard<std::mutex> lk(peer->send_mu);
     bool const was_empty = peer->write_buffer.empty();
     if (!enqueue_frame_locked(peer->write_buffer, frame)) {
-      stale_fds.push_back(peer->fd);
-      continue;
-    }
-    if (!peer->write_buffer.empty() &&
-        !flush_write_buffer_locked(peer->fd, peer->write_buffer) &&
-        errno != EAGAIN && errno != EWOULDBLOCK) {
       stale_fds.push_back(peer->fd);
       continue;
     }
@@ -985,48 +986,50 @@ void SocketExchanger::root_broadcast_pub(std::string const& key,
 void SocketExchanger::close_root_peer(int fd) {
   std::shared_ptr<PeerConn> peer;
   {
-    std::lock_guard<std::mutex> lk(peers_mu_);
-    auto it = peers_.find(fd);
-    if (it == peers_.end()) return;
+    std::lock_guard<std::mutex> lk(root_.peers_mu);
+    auto it = root_.peers.find(fd);
+    if (it == root_.peers.end()) return;
     peer = it->second;
-    peers_.erase(it);
+    root_.peers.erase(it);
   }
   if (peer) {
     std::lock_guard<std::mutex> send_lk(peer->send_mu);
     peer->write_buffer.clear();
+    peer->write_offset = 0;
     peer->read_buffer.clear();
+    peer->read_offset = 0;
   }
   {
-    std::lock_guard<std::mutex> lk(root_pending_mu_);
-    root_pending_write_interest_set_.erase(fd);
+    std::lock_guard<std::mutex> lk(root_.pending_mu);
+    root_.pending_write_interest_set.erase(fd);
   }
   ::shutdown(fd, SHUT_RDWR);
   ::close(fd);
 }
 
 void SocketExchanger::queue_root_peer_write_interest(int fd) {
-  std::lock_guard<std::mutex> lk(root_pending_mu_);
-  auto const [_, inserted] = root_pending_write_interest_set_.insert(fd);
+  std::lock_guard<std::mutex> lk(root_.pending_mu);
+  auto const [_, inserted] = root_.pending_write_interest_set.insert(fd);
   if (!inserted) return;
-  root_pending_write_interest_.push_back(fd);
+  root_.pending_write_interest.push_back(fd);
 }
 
 void SocketExchanger::drain_root_peer_write_interest(std::vector<int>& fds) {
   fds.clear();
-  std::lock_guard<std::mutex> lk(root_pending_mu_);
-  fds.reserve(root_pending_write_interest_.size());
-  while (!root_pending_write_interest_.empty()) {
-    int const fd = root_pending_write_interest_.front();
-    root_pending_write_interest_.pop_front();
-    root_pending_write_interest_set_.erase(fd);
+  std::lock_guard<std::mutex> lk(root_.pending_mu);
+  fds.reserve(root_.pending_write_interest.size());
+  while (!root_.pending_write_interest.empty()) {
+    int const fd = root_.pending_write_interest.front();
+    root_.pending_write_interest.pop_front();
+    root_.pending_write_interest_set.erase(fd);
     fds.push_back(fd);
   }
 }
 
 bool SocketExchanger::notify_root_wakeup() const {
-  if (root_wakeup_write_fd_ < 0) return false;
+  if (root_.wakeup_write_fd < 0) return false;
   char one = 1;
-  ssize_t n = ::write(root_wakeup_write_fd_, &one, sizeof(one));
+  ssize_t n = ::write(root_.wakeup_write_fd, &one, sizeof(one));
   return n == static_cast<ssize_t>(sizeof(one)) || errno == EAGAIN ||
          errno == EWOULDBLOCK;
 }
@@ -1046,15 +1049,19 @@ bool SocketExchanger::enqueue_frame_locked(std::string& write_buffer,
 }
 
 bool SocketExchanger::flush_write_buffer_locked(int fd,
-                                                std::string& write_buffer) const {
+                                                std::string& write_buffer,
+                                                size_t& write_offset) const {
   int send_flags = 0;
 #ifdef MSG_NOSIGNAL
   send_flags |= MSG_NOSIGNAL;
 #endif
-  while (!write_buffer.empty()) {
-    ssize_t n = ::send(fd, write_buffer.data(), write_buffer.size(), send_flags);
+  while (write_offset < write_buffer.size()) {
+    char const* data = write_buffer.data() + write_offset;
+    size_t const pending = write_buffer.size() - write_offset;
+    ssize_t n = ::send(fd, data, pending, send_flags);
     if (n > 0) {
-      write_buffer.erase(0, static_cast<size_t>(n));
+      write_offset += static_cast<size_t>(n);
+      compact_prefixed_buffer(write_buffer, write_offset);
       continue;
     }
     if (n == 0) {
@@ -1065,24 +1072,33 @@ bool SocketExchanger::flush_write_buffer_locked(int fd,
     if (errno == EAGAIN || errno == EWOULDBLOCK) return false;
     return false;
   }
+  write_buffer.clear();
+  write_offset = 0;
   return true;
 }
 
 bool SocketExchanger::recv_frame_buffered(int fd, std::string& buffer,
+                                          size_t& read_offset,
                                           std::string& frame,
                                           int timeout_ms) const {
   auto extract_frame = [&]() -> bool {
-    if (buffer.size() < sizeof(uint32_t)) return false;
-    size_t pos = 0;
+    if (read_offset > buffer.size()) {
+      errno = EPROTO;
+      return false;
+    }
+    size_t const available = buffer.size() - read_offset;
+    if (available < sizeof(uint32_t)) return false;
+    size_t pos = read_offset;
     uint32_t payload_len = 0;
     if (!read_net_u32(buffer, pos, payload_len)) return false;
     if (payload_len > max_line_bytes_) {
       errno = EMSGSIZE;
       return false;
     }
-    if (buffer.size() < sizeof(uint32_t) + payload_len) return false;
-    frame.assign(buffer.data() + sizeof(uint32_t), payload_len);
-    buffer.erase(0, sizeof(uint32_t) + payload_len);
+    if (available < sizeof(uint32_t) + payload_len) return false;
+    frame.assign(buffer.data() + read_offset + sizeof(uint32_t), payload_len);
+    read_offset += sizeof(uint32_t) + payload_len;
+    compact_prefixed_buffer(buffer, read_offset);
     return true;
   };
 
@@ -1122,8 +1138,9 @@ bool SocketExchanger::recv_frame_buffered(int fd, std::string& buffer,
       if (errno == EINTR) continue;
       return false;
     }
+    compact_prefixed_buffer(buffer, read_offset);
     buffer.append(chunk, chunk + n);
-    if (buffer.size() > max_line_bytes_ * 2) {
+    if (buffer.size() - read_offset > max_line_bytes_ * 2) {
       errno = EMSGSIZE;
       return false;
     }
@@ -1156,7 +1173,9 @@ bool SocketExchanger::connect_upstream_locked() {
 
   upstream_fd_ = fd;
   upstream_read_buffer_.clear();
+  upstream_read_offset_ = 0;
   upstream_write_buffer_.clear();
+  upstream_write_offset_ = 0;
   upstream_sync_complete_.store(false, std::memory_order_release);
   std::string sync_request_frame;
   if (!encode_socket_frame(SocketFrame{SocketFrameType::SyncRequest, {}, {}},
@@ -1165,7 +1184,8 @@ bool SocketExchanger::connect_upstream_locked() {
     close_upstream_locked();
     return false;
   }
-  if (!flush_write_buffer_locked(upstream_fd_, upstream_write_buffer_) &&
+  if (!flush_write_buffer_locked(upstream_fd_, upstream_write_buffer_,
+                                 upstream_write_offset_) &&
       errno != EAGAIN && errno != EWOULDBLOCK) {
     close_upstream_locked();
     return false;
@@ -1180,7 +1200,9 @@ void SocketExchanger::close_upstream_locked() {
     upstream_fd_ = -1;
   }
   upstream_read_buffer_.clear();
+  upstream_read_offset_ = 0;
   upstream_write_buffer_.clear();
+  upstream_write_offset_ = 0;
   upstream_sync_complete_.store(false, std::memory_order_release);
   ready_.store(false, std::memory_order_release);
   ready_cv_.notify_all();
@@ -1234,7 +1256,8 @@ void SocketExchanger::upstream_loop() {
       std::lock_guard<std::mutex> lk(upstream_mu_);
       if (upstream_fd_ >= 0) {
         bool const got_buffered_frame =
-            recv_frame_buffered(upstream_fd_, upstream_read_buffer_, frame, 0);
+            recv_frame_buffered(upstream_fd_, upstream_read_buffer_,
+                                upstream_read_offset_, frame, 0);
         if (got_buffered_frame) {
           progressed = true;
         } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
@@ -1259,7 +1282,8 @@ void SocketExchanger::upstream_loop() {
             continue;
           }
           if (pfd.revents & POLLOUT) {
-            if (!flush_write_buffer_locked(upstream_fd_, upstream_write_buffer_) &&
+            if (!flush_write_buffer_locked(upstream_fd_, upstream_write_buffer_,
+                                           upstream_write_offset_) &&
                 errno != EAGAIN && errno != EWOULDBLOCK) {
               close_upstream_locked();
               continue;
@@ -1267,8 +1291,9 @@ void SocketExchanger::upstream_loop() {
             progressed = true;
           }
           if (pfd.revents & POLLIN) {
-            bool const got_frame = recv_frame_buffered(
-                upstream_fd_, upstream_read_buffer_, frame, 0);
+            bool const got_frame =
+                recv_frame_buffered(upstream_fd_, upstream_read_buffer_,
+                                    upstream_read_offset_, frame, 0);
             if (!got_frame && errno != EAGAIN && errno != EWOULDBLOCK) {
               close_upstream_locked();
               continue;

--- a/experimental/ukernel/src/transport/oob/oob_socket.cc
+++ b/experimental/ukernel/src/transport/oob/oob_socket.cc
@@ -1,457 +1,1471 @@
 #include "oob.h"
+#include "../util/utils.h"
 #include <arpa/inet.h>
-#include <netinet/in.h>
-#include <atomic>
 #include <cerrno>
 #include <chrono>
 #include <cstring>
-#include <functional>
-#include <iostream>
-#include <map>
-#include <mutex>
+#include <fcntl.h>
+#include <poll.h>
 #include <sstream>
 #include <string>
-#include <thread>
-#include <unordered_map>
-#include <vector>
+#include <sys/epoll.h>
+#include <sys/file.h>
+#include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 namespace UKernel {
 namespace Transport {
 
-/* ----------------- Internal helpers ----------------- */
+namespace {
 
-static ssize_t send_all_robust(int fd, char const* buf, size_t len) {
-  size_t total = 0;
-  while (total < len) {
-    ssize_t n = ::send(fd, buf + total, len - total, 0);
-    if (n > 0) {
-      total += static_cast<size_t>(n);
-      continue;
-    }
-    if (n == 0) {
-      // peer closed
-      return 0;
-    }
-    if (errno == EINTR) continue;
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      continue;
-    }
-    return -1;
+constexpr int kRootAcceptPollMs = 100;
+constexpr int kSocketPollMs = 200;
+constexpr int kRelayWaitMs = 50;
+
+enum class SocketFrameType : uint8_t {
+  SyncRequest = 1,
+  SyncDone = 2,
+  Publish = 3,
+};
+
+int env_int_or_default(char const* name, int default_value) {
+  char const* v = std::getenv(name);
+  if (!v || v[0] == '\0') return default_value;
+  try {
+    return std::stoi(v);
+  } catch (...) {
+    return default_value;
   }
-  return static_cast<ssize_t>(total);
 }
 
-// recv until newline, but with a max cap and ability to break on running=false
-static bool recv_line_capped(int fd, std::string& out, size_t max_line_bytes,
-                             std::atomic<bool>& running) {
+bool env_bool_or_default(char const* name, bool default_value) {
+  char const* v = std::getenv(name);
+  if (!v || v[0] == '\0') return default_value;
+  if (v[0] == '0' || v[0] == 'n' || v[0] == 'N' || v[0] == 'f' ||
+      v[0] == 'F') {
+    return false;
+  }
+  return true;
+}
+
+bool connect_with_timeout(int fd, sockaddr_in const& addr, int timeout_ms) {
+  int const current_flags = ::fcntl(fd, F_GETFL, 0);
+  if (current_flags < 0) return false;
+  if (::fcntl(fd, F_SETFL, current_flags | O_NONBLOCK) != 0) return false;
+
+  int rc = ::connect(fd, reinterpret_cast<sockaddr const*>(&addr), sizeof(addr));
+  if (rc == 0) {
+    (void)::fcntl(fd, F_SETFL, current_flags | O_NONBLOCK);
+    return true;
+  }
+  if (errno != EINPROGRESS) return false;
+
+  pollfd pfd {};
+  pfd.fd = fd;
+  pfd.events = POLLOUT;
+  rc = ::poll(&pfd, 1, timeout_ms > 0 ? timeout_ms : kSocketPollMs);
+  if (rc <= 0) return false;
+
+  int so_error = 0;
+  socklen_t so_error_len = sizeof(so_error);
+  if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &so_error_len) != 0) {
+    return false;
+  }
+  if (so_error != 0) {
+    errno = so_error;
+    return false;
+  }
+
+  return ::fcntl(fd, F_SETFL, current_flags | O_NONBLOCK) == 0;
+}
+
+std::string kv_namespace_for_port(int port) {
+  char const* override_ns = std::getenv("UHM_OOB_NAMESPACE");
+  std::string seed =
+      std::string(override_ns && override_ns[0] != '\0' ? override_ns
+                                                        : generate_host_id()) +
+      ":" + std::to_string(port);
+  uint64_t h = static_cast<uint64_t>(std::hash<std::string>{}(seed));
+  std::ostringstream oss;
+  oss << "/uk_oob_kv_" << std::hex << h;
+  return oss.str();
+}
+
+struct SocketFrame {
+  SocketFrameType type = SocketFrameType::SyncRequest;
+  std::string key;
+  std::string value;
+};
+
+void append_net_u32(std::string& out, uint32_t value) {
+  uint32_t const net_value = htonl(value);
+  out.append(reinterpret_cast<char const*>(&net_value), sizeof(net_value));
+}
+
+bool read_net_u32(std::string const& in, size_t& pos, uint32_t& value) {
+  if (in.size() < pos + sizeof(uint32_t)) return false;
+  uint32_t net_value = 0;
+  std::memcpy(&net_value, in.data() + pos, sizeof(net_value));
+  value = ntohl(net_value);
+  pos += sizeof(uint32_t);
+  return true;
+}
+
+bool encode_socket_frame(SocketFrame const& frame, std::string& out) {
   out.clear();
-  char c;
-  while (running.load(std::memory_order_relaxed)) {
-    ssize_t n = ::recv(fd, &c, 1, 0);
-    if (n > 0) {
-      if (c == '\n') return true;
-      out.push_back(c);
-      if (out.size() > max_line_bytes) {
-        // protocol violation: line too big
-        return false;
-      }
-      continue;
+  if (frame.type == SocketFrameType::SyncRequest ||
+      frame.type == SocketFrameType::SyncDone) {
+    append_net_u32(out, 1);
+    out.push_back(static_cast<char>(frame.type));
+    return true;
+  }
+  if (frame.type != SocketFrameType::Publish) return false;
+  if (frame.key.size() > std::numeric_limits<uint32_t>::max() ||
+      frame.value.size() > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+  uint32_t const payload_len =
+      1 + sizeof(uint32_t) + static_cast<uint32_t>(frame.key.size()) +
+      sizeof(uint32_t) + static_cast<uint32_t>(frame.value.size());
+  append_net_u32(out, payload_len);
+  out.push_back(static_cast<char>(frame.type));
+  append_net_u32(out, static_cast<uint32_t>(frame.key.size()));
+  out.append(frame.key);
+  append_net_u32(out, static_cast<uint32_t>(frame.value.size()));
+  out.append(frame.value);
+  return true;
+}
+
+bool decode_socket_frame(std::string const& payload, SocketFrame& frame) {
+  frame = {};
+  if (payload.empty()) return false;
+  frame.type =
+      static_cast<SocketFrameType>(static_cast<uint8_t>(payload.front()));
+  if (frame.type == SocketFrameType::SyncRequest ||
+      frame.type == SocketFrameType::SyncDone) {
+    return payload.size() == 1;
+  }
+  if (frame.type != SocketFrameType::Publish) return false;
+
+  size_t pos = 1;
+  uint32_t key_len = 0;
+  uint32_t value_len = 0;
+  if (!read_net_u32(payload, pos, key_len)) return false;
+  if (payload.size() < pos + key_len) return false;
+  frame.key.assign(payload.data() + pos, key_len);
+  pos += key_len;
+  if (!read_net_u32(payload, pos, value_len)) return false;
+  if (payload.size() != pos + value_len) return false;
+  frame.value.assign(payload.data() + pos, value_len);
+  return true;
+}
+
+}  // namespace
+
+ShmExchanger::ShmExchanger(std::string kv_namespace)
+    : kv_namespace_(std::move(kv_namespace)) {
+  (void)init_shared_store();
+}
+
+ShmExchanger::~ShmExchanger() { close_shared_store(); }
+
+bool ShmExchanger::valid() const { return shm_ != nullptr; }
+
+bool ShmExchanger::apply_remote(std::string_view key, std::string_view value) {
+  return put_encoded(key, value, /*mark_relayed=*/true);
+}
+
+bool ShmExchanger::reset_for_new_run() {
+  if (!shm_ || !lock_store()) return false;
+  for (uint32_t i = 0; i < shm_->slot_capacity; ++i) {
+    shm_->slots[i] = KvSlot{};
+  }
+  shm_->used_slots = 0;
+  shm_->first_free_hint = 0;
+  shm_->write_seq = 0;
+  shm_->recovery_epoch += 1;
+  shm_->owner_pid = static_cast<uint32_t>(::getpid());
+  next_unrelayed_scan_index_ = 0;
+  slot_index_cache_.clear();
+  unlock_store();
+  maybe_post_sem();
+  return true;
+}
+
+size_t ShmExchanger::collect_unrelayed(
+    std::vector<std::pair<std::string, std::string>>& out, size_t max_items) {
+  size_t const collected =
+      collect_entries(out, max_items, next_unrelayed_scan_index_,
+                      /*only_unrelayed=*/true);
+  if (shm_ && shm_->slot_capacity > 0) {
+    next_unrelayed_scan_index_ =
+        (next_unrelayed_scan_index_ + (collected == 0 ? 1 : collected)) %
+        shm_->slot_capacity;
+  }
+  return collected;
+}
+
+size_t ShmExchanger::collect_all(
+    std::vector<std::pair<std::string, std::string>>& out,
+    size_t max_items) const {
+  return collect_entries(out, max_items, 0, /*only_unrelayed=*/false);
+}
+
+bool ShmExchanger::mark_relayed(std::string_view key) {
+  if (!shm_ || !lock_store()) return false;
+  int idx = find_slot_locked(key);
+  if (idx < 0) {
+    unlock_store();
+    return false;
+  }
+  shm_->slots[static_cast<size_t>(idx)].relayed = 1;
+  unlock_store();
+  return true;
+}
+
+bool ShmExchanger::wait_raw(std::string_view key, std::string& value,
+                            WaitOptions const& options) {
+  if (options.max_retries == 0) {
+    return get_raw(key, value);
+  }
+
+  int const delay_ms = options.delay_ms > 0 ? options.delay_ms : 1;
+  auto try_once = [&]() { return get_raw(key, value); };
+  if (try_once()) return true;
+
+  if (options.max_retries > 0) {
+    for (int i = 0; i < options.max_retries; ++i) {
+      if (!valid()) return false;
+      (void)wait_for_update(delay_ms);
+      if (try_once()) return true;
     }
-    if (n == 0) {
-      // peer closed
+    return false;
+  }
+
+  while (valid()) {
+    (void)wait_for_update(delay_ms);
+    if (try_once()) return true;
+  }
+  return false;
+}
+
+bool ShmExchanger::put_raw(std::string_view key, std::string_view value) {
+  return put_encoded(key, value, /*mark_relayed=*/false);
+}
+
+bool ShmExchanger::get_raw(std::string_view key, std::string& value) {
+  value.clear();
+  if (!shm_ || !lock_store()) return false;
+  int idx = find_slot_locked(key);
+  if (idx < 0) {
+    unlock_store();
+    return false;
+  }
+  auto const& slot = shm_->slots[static_cast<size_t>(idx)];
+  value.assign(slot.value, slot.value + slot.value_len);
+  unlock_store();
+  return true;
+}
+
+bool ShmExchanger::init_shared_store() {
+  bool created = false;
+  shm_fd_ = ::shm_open(kv_namespace_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+  if (shm_fd_ >= 0) {
+    created = true;
+  } else if (errno == EEXIST) {
+    shm_fd_ = ::shm_open(kv_namespace_.c_str(), O_CREAT | O_RDWR, 0600);
+  }
+  if (shm_fd_ < 0) return false;
+
+  if (::flock(shm_fd_, LOCK_EX) != 0) {
+    ::close(shm_fd_);
+    shm_fd_ = -1;
+    return false;
+  }
+
+  if (created &&
+      ::ftruncate(shm_fd_, static_cast<off_t>(sizeof(KvShmHeader))) != 0) {
+    (void)::flock(shm_fd_, LOCK_UN);
+    ::close(shm_fd_);
+    shm_fd_ = -1;
+    return false;
+  }
+
+  void* mapped = ::mmap(nullptr, sizeof(KvShmHeader), PROT_READ | PROT_WRITE,
+                        MAP_SHARED, shm_fd_, 0);
+  if (mapped == MAP_FAILED) {
+    (void)::flock(shm_fd_, LOCK_UN);
+    ::close(shm_fd_);
+    shm_fd_ = -1;
+    return false;
+  }
+  shm_ = reinterpret_cast<KvShmHeader*>(mapped);
+
+  bool need_init = created || shm_->magic != kShmMagic ||
+                   shm_->version != kShmVersion ||
+                   shm_->slot_capacity != kMaxSlots;
+  if (need_init) {
+    shm_->magic = kShmMagic;
+    shm_->version = kShmVersion;
+    shm_->slot_capacity = kMaxSlots;
+    shm_->recovery_epoch = 1;
+    shm_->write_seq = 0;
+    shm_->owner_pid = static_cast<uint32_t>(::getpid());
+    shm_->used_slots = 0;
+    shm_->first_free_hint = 0;
+    shm_->reserved0 = 0;
+    for (uint32_t i = 0; i < kMaxSlots; ++i) {
+      shm_->slots[i] = KvSlot{};
+    }
+
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_setpshared(&attr, PTHREAD_PROCESS_SHARED);
+#ifdef PTHREAD_MUTEX_ROBUST
+    pthread_mutexattr_setrobust(&attr, PTHREAD_MUTEX_ROBUST);
+#endif
+    pthread_mutex_init(&shm_->mu, &attr);
+    pthread_mutexattr_destroy(&attr);
+    sem_init(&shm_->notify_sem, 1, 0);
+  } else {
+    if (!lock_store()) {
+      (void)::flock(shm_fd_, LOCK_UN);
+      ::munmap(shm_, sizeof(KvShmHeader));
+      shm_ = nullptr;
+      ::close(shm_fd_);
+      shm_fd_ = -1;
       return false;
     }
-    // n < 0
+    shm_->recovery_epoch += 1;
+    shm_->owner_pid = static_cast<uint32_t>(::getpid());
+    rebuild_metadata_locked();
+    unlock_store();
+  }
+
+  (void)::flock(shm_fd_, LOCK_UN);
+  return true;
+}
+
+void ShmExchanger::close_shared_store() {
+  slot_index_cache_.clear();
+  if (shm_) {
+    ::munmap(shm_, sizeof(KvShmHeader));
+    shm_ = nullptr;
+  }
+  if (shm_fd_ >= 0) {
+    ::close(shm_fd_);
+    shm_fd_ = -1;
+  }
+}
+
+bool ShmExchanger::put_encoded(std::string_view key, std::string_view value,
+                               bool mark_relayed) {
+  if (!shm_) return false;
+  if (key.empty() || key.size() >= kMaxKeyBytes) return false;
+  if (value.size() >= kMaxValueBytes) return false;
+  if (!lock_store()) return false;
+
+  int slot_idx = find_slot_locked(key);
+  if (slot_idx < 0) {
+    if (shm_->used_slots >= shm_->slot_capacity) {
+      unlock_store();
+      return false;
+    }
+    slot_idx = find_free_slot_locked();
+  }
+  if (slot_idx < 0) {
+    unlock_store();
+    return false;
+  }
+
+  auto& slot = shm_->slots[static_cast<size_t>(slot_idx)];
+  bool const is_new_slot = slot.state != kSlotUsed;
+  slot.state = kSlotUsed;
+  slot.relayed = mark_relayed ? 1 : 0;
+  slot.write_seq = ++shm_->write_seq;
+  slot.key_len = static_cast<uint32_t>(key.size());
+  slot.value_len = static_cast<uint32_t>(value.size());
+  std::memset(slot.key, 0, sizeof(slot.key));
+  std::memset(slot.value, 0, sizeof(slot.value));
+  std::memcpy(slot.key, key.data(), key.size());
+  std::memcpy(slot.value, value.data(), value.size());
+  if (is_new_slot) {
+    shm_->used_slots += 1;
+  }
+  if (static_cast<uint32_t>(slot_idx) == shm_->first_free_hint) {
+    shm_->first_free_hint = static_cast<uint32_t>((slot_idx + 1) %
+                                                  shm_->slot_capacity);
+  }
+  slot_index_cache_[std::string(key)] = static_cast<uint32_t>(slot_idx);
+  unlock_store();
+  maybe_post_sem();
+  return true;
+}
+
+size_t ShmExchanger::collect_entries(
+    std::vector<std::pair<std::string, std::string>>& out, size_t max_items,
+    size_t start_index, bool only_unrelayed) const {
+  out.clear();
+  if (!shm_ || max_items == 0) return 0;
+  if (!lock_store()) return 0;
+
+  size_t const slot_count = shm_->slot_capacity;
+  if (slot_count == 0) {
+    unlock_store();
+    return 0;
+  }
+
+  size_t const begin = start_index % slot_count;
+  for (size_t visited = 0; visited < slot_count && out.size() < max_items;
+       ++visited) {
+    size_t const index = (begin + visited) % slot_count;
+    auto const& slot = shm_->slots[index];
+    if (slot.state != kSlotUsed) continue;
+    if (only_unrelayed && slot.relayed) continue;
+    out.emplace_back(std::string(slot.key, slot.key + slot.key_len),
+                     std::string(slot.value, slot.value + slot.value_len));
+  }
+  unlock_store();
+  return out.size();
+}
+
+bool ShmExchanger::wait_for_update(int delay_ms) const {
+  if (!shm_) return false;
+  if (delay_ms <= 0) delay_ms = 1;
+
+  auto deadline = std::chrono::system_clock::now() +
+                  std::chrono::milliseconds(delay_ms);
+  auto sec = std::chrono::time_point_cast<std::chrono::seconds>(deadline);
+  auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(deadline -
+                                                                   sec)
+                  .count();
+  struct timespec ts {};
+  ts.tv_sec = static_cast<time_t>(sec.time_since_epoch().count());
+  ts.tv_nsec = static_cast<long>(nsec);
+
+  while (true) {
+    if (sem_timedwait(&shm_->notify_sem, &ts) == 0) return true;
     if (errno == EINTR) continue;
-    if (errno == EAGAIN || errno == EWOULDBLOCK) {
-      // timed out; check running flag again
+    if (errno == ETIMEDOUT) return false;
+    return false;
+  }
+}
+
+int ShmExchanger::find_slot_locked(std::string_view key) const {
+  if (!shm_) return -1;
+  auto const cache_it = slot_index_cache_.find(std::string(key));
+  if (cache_it != slot_index_cache_.end()) {
+    uint32_t const idx = cache_it->second;
+    if (idx < shm_->slot_capacity) {
+      auto const& slot = shm_->slots[idx];
+      if (slot.state == kSlotUsed && slot.key_len == key.size() &&
+          std::memcmp(slot.key, key.data(), key.size()) == 0) {
+        return static_cast<int>(idx);
+      }
+    }
+    slot_index_cache_.erase(cache_it);
+  }
+  for (uint32_t i = 0; i < shm_->slot_capacity; ++i) {
+    auto const& slot = shm_->slots[i];
+    if (slot.state != kSlotUsed || slot.key_len != key.size()) continue;
+    if (std::memcmp(slot.key, key.data(), key.size()) == 0) {
+      slot_index_cache_[std::string(key)] = i;
+      return static_cast<int>(i);
+    }
+  }
+  return -1;
+}
+
+int ShmExchanger::find_free_slot_locked() const {
+  if (!shm_) return -1;
+  for (uint32_t offset = 0; offset < shm_->slot_capacity; ++offset) {
+    uint32_t const index = (shm_->first_free_hint + offset) % shm_->slot_capacity;
+    if (shm_->slots[index].state != kSlotUsed) return static_cast<int>(index);
+  }
+  return -1;
+}
+
+void ShmExchanger::rebuild_metadata_locked() {
+  if (!shm_) return;
+  slot_index_cache_.clear();
+  shm_->used_slots = 0;
+  shm_->first_free_hint = 0;
+  uint64_t max_write_seq = 0;
+  bool found_free_slot = false;
+  for (uint32_t i = 0; i < shm_->slot_capacity; ++i) {
+    auto const& slot = shm_->slots[i];
+    if (slot.state != kSlotUsed) {
+      if (!found_free_slot) {
+        shm_->first_free_hint = i;
+        found_free_slot = true;
+      }
       continue;
     }
-    return false;
+    shm_->used_slots += 1;
+    slot_index_cache_[std::string(slot.key, slot.key + slot.key_len)] = i;
+    if (slot.write_seq > max_write_seq) max_write_seq = slot.write_seq;
   }
+  if (!found_free_slot) {
+    shm_->first_free_hint = 0;
+  }
+  shm_->write_seq = std::max(shm_->write_seq, max_write_seq);
+}
+
+bool ShmExchanger::lock_store() const {
+  if (!shm_) return false;
+  int rc = pthread_mutex_lock(&shm_->mu);
+  if (rc == 0) return true;
+#ifdef EOWNERDEAD
+  if (rc == EOWNERDEAD) {
+    (void)pthread_mutex_consistent(&shm_->mu);
+    return true;
+  }
+#endif
   return false;
 }
 
-static std::vector<std::string> split_tokens(std::string const& s) {
-  std::istringstream iss(s);
-  std::vector<std::string> toks;
-  std::string t;
-  while (iss >> t) toks.push_back(t);
-  return toks;
+void ShmExchanger::unlock_store() const {
+  if (!shm_) return;
+  (void)pthread_mutex_unlock(&shm_->mu);
 }
 
-static void add_conn_thread(std::vector<std::thread>& vec, std::mutex& mtx,
-                            std::thread&& t) {
-  std::lock_guard<std::mutex> lk(mtx);
-  vec.emplace_back(std::move(t));
+void ShmExchanger::maybe_post_sem() const {
+  if (!shm_) return;
+  (void)sem_post(&shm_->notify_sem);
 }
 
-/* ----------------- Forward decl for friend ----------------- */
-static void handle_connection_inner(
-    int connfd,
-    std::unordered_map<std::string, std::map<std::string, std::string>>& store,
-    std::mutex& store_mutex, std::atomic<bool>& running,
-    size_t max_line_bytes) {
-  try {
-    std::string line;
-    while (running.load(std::memory_order_relaxed)) {
-      if (!recv_line_capped(connfd, line, max_line_bytes, running)) break;
-
-      auto toks = split_tokens(line);
-      if (toks.empty()) {
-        char const* r = "ERR\n";
-        send_all_robust(connfd, r, ::strlen(r));
-        continue;
-      }
-      std::string const& cmd = toks[0];
-
-      if (cmd == "HSET") {
-        if (toks.size() < 4 || ((toks.size() - 2) % 2 != 0)) {
-          char const* r = "ERR\n";
-          send_all_robust(connfd, r, ::strlen(r));
-          continue;
-        }
-        std::string const& key = toks[1];
-        {
-          std::lock_guard<std::mutex> lk(store_mutex);
-          auto& mp = store[key];
-          for (size_t i = 2; i + 1 < toks.size(); i += 2) {
-            mp[toks[i]] = toks[i + 1];
-          }
-        }
-        char const* r = "OK\n";
-        send_all_robust(connfd, r, ::strlen(r));
-      } else if (cmd == "HGETALL") {
-        if (toks.size() != 2) {
-          char const* r = "ERR\n";
-          send_all_robust(connfd, r, ::strlen(r));
-          continue;
-        }
-        std::string const& key = toks[1];
-        std::ostringstream oss;
-        {
-          std::lock_guard<std::mutex> lk(store_mutex);
-          auto it = store.find(key);
-          if (it == store.end()) {
-            char const* r = "EMPTY\n";
-            send_all_robust(connfd, r, ::strlen(r));
-            continue;
-          } else {
-            auto const& mp = it->second;
-            oss << "ARRAY " << mp.size();
-            for (auto const& p : mp) {
-              oss << " " << p.first << " " << p.second;
-            }
-            oss << "\n";
-          }
-        }
-        const std::string resp = oss.str();
-        send_all_robust(connfd, resp.c_str(), resp.size());
-      } else {
-        char const* r = "ERR\n";
-        send_all_robust(connfd, r, ::strlen(r));
-      }
-    }
-  } catch (std::exception const& e) {
-    std::cerr << "[EXCEPTION] handle_connection_inner: " << e.what() << "\n";
-  } catch (...) {
-    std::cerr << "[EXCEPTION] handle_connection_inner: unknown\n";
-  }
-
-  ::shutdown(connfd, SHUT_RDWR);
-  ::close(connfd);
-}
-
-void handle_connection(
-    int connfd,
-    std::unordered_map<std::string, std::map<std::string, std::string>>& store,
-    std::mutex& store_mutex, std::atomic<bool>& running, size_t max_line_bytes,
-    std::function<void(std::thread&&)> register_thread) {
-  std::thread t(handle_connection_inner, connfd, std::ref(store),
-                std::ref(store_mutex), std::ref(running), max_line_bytes);
-  register_thread(std::move(t));
-}
-
-/* ----------------- SockExchanger implementation ----------------- */
-
-SockExchanger::SockExchanger(bool is_server, std::string const& host, int port,
-                             int timeout_ms, size_t max_line_bytes)
-    : sock_fd_(-1),
-      host_(host),
+SocketExchanger::SocketExchanger(bool is_root, std::string host, int port,
+                                 int timeout_ms, size_t max_line_bytes,
+                                 ReceiveCallback on_receive)
+    : host_(std::move(host)),
       port_(port),
       timeout_ms_(timeout_ms),
-      is_server_(is_server),
-      listen_fd_(-1),
-      running_(false),
-      max_line_bytes_(max_line_bytes) {
-  if (is_server_) {
-    if (!start_server()) {
-      std::cerr << "SockExchanger: failed to start server on port " << port_
-                << "\n";
+      is_root_(is_root),
+      max_line_bytes_(max_line_bytes),
+      on_receive_(std::move(on_receive)) {}
+
+SocketExchanger::~SocketExchanger() {
+  running_.store(false, std::memory_order_release);
+  ready_cv_.notify_all();
+  pending_cv_.notify_all();
+  (void)notify_root_wakeup();
+  if (listen_fd_ >= 0) {
+    ::shutdown(listen_fd_, SHUT_RDWR);
+  }
+  {
+    std::lock_guard<std::mutex> lk(upstream_mu_);
+    if (upstream_fd_ >= 0) {
+      ::shutdown(upstream_fd_, SHUT_RDWR);
     }
-  } else {
-    int count = 0;
-    while (!running_.load(std::memory_order_relaxed) && count <= 10) {
-      if (connect_client()) {
-        std::cout << "SockExchanger: connect to " << host_ << ":" << port_
-                  << " success.\n";
-        break;
-      }
-      std::cout << "SockExchanger: connect to " << host_ << ":" << port_
-                << " failed (errno=" << errno << "). Retrying...\n";
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-      ++count;
-    }
-    if (!running_.load(std::memory_order_relaxed)) {
-      std::cerr << "SockExchanger: failed to connect to " << host_ << ":"
-                << port_ << " after " << count << " attempts.\n";
+  }
+  if (upstream_thread_.joinable()) upstream_thread_.join();
+  if (server_thread_.joinable()) server_thread_.join();
+  stop_root_server();
+
+  {
+    std::lock_guard<std::mutex> lk(upstream_mu_);
+    close_upstream_locked();
+  }
+
+  {
+    std::lock_guard<std::mutex> lk(peers_mu_);
+    for (auto const& [fd, _] : peers_) {
+      (void)_;
+      ::shutdown(fd, SHUT_RDWR);
     }
   }
 }
 
-SockExchanger::~SockExchanger() {
-  // orderly shutdown
+bool SocketExchanger::valid() const {
+  return started_.load(std::memory_order_acquire) &&
+         running_.load(std::memory_order_acquire);
+}
+
+bool SocketExchanger::start() {
+  if (started_.exchange(true, std::memory_order_acq_rel)) return valid();
+  running_.store(true, std::memory_order_release);
+  if (is_root_) {
+    if (!start_root_server()) {
+      running_.store(false, std::memory_order_release);
+      ready_.store(false, std::memory_order_release);
+      return false;
+    }
+    ready_.store(true, std::memory_order_release);
+    connection_epoch_.fetch_add(1, std::memory_order_acq_rel);
+    ready_cv_.notify_all();
+    return true;
+  }
+  upstream_thread_ = std::thread(&SocketExchanger::upstream_loop, this);
+  if (wait_until_ready(timeout_ms_)) return true;
+
+  running_.store(false, std::memory_order_release);
+  ready_cv_.notify_all();
+  pending_cv_.notify_all();
+  {
+    std::lock_guard<std::mutex> lk(upstream_mu_);
+    if (upstream_fd_ >= 0) {
+      ::shutdown(upstream_fd_, SHUT_RDWR);
+    }
+  }
+  if (upstream_thread_.joinable()) upstream_thread_.join();
+  {
+    std::lock_guard<std::mutex> lk(upstream_mu_);
+    close_upstream_locked();
+  }
+  started_.store(false, std::memory_order_release);
+  return false;
+}
+
+uint64_t SocketExchanger::connection_epoch() const {
+  return connection_epoch_.load(std::memory_order_acquire);
+}
+
+bool SocketExchanger::put_raw(std::string_view key, std::string_view value) {
+  if (!running_.load(std::memory_order_acquire)) return false;
+  if (is_root_ && !ready_.load(std::memory_order_acquire)) return false;
+
+  std::string key_copy(key);
+  std::string value_copy(value);
+  {
+    std::lock_guard<std::mutex> lk(entries_mu_);
+    entries_[key_copy] = value_copy;
+  }
+  if (is_root_) {
+    root_broadcast_pub(key_copy, value_copy, -1);
+    return true;
+  }
+  {
+    std::lock_guard<std::mutex> lk(pending_mu_);
+    pending_pubs_.emplace_back(std::move(key_copy), std::move(value_copy));
+  }
+  pending_cv_.notify_all();
+  return running_.load(std::memory_order_acquire);
+}
+
+bool SocketExchanger::get_raw(std::string_view key, std::string& value) {
+  std::lock_guard<std::mutex> lk(entries_mu_);
+  auto it = entries_.find(std::string(key));
+  if (it == entries_.end()) return false;
+  value = it->second;
+  return true;
+}
+
+bool SocketExchanger::start_root_server() {
+  listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (listen_fd_ < 0) return false;
+
+  int opt = 1;
+  (void)::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+  (void)::fcntl(listen_fd_, F_SETFL, O_NONBLOCK);
+
+  sockaddr_in addr {};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(static_cast<uint16_t>(port_));
+  if (::bind(listen_fd_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) !=
+      0) {
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return false;
+  }
+  if (::listen(listen_fd_, 64) != 0) {
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return false;
+  }
+  int wake_pipe[2] = {-1, -1};
+  if (::pipe(wake_pipe) != 0) {
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return false;
+  }
+  int const wake_read_flags = ::fcntl(wake_pipe[0], F_GETFL, 0);
+  int const wake_write_flags = ::fcntl(wake_pipe[1], F_GETFL, 0);
+  if (wake_read_flags < 0 || wake_write_flags < 0 ||
+      ::fcntl(wake_pipe[0], F_SETFL, wake_read_flags | O_NONBLOCK) != 0 ||
+      ::fcntl(wake_pipe[1], F_SETFL, wake_write_flags | O_NONBLOCK) != 0) {
+    ::close(wake_pipe[0]);
+    ::close(wake_pipe[1]);
+    ::close(listen_fd_);
+    listen_fd_ = -1;
+    return false;
+  }
+  root_wakeup_read_fd_ = wake_pipe[0];
+  root_wakeup_write_fd_ = wake_pipe[1];
   try {
-    running_.store(false, std::memory_order_relaxed);
-
-    // Break accept()
-    if (listen_fd_ != -1) {
-      ::shutdown(listen_fd_, SHUT_RDWR);
-    }
-
-    // Give the accept loop a brief moment to observe running_=false
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    // Close listening socket
-    if (listen_fd_ != -1) {
-      ::close(listen_fd_);
-      listen_fd_ = -1;
-    }
-
-    // Close client socket if any
-    if (sock_fd_ != -1) {
-      ::shutdown(sock_fd_, SHUT_RDWR);
-      ::close(sock_fd_);
-      sock_fd_ = -1;
-    }
-
-    // Join accept thread
-    if (server_thread_.joinable()) server_thread_.join();
-
-    // Join all connection handler threads
-    {
-      std::lock_guard<std::mutex> lk(conn_threads_mutex_);
-      for (auto& t : conn_threads_) {
-        if (t.joinable()) t.join();
-      }
-      conn_threads_.clear();
-    }
+    server_thread_ = std::thread(&SocketExchanger::root_accept_loop, this);
   } catch (...) {
-    // do not throw in destructor
-    std::cerr << "[WARN] SockExchanger::~SockExchanger caught exception during "
-                 "shutdown\n";
+    stop_root_server();
+    return false;
+  }
+  return true;
+}
+
+void SocketExchanger::stop_root_server() {
+  if (root_wakeup_write_fd_ >= 0) {
+    ::close(root_wakeup_write_fd_);
+    root_wakeup_write_fd_ = -1;
+  }
+  if (root_wakeup_read_fd_ >= 0) {
+    ::close(root_wakeup_read_fd_);
+    root_wakeup_read_fd_ = -1;
+  }
+  if (listen_fd_ >= 0) {
+    ::shutdown(listen_fd_, SHUT_RDWR);
+    ::close(listen_fd_);
+    listen_fd_ = -1;
   }
 }
 
-bool SockExchanger::valid() const {
-  if (!running_.load(std::memory_order_relaxed)) return false;
-  if (is_server_) return listen_fd_ != -1;
-  return sock_fd_ != -1;
-}
+void SocketExchanger::root_accept_loop() {
+  int epoll_fd = ::epoll_create1(EPOLL_CLOEXEC);
+  if (epoll_fd < 0) return;
 
-bool SockExchanger::send_cmd_and_recv(std::string const& cmd,
-                                      std::string& resp) {
-  if (sock_fd_ == -1) return false;
-  std::string out = cmd;
-  if (out.empty() || out.back() != '\n') out.push_back('\n');
-  if (send_all_robust(sock_fd_, out.c_str(), out.size()) <= 0) return false;
-  return recv_line_capped(sock_fd_, resp, max_line_bytes_, running_);
-}
+  auto set_peer_events = [&](int fd, bool want_write) -> bool {
+    epoll_event ev {};
+    ev.events = EPOLLIN | EPOLLRDHUP | (want_write ? EPOLLOUT : 0);
+    ev.data.fd = fd;
+    return ::epoll_ctl(epoll_fd, EPOLL_CTL_MOD, fd, &ev) == 0;
+  };
 
-bool SockExchanger::publish(std::string const& key, Exchangeable const& obj) {
-  auto kv = obj.to_map();
+  auto add_epoll_in = [&](int fd) -> bool {
+    epoll_event ev {};
+    ev.events = EPOLLIN | EPOLLRDHUP;
+    ev.data.fd = fd;
+    return ::epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &ev) == 0;
+  };
 
-  // Build command: HSET key f1 v1 f2 v2 ... (no spaces in fields/values)
-  std::ostringstream oss;
-  oss << "HSET " << key;
-  for (auto const& p : kv) {
-    oss << " " << p.first << " " << p.second;
-  }
-  std::string cmd = oss.str();
+  auto sync_peer_interest = [&](std::shared_ptr<PeerConn> const& peer) -> bool {
+    bool want_write = false;
+    {
+      std::lock_guard<std::mutex> send_lk(peer->send_mu);
+      want_write = !peer->write_buffer.empty();
+    }
+    return set_peer_events(peer->fd, want_write);
+  };
 
-  if (is_server_) {
-    std::lock_guard<std::mutex> lk(store_mutex_);
-    auto& mp = store_[key];
-    for (auto const& p : kv) mp[p.first] = p.second;
-    return true;
-  } else {
-    std::string resp;
-    if (!send_cmd_and_recv(cmd, resp)) return false;
-    return resp.rfind("OK", 0) == 0;
-  }
-}
-
-bool SockExchanger::fetch(std::string const& key, Exchangeable& obj) {
-  if (is_server_) {
-    std::lock_guard<std::mutex> lk(store_mutex_);
-    auto it = store_.find(key);
-    if (it == store_.end()) return false;
-    obj.from_map(it->second);
-    return true;
-  } else {
-    std::string cmd = "HGETALL " + key;
-    std::string resp;
-    if (!send_cmd_and_recv(cmd, resp)) return false;
-    if (resp.rfind("EMPTY", 0) == 0) return false;
-    if (resp.rfind("ARRAY ", 0) == 0) {
-      // format: ARRAY <n> f1 v1 f2 v2 ...
-      std::istringstream iss(resp);
-      std::string tag;
-      size_t n;
-      iss >> tag >> n;
-      std::map<std::string, std::string> kv;
-      for (size_t i = 0; i < n; ++i) {
-        std::string f, v;
-        if (!(iss >> f >> v)) return false;
-        kv[f] = v;
+  auto process_pending_interests = [&]() {
+    std::vector<int> pending_interest_fds;
+    drain_root_peer_write_interest(pending_interest_fds);
+    for (int pending_fd : pending_interest_fds) {
+      std::shared_ptr<PeerConn> pending_peer;
+      {
+        std::lock_guard<std::mutex> lk(peers_mu_);
+        auto it = peers_.find(pending_fd);
+        if (it != peers_.end()) pending_peer = it->second;
       }
-      obj.from_map(kv);
-      return true;
+      if (!pending_peer) continue;
+      if (!sync_peer_interest(pending_peer)) {
+        close_root_peer(pending_fd);
+      }
     }
-    return false;
+  };
+
+  if (listen_fd_ < 0 || root_wakeup_read_fd_ < 0 || !add_epoll_in(listen_fd_) ||
+      !add_epoll_in(root_wakeup_read_fd_)) {
+    ::close(epoll_fd);
+    return;
+  }
+
+  constexpr int kMaxEvents = 64;
+  epoll_event events[kMaxEvents];
+  while (running_.load(std::memory_order_acquire)) {
+    process_pending_interests();
+
+    int const ready_count =
+        ::epoll_wait(epoll_fd, events, kMaxEvents, kRootAcceptPollMs);
+    if (ready_count < 0) {
+      if (errno == EINTR) continue;
+      break;
+    }
+    for (int i = 0; i < ready_count; ++i) {
+      int const fd = events[i].data.fd;
+      uint32_t const ev = events[i].events;
+      if (fd == listen_fd_) {
+        while (running_.load(std::memory_order_acquire)) {
+          sockaddr_in cli {};
+          socklen_t len = sizeof(cli);
+          int conn_fd =
+              ::accept(listen_fd_, reinterpret_cast<sockaddr*>(&cli), &len);
+          if (conn_fd < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+              break;
+            }
+            break;
+          }
+          int const current_flags = ::fcntl(conn_fd, F_GETFL, 0);
+          if (current_flags < 0 ||
+              ::fcntl(conn_fd, F_SETFL, current_flags | O_NONBLOCK) != 0) {
+            ::shutdown(conn_fd, SHUT_RDWR);
+            ::close(conn_fd);
+            continue;
+          }
+          auto peer = std::make_shared<PeerConn>();
+          peer->fd = conn_fd;
+          {
+            std::lock_guard<std::mutex> lk(peers_mu_);
+            peers_[conn_fd] = peer;
+          }
+          if (!add_epoll_in(conn_fd)) {
+            close_root_peer(conn_fd);
+            continue;
+          }
+        }
+        continue;
+      }
+      if (fd == root_wakeup_read_fd_) {
+        char buf[128];
+        while (::read(root_wakeup_read_fd_, buf, sizeof(buf)) > 0) {
+        }
+        process_pending_interests();
+        continue;
+      }
+
+      if (ev & (EPOLLERR | EPOLLHUP | EPOLLRDHUP)) {
+        close_root_peer(fd);
+        continue;
+      }
+      if (!(ev & (EPOLLIN | EPOLLOUT))) continue;
+
+      std::shared_ptr<PeerConn> peer;
+      {
+        std::lock_guard<std::mutex> lk(peers_mu_);
+        auto it = peers_.find(fd);
+        if (it != peers_.end()) peer = it->second;
+      }
+      if (!peer) continue;
+
+      bool close_peer_now = false;
+      if (ev & EPOLLOUT) {
+        std::lock_guard<std::mutex> send_lk(peer->send_mu);
+        if (!peer->write_buffer.empty() &&
+            !flush_write_buffer_locked(fd, peer->write_buffer) &&
+            errno != EAGAIN && errno != EWOULDBLOCK) {
+          close_peer_now = true;
+        }
+      }
+      if (close_peer_now) {
+        close_root_peer(fd);
+        continue;
+      }
+
+      for (;;) {
+        std::string frame;
+        bool const got_frame =
+            recv_frame_buffered(fd, peer->read_buffer, frame, 0);
+        if (!got_frame) {
+          if (errno == EAGAIN || errno == EWOULDBLOCK) break;
+          close_peer_now = true;
+          break;
+        }
+        SocketFrame decoded;
+        if (!decode_socket_frame(frame, decoded)) continue;
+        if (decoded.type == SocketFrameType::SyncRequest) {
+          std::vector<std::pair<std::string, std::string>> snapshot;
+          snapshot_entries(snapshot);
+          bool snapshot_ok = true;
+          bool need_write_interest = false;
+          {
+            std::lock_guard<std::mutex> send_lk(peer->send_mu);
+            for (auto const& entry : snapshot) {
+              std::string publish_frame;
+              if (!encode_socket_frame(SocketFrame{SocketFrameType::Publish,
+                                                   entry.first, entry.second},
+                                       publish_frame) ||
+                  !enqueue_frame_locked(peer->write_buffer, publish_frame)) {
+                snapshot_ok = false;
+                break;
+              }
+            }
+            if (snapshot_ok) {
+              std::string sync_done_frame;
+              snapshot_ok = encode_socket_frame(
+                                SocketFrame{SocketFrameType::SyncDone, {}, {}},
+                                sync_done_frame) &&
+                            enqueue_frame_locked(peer->write_buffer,
+                                                 sync_done_frame);
+            }
+            if (snapshot_ok && !peer->write_buffer.empty() &&
+                !flush_write_buffer_locked(fd, peer->write_buffer) &&
+                errno != EAGAIN && errno != EWOULDBLOCK) {
+              snapshot_ok = false;
+            }
+            need_write_interest = !peer->write_buffer.empty();
+          }
+          if (snapshot_ok && need_write_interest) {
+            queue_root_peer_write_interest(peer->fd);
+          }
+          if (!snapshot_ok) {
+            close_peer_now = true;
+            break;
+          }
+          if (!sync_peer_interest(peer)) {
+            close_peer_now = true;
+            break;
+          }
+          continue;
+        }
+        if (decoded.type == SocketFrameType::Publish) {
+          handle_publish(decoded.key, decoded.value, /*broadcast_from_root=*/true,
+                         fd);
+        }
+      }
+      if (close_peer_now) {
+        close_root_peer(fd);
+      } else if (!sync_peer_interest(peer)) {
+        close_root_peer(fd);
+      }
+    }
+  }
+
+  std::vector<int> stale_fds;
+  {
+    std::lock_guard<std::mutex> lk(peers_mu_);
+    stale_fds.reserve(peers_.size());
+    for (auto const& [fd, _] : peers_) stale_fds.push_back(fd);
+  }
+  for (int fd : stale_fds) {
+    close_root_peer(fd);
+  }
+  ::close(epoll_fd);
+}
+
+void SocketExchanger::root_broadcast_pub(std::string const& key,
+                                         std::string const& value,
+                                         int exclude_fd) {
+  std::vector<std::shared_ptr<PeerConn>> peers;
+  std::vector<int> stale_fds;
+  std::vector<int> activate_write_fds;
+  {
+    std::lock_guard<std::mutex> lk(peers_mu_);
+    peers.reserve(peers_.size());
+    for (auto const& [fd, peer] : peers_) {
+      if (fd == exclude_fd) continue;
+      peers.push_back(peer);
+    }
+  }
+
+  std::string frame;
+  if (!encode_socket_frame(
+          SocketFrame{SocketFrameType::Publish, key, value}, frame)) {
+    return;
+  }
+  for (auto const& peer : peers) {
+    std::lock_guard<std::mutex> lk(peer->send_mu);
+    bool const was_empty = peer->write_buffer.empty();
+    if (!enqueue_frame_locked(peer->write_buffer, frame)) {
+      stale_fds.push_back(peer->fd);
+      continue;
+    }
+    if (!peer->write_buffer.empty() &&
+        !flush_write_buffer_locked(peer->fd, peer->write_buffer) &&
+        errno != EAGAIN && errno != EWOULDBLOCK) {
+      stale_fds.push_back(peer->fd);
+      continue;
+    }
+    if (was_empty && !peer->write_buffer.empty()) {
+      activate_write_fds.push_back(peer->fd);
+    }
+  }
+  for (int fd : activate_write_fds) {
+    queue_root_peer_write_interest(fd);
+  }
+
+  if (!stale_fds.empty()) {
+    for (int fd : stale_fds) {
+      close_root_peer(fd);
+    }
+  }
+  (void)notify_root_wakeup();
+}
+
+void SocketExchanger::close_root_peer(int fd) {
+  std::shared_ptr<PeerConn> peer;
+  {
+    std::lock_guard<std::mutex> lk(peers_mu_);
+    auto it = peers_.find(fd);
+    if (it == peers_.end()) return;
+    peer = it->second;
+    peers_.erase(it);
+  }
+  if (peer) {
+    std::lock_guard<std::mutex> send_lk(peer->send_mu);
+    peer->write_buffer.clear();
+    peer->read_buffer.clear();
+  }
+  {
+    std::lock_guard<std::mutex> lk(root_pending_mu_);
+    root_pending_write_interest_set_.erase(fd);
+  }
+  ::shutdown(fd, SHUT_RDWR);
+  ::close(fd);
+}
+
+void SocketExchanger::queue_root_peer_write_interest(int fd) {
+  std::lock_guard<std::mutex> lk(root_pending_mu_);
+  auto const [_, inserted] = root_pending_write_interest_set_.insert(fd);
+  if (!inserted) return;
+  root_pending_write_interest_.push_back(fd);
+}
+
+void SocketExchanger::drain_root_peer_write_interest(std::vector<int>& fds) {
+  fds.clear();
+  std::lock_guard<std::mutex> lk(root_pending_mu_);
+  fds.reserve(root_pending_write_interest_.size());
+  while (!root_pending_write_interest_.empty()) {
+    int const fd = root_pending_write_interest_.front();
+    root_pending_write_interest_.pop_front();
+    root_pending_write_interest_set_.erase(fd);
+    fds.push_back(fd);
   }
 }
 
-bool SockExchanger::wait_and_fetch(std::string const& key, Exchangeable& obj,
-                                   int max_retries, int delay_ms) {
-  if (max_retries > 0) {
-    for (int i = 0; i < max_retries; ++i) {
-      if (!running_.load(std::memory_order_relaxed)) return false;
-      if (fetch(key, obj)) return true;
-      std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
-    }
-  } else {  // -1 => forever but stop if running_ becomes false
-    while (running_.load(std::memory_order_relaxed)) {
-      if (fetch(key, obj)) return true;
-      std::this_thread::sleep_for(std::chrono::milliseconds(delay_ms));
-    }
+bool SocketExchanger::notify_root_wakeup() const {
+  if (root_wakeup_write_fd_ < 0) return false;
+  char one = 1;
+  ssize_t n = ::write(root_wakeup_write_fd_, &one, sizeof(one));
+  return n == static_cast<ssize_t>(sizeof(one)) || errno == EAGAIN ||
+         errno == EWOULDBLOCK;
+}
+
+bool SocketExchanger::enqueue_frame_locked(std::string& write_buffer,
+                                           std::string const& frame) const {
+  if (frame.size() > max_line_bytes_) {
+    errno = EMSGSIZE;
     return false;
+  }
+  if (write_buffer.size() + frame.size() > max_line_bytes_ * 4) {
+    errno = ENOBUFS;
+    return false;
+  }
+  write_buffer.append(frame);
+  return true;
+}
+
+bool SocketExchanger::flush_write_buffer_locked(int fd,
+                                                std::string& write_buffer) const {
+  int send_flags = 0;
+#ifdef MSG_NOSIGNAL
+  send_flags |= MSG_NOSIGNAL;
+#endif
+  while (!write_buffer.empty()) {
+    ssize_t n = ::send(fd, write_buffer.data(), write_buffer.size(), send_flags);
+    if (n > 0) {
+      write_buffer.erase(0, static_cast<size_t>(n));
+      continue;
+    }
+    if (n == 0) {
+      errno = ECONNRESET;
+      return false;
+    }
+    if (errno == EINTR) continue;
+    if (errno == EAGAIN || errno == EWOULDBLOCK) return false;
+    return false;
+  }
+  return true;
+}
+
+bool SocketExchanger::recv_frame_buffered(int fd, std::string& buffer,
+                                          std::string& frame,
+                                          int timeout_ms) const {
+  auto extract_frame = [&]() -> bool {
+    if (buffer.size() < sizeof(uint32_t)) return false;
+    size_t pos = 0;
+    uint32_t payload_len = 0;
+    if (!read_net_u32(buffer, pos, payload_len)) return false;
+    if (payload_len > max_line_bytes_) {
+      errno = EMSGSIZE;
+      return false;
+    }
+    if (buffer.size() < sizeof(uint32_t) + payload_len) return false;
+    frame.assign(buffer.data() + sizeof(uint32_t), payload_len);
+    buffer.erase(0, sizeof(uint32_t) + payload_len);
+    return true;
+  };
+
+  if (extract_frame()) return true;
+
+  while (running_.load(std::memory_order_acquire)) {
+    if (timeout_ms > 0) {
+      pollfd pfd {};
+      pfd.fd = fd;
+      pfd.events = POLLIN;
+      int rc = ::poll(&pfd, 1, timeout_ms);
+      if (rc == 0) {
+        errno = EAGAIN;
+        return false;
+      }
+      if (rc < 0) {
+        if (errno == EINTR) continue;
+        return false;
+      }
+      if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+        errno = ECONNRESET;
+        return false;
+      }
+      if (!(pfd.revents & POLLIN)) {
+        errno = EAGAIN;
+        return false;
+      }
+    }
+
+    char chunk[4096];
+    ssize_t n = ::recv(fd, chunk, sizeof(chunk), 0);
+    if (n == 0) {
+      errno = ECONNRESET;
+      return false;
+    }
+    if (n < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    buffer.append(chunk, chunk + n);
+    if (buffer.size() > max_line_bytes_ * 2) {
+      errno = EMSGSIZE;
+      return false;
+    }
+    if (extract_frame()) return true;
+    if (timeout_ms == 0) {
+      errno = EAGAIN;
+      return false;
+    }
   }
   return false;
 }
 
-bool SockExchanger::connect_client() {
+bool SocketExchanger::connect_upstream_locked() {
+  if (upstream_fd_ >= 0) return true;
+
   int fd = ::socket(AF_INET, SOCK_STREAM, 0);
-  if (fd < 0) {
-    std::cerr << "SockExchanger: socket() failed: " << std::strerror(errno)
-              << "\n";
+  if (fd < 0) return false;
+
+  sockaddr_in addr {};
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(static_cast<uint16_t>(port_));
+  if (::inet_pton(AF_INET, host_.c_str(), &addr.sin_addr) <= 0) {
+    ::close(fd);
     return false;
   }
-
-  // set timeouts
-  struct timeval tv;
-  tv.tv_sec = timeout_ms_ / 1000;
-  tv.tv_usec = (timeout_ms_ % 1000) * 1000;
-  ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, (char const*)&tv, sizeof tv);
-  ::setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, (char const*)&tv, sizeof tv);
-
-  struct sockaddr_in serv {};
-  serv.sin_family = AF_INET;
-  serv.sin_port = htons(port_);
-  if (::inet_pton(AF_INET, host_.c_str(), &serv.sin_addr) <= 0) {
+  if (!connect_with_timeout(fd, addr, timeout_ms_)) {
     ::close(fd);
     return false;
   }
 
-  if (::connect(fd, (struct sockaddr*)&serv, sizeof(serv)) < 0) {
-    ::close(fd);
+  upstream_fd_ = fd;
+  upstream_read_buffer_.clear();
+  upstream_write_buffer_.clear();
+  upstream_sync_complete_.store(false, std::memory_order_release);
+  std::string sync_request_frame;
+  if (!encode_socket_frame(SocketFrame{SocketFrameType::SyncRequest, {}, {}},
+                           sync_request_frame) ||
+      !enqueue_frame_locked(upstream_write_buffer_, sync_request_frame)) {
+    close_upstream_locked();
     return false;
   }
-
-  sock_fd_ = fd;
-  running_.store(true, std::memory_order_relaxed);
+  if (!flush_write_buffer_locked(upstream_fd_, upstream_write_buffer_) &&
+      errno != EAGAIN && errno != EWOULDBLOCK) {
+    close_upstream_locked();
+    return false;
+  }
   return true;
 }
 
-bool SockExchanger::start_server() {
-  listen_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
-  if (listen_fd_ < 0) {
-    std::cerr << "SockExchanger: create listen socket failed: "
-              << std::strerror(errno) << "\n";
-    return false;
+void SocketExchanger::close_upstream_locked() {
+  if (upstream_fd_ >= 0) {
+    ::shutdown(upstream_fd_, SHUT_RDWR);
+    ::close(upstream_fd_);
+    upstream_fd_ = -1;
   }
+  upstream_read_buffer_.clear();
+  upstream_write_buffer_.clear();
+  upstream_sync_complete_.store(false, std::memory_order_release);
+  ready_.store(false, std::memory_order_release);
+  ready_cv_.notify_all();
+}
 
-  int opt = 1;
-  ::setsockopt(listen_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+void SocketExchanger::upstream_loop() {
+  while (running_.load(std::memory_order_acquire)) {
+    {
+      std::lock_guard<std::mutex> lk(upstream_mu_);
+      if (upstream_fd_ < 0 && !connect_upstream_locked()) {
+        std::unique_lock<std::mutex> pending_lk(pending_mu_);
+        pending_cv_.wait_for(pending_lk, std::chrono::milliseconds(kSocketPollMs));
+        continue;
+      }
+    }
 
-  struct sockaddr_in addr {};
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = INADDR_ANY;
-  addr.sin_port = htons(port_);
+    for (;;) {
+      bool queued_any = false;
+      {
+        std::lock_guard<std::mutex> lk(pending_mu_);
+        while (!pending_pubs_.empty()) {
+          std::string frame;
+          auto const& pending = pending_pubs_.front();
+          if (!encode_socket_frame(
+                  SocketFrame{SocketFrameType::Publish, pending.first,
+                              pending.second},
+                  frame)) {
+            pending_pubs_.pop_front();
+            continue;
+          }
+          std::lock_guard<std::mutex> upstream_lk(upstream_mu_);
+          if (!enqueue_frame_locked(upstream_write_buffer_, frame)) {
+            if (errno == EMSGSIZE) {
+              // Oversized payload can never be sent; drop it to avoid
+              // head-of-line blocking in pending_pubs_.
+              pending_pubs_.pop_front();
+              continue;
+            }
+            break;
+          }
+          pending_pubs_.pop_front();
+          queued_any = true;
+        }
+      }
+      if (!queued_any) break;
+    }
 
-  if (::bind(listen_fd_, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
-    std::cerr << "SockExchanger: bind failed: " << std::strerror(errno) << "\n";
-    ::close(listen_fd_);
-    listen_fd_ = -1;
-    return false;
-  }
-
-  if (::listen(listen_fd_, 16) < 0) {
-    std::cerr << "SockExchanger: listen failed: " << std::strerror(errno)
-              << "\n";
-    ::close(listen_fd_);
-    listen_fd_ = -1;
-    return false;
-  }
-
-  running_.store(true, std::memory_order_relaxed);
-
-  // background accept loop
-  server_thread_ = std::thread([this]() {
-    try {
-      // default per-connection timeout so recv() can exit when shutting down
-      struct timeval conn_tv;
-      conn_tv.tv_sec = 1;  // 1s
-      conn_tv.tv_usec = 0;
-
-      while (running_.load(std::memory_order_relaxed)) {
-        struct sockaddr_in cli {};
-        socklen_t clilen = sizeof(cli);
-        int conn = ::accept(listen_fd_, (struct sockaddr*)&cli, &clilen);
-        if (conn < 0) {
-          if (!running_.load(std::memory_order_relaxed)) break;
-          if (errno == EINTR) continue;
-          // transient error; small backoff
-          std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::string frame;
+    bool progressed = false;
+    {
+      std::lock_guard<std::mutex> lk(upstream_mu_);
+      if (upstream_fd_ >= 0) {
+        bool const got_buffered_frame =
+            recv_frame_buffered(upstream_fd_, upstream_read_buffer_, frame, 0);
+        if (got_buffered_frame) {
+          progressed = true;
+        } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
+          close_upstream_locked();
           continue;
         }
 
-        // Set timeouts on accepted socket so that recv() can wake up
-        ::setsockopt(conn, SOL_SOCKET, SO_RCVTIMEO, (const char*)&conn_tv,
-                     sizeof conn_tv);
-        ::setsockopt(conn, SOL_SOCKET, SO_SNDTIMEO, (const char*)&conn_tv,
-                     sizeof conn_tv);
-
-        auto registrar = [this](std::thread&& t) {
-          add_conn_thread(this->conn_threads_, this->conn_threads_mutex_,
-                          std::move(t));
-        };
-
-        handle_connection(conn, this->store_, this->store_mutex_,
-                          this->running_, this->max_line_bytes_, registrar);
+        pollfd pfd {};
+        pfd.fd = upstream_fd_;
+        pfd.events = POLLIN;
+        if (!upstream_write_buffer_.empty()) pfd.events |= POLLOUT;
+        if (!progressed) {
+          int rc = ::poll(&pfd, 1, kSocketPollMs);
+          if (rc < 0) {
+            if (errno == EINTR) continue;
+            close_upstream_locked();
+            continue;
+          }
+          if (rc == 0) continue;
+          if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) {
+            close_upstream_locked();
+            continue;
+          }
+          if (pfd.revents & POLLOUT) {
+            if (!flush_write_buffer_locked(upstream_fd_, upstream_write_buffer_) &&
+                errno != EAGAIN && errno != EWOULDBLOCK) {
+              close_upstream_locked();
+              continue;
+            }
+            progressed = true;
+          }
+          if (pfd.revents & POLLIN) {
+            bool const got_frame = recv_frame_buffered(
+                upstream_fd_, upstream_read_buffer_, frame, 0);
+            if (!got_frame && errno != EAGAIN && errno != EWOULDBLOCK) {
+              close_upstream_locked();
+              continue;
+            }
+            progressed = got_frame || progressed;
+          }
+        }
       }
-    } catch (const std::exception& e) {
-      std::cerr << "[EXCEPTION] accept loop: " << e.what() << "\n";
-    } catch (...) {
-      std::cerr << "[EXCEPTION] accept loop: unknown\n";
     }
-  });
 
+    if (!progressed || frame.empty()) {
+      continue;
+    }
+
+    SocketFrame decoded;
+    if (!decode_socket_frame(frame, decoded)) continue;
+    if (decoded.type == SocketFrameType::SyncDone) {
+      if (!upstream_sync_complete_.load(std::memory_order_acquire)) {
+        upstream_sync_complete_.store(true, std::memory_order_release);
+        ready_.store(true, std::memory_order_release);
+        connection_epoch_.fetch_add(1, std::memory_order_acq_rel);
+        ready_cv_.notify_all();
+      }
+      continue;
+    }
+    if (decoded.type == SocketFrameType::Publish) {
+      handle_publish(decoded.key, decoded.value, /*broadcast_from_root=*/false,
+                     -1);
+    }
+  }
+}
+
+void SocketExchanger::handle_publish(std::string const& key,
+                                     std::string const& value,
+                                     bool broadcast_from_root,
+                                     int exclude_fd) {
+  {
+    std::lock_guard<std::mutex> lk(entries_mu_);
+    entries_[key] = value;
+  }
+  if (on_receive_) on_receive_(key, value);
+  if (is_root_ && broadcast_from_root) {
+    root_broadcast_pub(key, value, exclude_fd);
+  }
+}
+
+bool SocketExchanger::wait_until_ready(int timeout_ms) {
+  if (ready_.load(std::memory_order_acquire)) return true;
+  std::unique_lock<std::mutex> lk(ready_mu_);
+  if (timeout_ms <= 0) {
+    ready_cv_.wait(lk, [this] {
+      return !running_.load(std::memory_order_acquire) ||
+             ready_.load(std::memory_order_acquire);
+    });
+  } else {
+    ready_cv_.wait_for(lk, std::chrono::milliseconds(timeout_ms), [this] {
+      return !running_.load(std::memory_order_acquire) ||
+             ready_.load(std::memory_order_acquire);
+    });
+  }
+  return ready_.load(std::memory_order_acquire);
+}
+
+void SocketExchanger::snapshot_entries(
+    std::vector<std::pair<std::string, std::string>>& out) {
+  out.clear();
+  std::lock_guard<std::mutex> lk(entries_mu_);
+  out.reserve(entries_.size());
+  for (auto const& [key, value] : entries_) {
+    out.emplace_back(key, value);
+  }
+}
+
+HierarchicalExchanger::HierarchicalExchanger(bool is_server,
+                                             std::string const& host, int port,
+                                             int timeout_ms,
+                                             size_t max_line_bytes,
+                                             int local_id)
+    : host_(host),
+      port_(port),
+      is_server_(is_server),
+      local_id_(local_id),
+      node_leader_(false) {
+  if (local_id_ < 0) {
+    local_id_ = env_int_or_default("UHM_LOCAL_ID",
+                                   env_int_or_default("LOCAL_RANK", -1));
+  }
+  node_leader_ = is_node_leader();
+
+  std::string const ns = kv_namespace();
+  shm_ = std::make_unique<ShmExchanger>(ns);
+  if (!shm_ || !shm_->valid()) return;
+  // On root startup, clear stale entries in-place in the same shared segment.
+  // This avoids split-brain behavior that can happen with shm_unlink while
+  // other local processes still hold mappings to the previous object.
+  if (is_server_ && env_bool_or_default("UHM_OOB_CLEAN_START", true)) {
+    (void)shm_->reset_for_new_run();
+  }
+
+  running_.store(true, std::memory_order_release);
+  if (node_leader_) {
+    socket_ = std::make_unique<SocketExchanger>(
+        is_server_, host_, port_, timeout_ms, max_line_bytes,
+        [this](std::string const& key, std::string const& value) {
+          apply_remote_entry(key, value);
+        });
+    if (!socket_->start()) {
+      running_.store(false, std::memory_order_release);
+      return;
+    }
+    last_replayed_epoch_ = 0;
+    relay_thread_ = std::thread(&HierarchicalExchanger::relay_loop, this);
+  }
+}
+
+HierarchicalExchanger::~HierarchicalExchanger() {
+  running_.store(false, std::memory_order_release);
+  if (relay_thread_.joinable()) relay_thread_.join();
+}
+
+bool HierarchicalExchanger::valid() const {
+  if (!running_.load(std::memory_order_acquire) || !shm_ || !shm_->valid()) {
+    return false;
+  }
+  if (node_leader_ && (!socket_ || !socket_->valid())) return false;
   return true;
+}
+
+bool HierarchicalExchanger::wait_raw(std::string_view key, std::string& value,
+                                     WaitOptions const& options) {
+  if (!shm_) return false;
+  return shm_->wait_raw(key, value, options);
+}
+
+bool HierarchicalExchanger::put_raw(std::string_view key,
+                                    std::string_view value) {
+  if (!shm_) return false;
+  if (!shm_->put_raw(key, value)) return false;
+  if (node_leader_ && socket_) {
+    if (socket_->put_raw(key, value)) {
+      (void)shm_->mark_relayed(key);
+    }
+  }
+  return true;
+}
+
+bool HierarchicalExchanger::get_raw(std::string_view key, std::string& value) {
+  if (!shm_) return false;
+  return shm_->get_raw(key, value);
+}
+
+bool HierarchicalExchanger::is_node_leader() const {
+  if (local_id_ >= 0) return local_id_ == 0;
+  return is_server_;
+}
+
+void HierarchicalExchanger::relay_loop() {
+  std::vector<std::pair<std::string, std::string>> pending;
+  while (running_.load(std::memory_order_acquire)) {
+    if (!socket_ || !shm_) break;
+    uint64_t const socket_epoch = socket_->connection_epoch();
+    if (socket_epoch != 0 && socket_epoch != last_replayed_epoch_) {
+      replay_local_state();
+      last_replayed_epoch_ = socket_epoch;
+    }
+    if (shm_->collect_unrelayed(pending, 32) == 0) {
+      (void)shm_->wait_for_update(kRelayWaitMs);
+      continue;
+    }
+
+    for (auto const& [key, value] : pending) {
+      if (!socket_->put_raw(key, value)) break;
+      (void)shm_->mark_relayed(key);
+    }
+  }
+}
+
+void HierarchicalExchanger::replay_local_state() {
+  if (!socket_ || !shm_) return;
+  std::vector<std::pair<std::string, std::string>> batch;
+  if (shm_->collect_all(batch, std::numeric_limits<size_t>::max()) == 0) {
+    return;
+  }
+  for (auto const& [key, value] : batch) {
+    if (!socket_->put_raw(key, value)) return;
+    (void)shm_->mark_relayed(key);
+  }
+}
+
+std::string HierarchicalExchanger::kv_namespace() const {
+  return kv_namespace_for_port(port_);
+}
+
+void HierarchicalExchanger::apply_remote_entry(std::string const& key,
+                                               std::string const& value) {
+  if (!running_.load(std::memory_order_acquire) || !shm_) return;
+  (void)shm_->apply_remote(key, value);
 }
 
 }  // namespace Transport

--- a/experimental/ukernel/src/transport/oob/oob_socket.cc
+++ b/experimental/ukernel/src/transport/oob/oob_socket.cc
@@ -1,14 +1,14 @@
-#include "oob.h"
 #include "../util/utils.h"
+#include "oob.h"
 #include <arpa/inet.h>
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <sstream>
+#include <string>
 #include <fcntl.h>
 #include <poll.h>
 #include <signal.h>
-#include <sstream>
-#include <string>
 #include <sys/epoll.h>
 #include <sys/file.h>
 #include <sys/mman.h>
@@ -59,8 +59,7 @@ int env_int_or_default(char const* name, int default_value) {
 bool env_bool_or_default(char const* name, bool default_value) {
   char const* v = std::getenv(name);
   if (!v || v[0] == '\0') return default_value;
-  if (v[0] == '0' || v[0] == 'n' || v[0] == 'N' || v[0] == 'f' ||
-      v[0] == 'F') {
+  if (v[0] == '0' || v[0] == 'n' || v[0] == 'N' || v[0] == 'f' || v[0] == 'F') {
     return false;
   }
   return true;
@@ -71,14 +70,15 @@ bool connect_with_timeout(int fd, sockaddr_in const& addr, int timeout_ms) {
   if (current_flags < 0) return false;
   if (::fcntl(fd, F_SETFL, current_flags | O_NONBLOCK) != 0) return false;
 
-  int rc = ::connect(fd, reinterpret_cast<sockaddr const*>(&addr), sizeof(addr));
+  int rc =
+      ::connect(fd, reinterpret_cast<sockaddr const*>(&addr), sizeof(addr));
   if (rc == 0) {
     (void)::fcntl(fd, F_SETFL, current_flags | O_NONBLOCK);
     return true;
   }
   if (errno != EINPROGRESS) return false;
 
-  pollfd pfd {};
+  pollfd pfd{};
   pfd.fd = fd;
   pfd.events = POLLOUT;
   rc = ::poll(&pfd, 1, timeout_ms > 0 ? timeout_ms : kSocketPollMs);
@@ -250,9 +250,9 @@ bool ShmExchanger::begin_leader_run() {
       owner_alive = true;
     } else {
       uint64_t current_ticks = 0;
-      owner_alive =
-          read_process_start_ticks(static_cast<pid_t>(owner_pid), current_ticks) &&
-          current_ticks == owner_start_ticks;
+      owner_alive = read_process_start_ticks(static_cast<pid_t>(owner_pid),
+                                             current_ticks) &&
+                    current_ticks == owner_start_ticks;
     }
   }
   if (owner_alive) {
@@ -292,8 +292,7 @@ bool ShmExchanger::mark_run_ready() {
 
 bool ShmExchanger::wait_until_ready(int timeout_ms) const {
   if (!shm_) return false;
-  int const wait_ms =
-      timeout_ms > 0 ? timeout_ms : kLeaderReadyWaitDefaultMs;
+  int const wait_ms = timeout_ms > 0 ? timeout_ms : kLeaderReadyWaitDefaultMs;
   auto const deadline =
       std::chrono::steady_clock::now() + std::chrono::milliseconds(wait_ms);
   while (std::chrono::steady_clock::now() < deadline) {
@@ -311,7 +310,8 @@ bool ShmExchanger::wait_until_ready(int timeout_ms) const {
     if (owner_start_ticks == 0) return true;
 
     uint64_t current_ticks = 0;
-    if (read_process_start_ticks(static_cast<pid_t>(owner_pid), current_ticks) &&
+    if (read_process_start_ticks(static_cast<pid_t>(owner_pid),
+                                 current_ticks) &&
         current_ticks == owner_start_ticks) {
       return true;
     }
@@ -530,10 +530,11 @@ bool ShmExchanger::put_encoded(std::string_view key, std::string_view value,
     shm_->used_slots += 1;
   }
   if (static_cast<uint32_t>(slot_idx) == shm_->first_free_hint) {
-    shm_->first_free_hint = static_cast<uint32_t>((slot_idx + 1) %
-                                                  shm_->slot_capacity);
+    shm_->first_free_hint =
+        static_cast<uint32_t>((slot_idx + 1) % shm_->slot_capacity);
   }
-  slot_index_cache_[SlotCacheHash::hash_key(key)] = static_cast<uint32_t>(slot_idx);
+  slot_index_cache_[SlotCacheHash::hash_key(key)] =
+      static_cast<uint32_t>(slot_idx);
   unlock_store();
   maybe_post_sem();
   return true;
@@ -570,12 +571,12 @@ bool ShmExchanger::wait_for_update(int delay_ms) const {
   if (!shm_) return false;
   if (delay_ms <= 0) delay_ms = 1;
 
-  auto deadline = std::chrono::system_clock::now() +
-                  std::chrono::milliseconds(delay_ms);
+  auto deadline =
+      std::chrono::system_clock::now() + std::chrono::milliseconds(delay_ms);
   auto sec = std::chrono::time_point_cast<std::chrono::seconds>(deadline);
-  auto nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(deadline -
-                                                                   sec)
-                  .count();
+  auto nsec =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(deadline - sec)
+          .count();
   struct timespec ts {};
   ts.tv_sec = static_cast<time_t>(sec.time_since_epoch().count());
   ts.tv_nsec = static_cast<long>(nsec);
@@ -617,7 +618,8 @@ int ShmExchanger::find_slot_locked(std::string_view key) const {
 int ShmExchanger::find_free_slot_locked() const {
   if (!shm_) return -1;
   for (uint32_t offset = 0; offset < shm_->slot_capacity; ++offset) {
-    uint32_t const index = (shm_->first_free_hint + offset) % shm_->slot_capacity;
+    uint32_t const index =
+        (shm_->first_free_hint + offset) % shm_->slot_capacity;
     if (shm_->slots[index].state != kSlotUsed) return static_cast<int>(index);
   }
   return -1;
@@ -794,15 +796,16 @@ bool SocketExchanger::start_root_server() {
   if (root_.listen_fd < 0) return false;
 
   int opt = 1;
-  (void)::setsockopt(root_.listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+  (void)::setsockopt(root_.listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt,
+                     sizeof(opt));
   (void)::fcntl(root_.listen_fd, F_SETFL, O_NONBLOCK);
 
-  sockaddr_in addr {};
+  sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_addr.s_addr = INADDR_ANY;
   addr.sin_port = htons(static_cast<uint16_t>(port_));
-  if (::bind(root_.listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) !=
-      0) {
+  if (::bind(root_.listen_fd, reinterpret_cast<sockaddr*>(&addr),
+             sizeof(addr)) != 0) {
     ::close(root_.listen_fd);
     root_.listen_fd = -1;
     return false;
@@ -861,14 +864,14 @@ void SocketExchanger::root_accept_loop() {
   if (epoll_fd < 0) return;
 
   auto set_peer_events = [&](int fd, bool want_write) -> bool {
-    epoll_event ev {};
+    epoll_event ev{};
     ev.events = EPOLLIN | EPOLLRDHUP | (want_write ? EPOLLOUT : 0);
     ev.data.fd = fd;
     return ::epoll_ctl(epoll_fd, EPOLL_CTL_MOD, fd, &ev) == 0;
   };
 
   auto add_epoll_in = [&](int fd) -> bool {
-    epoll_event ev {};
+    epoll_event ev{};
     ev.events = EPOLLIN | EPOLLRDHUP;
     ev.data.fd = fd;
     return ::epoll_ctl(epoll_fd, EPOLL_CTL_ADD, fd, &ev) == 0;
@@ -902,10 +905,10 @@ void SocketExchanger::root_accept_loop() {
       uint32_t const ev = events[i].events;
       if (fd == root_.listen_fd) {
         while (running_.load(std::memory_order_acquire)) {
-          sockaddr_in cli {};
+          sockaddr_in cli{};
           socklen_t len = sizeof(cli);
-          int conn_fd =
-              ::accept(root_.listen_fd, reinterpret_cast<sockaddr*>(&cli), &len);
+          int conn_fd = ::accept(root_.listen_fd,
+                                 reinterpret_cast<sockaddr*>(&cli), &len);
           if (conn_fd < 0) {
             if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
               break;
@@ -984,8 +987,8 @@ void SocketExchanger::root_accept_loop() {
 
       for (;;) {
         std::string frame;
-        bool const got_frame = recv_frame_buffered(
-            fd, peer->read_buffer, peer->read_offset, frame, 0);
+        bool const got_frame = recv_frame_buffered(fd, peer->read_buffer,
+                                                   peer->read_offset, frame, 0);
         if (!got_frame) {
           if (errno == EAGAIN || errno == EWOULDBLOCK) break;
           close_peer_now = true;
@@ -1011,11 +1014,11 @@ void SocketExchanger::root_accept_loop() {
             }
             if (snapshot_ok) {
               std::string sync_done_frame;
-              snapshot_ok = encode_socket_frame(
-                                SocketFrame{SocketFrameType::SyncDone, {}, {}},
-                                sync_done_frame) &&
-                            enqueue_frame_locked(peer->write_buffer,
-                                                 sync_done_frame);
+              snapshot_ok =
+                  encode_socket_frame(
+                      SocketFrame{SocketFrameType::SyncDone, {}, {}},
+                      sync_done_frame) &&
+                  enqueue_frame_locked(peer->write_buffer, sync_done_frame);
             }
           }
           if (!snapshot_ok) {
@@ -1029,8 +1032,8 @@ void SocketExchanger::root_accept_loop() {
           continue;
         }
         if (decoded.type == SocketFrameType::Publish) {
-          handle_publish(decoded.key, decoded.value, /*broadcast_from_root=*/true,
-                         fd);
+          handle_publish(decoded.key, decoded.value,
+                         /*broadcast_from_root=*/true, fd);
         }
       }
       if (close_peer_now) {
@@ -1069,8 +1072,8 @@ void SocketExchanger::root_broadcast_pub(std::string const& key,
   }
 
   std::string frame;
-  if (!encode_socket_frame(
-          SocketFrame{SocketFrameType::Publish, key, value}, frame)) {
+  if (!encode_socket_frame(SocketFrame{SocketFrameType::Publish, key, value},
+                           frame)) {
     return;
   }
   for (auto const& peer : peers) {
@@ -1219,7 +1222,7 @@ bool SocketExchanger::recv_frame_buffered(int fd, std::string& buffer,
 
   while (running_.load(std::memory_order_acquire)) {
     if (timeout_ms > 0) {
-      pollfd pfd {};
+      pollfd pfd{};
       pfd.fd = fd;
       pfd.events = POLLIN;
       int rc = ::poll(&pfd, 1, timeout_ms);
@@ -1272,7 +1275,7 @@ bool SocketExchanger::connect_upstream_locked() {
   int fd = ::socket(AF_INET, SOCK_STREAM, 0);
   if (fd < 0) return false;
 
-  sockaddr_in addr {};
+  sockaddr_in addr{};
   addr.sin_family = AF_INET;
   addr.sin_port = htons(static_cast<uint16_t>(port_));
   if (::inet_pton(AF_INET, host_.c_str(), &addr.sin_addr) <= 0) {
@@ -1327,7 +1330,8 @@ void SocketExchanger::upstream_loop() {
       std::lock_guard<std::mutex> lk(upstream_mu_);
       if (upstream_fd_ < 0 && !connect_upstream_locked()) {
         std::unique_lock<std::mutex> pending_lk(pending_mu_);
-        pending_cv_.wait_for(pending_lk, std::chrono::milliseconds(kSocketPollMs));
+        pending_cv_.wait_for(pending_lk,
+                             std::chrono::milliseconds(kSocketPollMs));
         continue;
       }
     }
@@ -1339,10 +1343,9 @@ void SocketExchanger::upstream_loop() {
         while (!pending_pubs_.empty()) {
           std::string frame;
           auto const& pending = pending_pubs_.front();
-          if (!encode_socket_frame(
-                  SocketFrame{SocketFrameType::Publish, pending.first,
-                              pending.second},
-                  frame)) {
+          if (!encode_socket_frame(SocketFrame{SocketFrameType::Publish,
+                                               pending.first, pending.second},
+                                   frame)) {
             pending_pubs_.pop_front();
             continue;
           }
@@ -1378,7 +1381,7 @@ void SocketExchanger::upstream_loop() {
           continue;
         }
 
-        pollfd pfd {};
+        pollfd pfd{};
         pfd.fd = upstream_fd_;
         pfd.events = POLLIN;
         if (!upstream_write_buffer_.empty()) pfd.events |= POLLOUT;
@@ -1441,8 +1444,7 @@ void SocketExchanger::upstream_loop() {
 
 void SocketExchanger::handle_publish(std::string const& key,
                                      std::string const& value,
-                                     bool broadcast_from_root,
-                                     int exclude_fd) {
+                                     bool broadcast_from_root, int exclude_fd) {
   {
     std::lock_guard<std::mutex> lk(entries_mu_);
     entries_[key] = value;

--- a/experimental/ukernel/src/transport/oob/oob_socket.cc
+++ b/experimental/ukernel/src/transport/oob/oob_socket.cc
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <poll.h>
+#include <signal.h>
 #include <sstream>
 #include <string>
 #include <sys/epoll.h>
@@ -24,6 +25,7 @@ namespace {
 constexpr int kSocketPollMs = 200;
 constexpr int kRelayWaitMs = 50;
 constexpr size_t kBufferCompactMinPrefix = 4096;
+constexpr int kLeaderReadyWaitDefaultMs = 30000;
 
 void compact_prefixed_buffer(std::string& buffer, size_t& offset) {
   if (offset == 0) return;
@@ -107,6 +109,40 @@ std::string kv_namespace_for_port(int port) {
   return oss.str();
 }
 
+bool read_process_start_ticks(pid_t pid, uint64_t& out_ticks) {
+  out_ticks = 0;
+  std::ostringstream path;
+  path << "/proc/" << static_cast<long long>(pid) << "/stat";
+  int const fd = ::open(path.str().c_str(), O_RDONLY | O_CLOEXEC);
+  if (fd < 0) return false;
+  char buf[2048] = {};
+  ssize_t const n = ::read(fd, buf, sizeof(buf) - 1);
+  ::close(fd);
+  if (n <= 0) return false;
+  std::string const stat(buf, static_cast<size_t>(n));
+  size_t const right_paren = stat.rfind(')');
+  if (right_paren == std::string::npos || right_paren + 2 >= stat.size()) {
+    return false;
+  }
+  std::istringstream iss(stat.substr(right_paren + 2));
+  std::string token;
+  for (int i = 0; i < 20; ++i) {
+    if (!(iss >> token)) return false;
+  }
+  try {
+    out_ticks = static_cast<uint64_t>(std::stoull(token));
+    return out_ticks != 0;
+  } catch (...) {
+    return false;
+  }
+}
+
+bool pid_is_alive(pid_t pid) {
+  if (pid <= 1) return false;
+  if (::kill(pid, 0) == 0) return true;
+  return errno == EPERM;
+}
+
 struct SocketFrame {
   SocketFrameType type = SocketFrameType::SyncRequest;
   std::string key;
@@ -188,8 +224,11 @@ uint64_t ShmExchanger::SlotCacheHash::hash_key(std::string_view key) {
   return h;
 }
 
-ShmExchanger::ShmExchanger(std::string kv_namespace)
-    : kv_namespace_(std::move(kv_namespace)) {
+ShmExchanger::ShmExchanger(std::string kv_namespace, bool create_if_missing,
+                           int open_timeout_ms)
+    : kv_namespace_(std::move(kv_namespace)),
+      create_if_missing_(create_if_missing),
+      open_timeout_ms_(open_timeout_ms > 0 ? open_timeout_ms : 30000) {
   (void)init_shared_store();
 }
 
@@ -201,21 +240,84 @@ bool ShmExchanger::apply_remote(std::string_view key, std::string_view value) {
   return put_encoded(key, value, /*mark_relayed=*/true);
 }
 
-bool ShmExchanger::reset_for_new_run() {
-  if (!shm_ || !lock_store()) return false;
+bool ShmExchanger::begin_leader_run() {
+  if (!lock_store()) return false;
+  uint32_t const owner_pid = shm_->owner_pid;
+  uint64_t const owner_start_ticks = shm_->owner_start_ticks;
+  bool owner_alive = false;
+  if (owner_pid > 1 && pid_is_alive(static_cast<pid_t>(owner_pid))) {
+    if (owner_start_ticks == 0) {
+      owner_alive = true;
+    } else {
+      uint64_t current_ticks = 0;
+      owner_alive =
+          read_process_start_ticks(static_cast<pid_t>(owner_pid), current_ticks) &&
+          current_ticks == owner_start_ticks;
+    }
+  }
+  if (owner_alive) {
+    unlock_store();
+    return false;
+  }
+
   for (uint32_t i = 0; i < shm_->slot_capacity; ++i) {
     shm_->slots[i] = KvSlot{};
   }
   shm_->used_slots = 0;
   shm_->first_free_hint = 0;
   shm_->write_seq = 0;
-  shm_->recovery_epoch += 1;
+  shm_->init_done = 0;
   shm_->owner_pid = static_cast<uint32_t>(::getpid());
+  uint64_t start_ticks = 0;
+  (void)read_process_start_ticks(::getpid(), start_ticks);
+  shm_->owner_start_ticks = start_ticks;
   next_unrelayed_scan_index_ = 0;
   slot_index_cache_.clear();
   unlock_store();
   maybe_post_sem();
   return true;
+}
+
+bool ShmExchanger::mark_run_ready() {
+  if (!shm_ || !lock_store()) return false;
+  shm_->init_done = 1;
+  shm_->owner_pid = static_cast<uint32_t>(::getpid());
+  uint64_t start_ticks = 0;
+  (void)read_process_start_ticks(::getpid(), start_ticks);
+  shm_->owner_start_ticks = start_ticks;
+  unlock_store();
+  maybe_post_sem();
+  return true;
+}
+
+bool ShmExchanger::wait_until_ready(int timeout_ms) const {
+  if (!shm_) return false;
+  int const wait_ms =
+      timeout_ms > 0 ? timeout_ms : kLeaderReadyWaitDefaultMs;
+  auto const deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(wait_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    if (!lock_store()) return false;
+    uint32_t const owner_pid = shm_->owner_pid;
+    uint64_t const owner_start_ticks = shm_->owner_start_ticks;
+    bool const init_done = shm_->init_done != 0;
+    unlock_store();
+
+    if (!init_done || owner_pid <= 1 ||
+        !pid_is_alive(static_cast<pid_t>(owner_pid))) {
+      (void)wait_for_update(10);
+      continue;
+    }
+    if (owner_start_ticks == 0) return true;
+
+    uint64_t current_ticks = 0;
+    if (read_process_start_ticks(static_cast<pid_t>(owner_pid), current_ticks) &&
+        current_ticks == owner_start_ticks) {
+      return true;
+    }
+    (void)wait_for_update(10);
+  }
+  return false;
 }
 
 size_t ShmExchanger::collect_unrelayed(
@@ -295,11 +397,23 @@ bool ShmExchanger::get_raw(std::string_view key, std::string& value) {
 
 bool ShmExchanger::init_shared_store() {
   bool created = false;
-  shm_fd_ = ::shm_open(kv_namespace_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
-  if (shm_fd_ >= 0) {
-    created = true;
-  } else if (errno == EEXIST) {
-    shm_fd_ = ::shm_open(kv_namespace_.c_str(), O_CREAT | O_RDWR, 0600);
+  if (create_if_missing_) {
+    shm_fd_ =
+        ::shm_open(kv_namespace_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (shm_fd_ >= 0) {
+      created = true;
+    } else if (errno == EEXIST) {
+      shm_fd_ = ::shm_open(kv_namespace_.c_str(), O_CREAT | O_RDWR, 0600);
+    }
+  } else {
+    auto const deadline = std::chrono::steady_clock::now() +
+                          std::chrono::milliseconds(open_timeout_ms_);
+    while (std::chrono::steady_clock::now() < deadline) {
+      shm_fd_ = ::shm_open(kv_namespace_.c_str(), O_RDWR, 0600);
+      if (shm_fd_ >= 0) break;
+      if (errno != ENOENT) break;
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
   }
   if (shm_fd_ < 0) return false;
 
@@ -334,9 +448,10 @@ bool ShmExchanger::init_shared_store() {
     shm_->magic = kShmMagic;
     shm_->version = kShmVersion;
     shm_->slot_capacity = kMaxSlots;
-    shm_->recovery_epoch = 1;
     shm_->write_seq = 0;
-    shm_->owner_pid = static_cast<uint32_t>(::getpid());
+    shm_->owner_pid = 0;
+    shm_->init_done = 0;
+    shm_->owner_start_ticks = 0;
     shm_->used_slots = 0;
     shm_->first_free_hint = 0;
     shm_->reserved0 = 0;
@@ -362,8 +477,6 @@ bool ShmExchanger::init_shared_store() {
       shm_fd_ = -1;
       return false;
     }
-    shm_->recovery_epoch += 1;
-    shm_->owner_pid = static_cast<uint32_t>(::getpid());
     rebuild_metadata_locked();
     unlock_store();
   }
@@ -1384,17 +1497,11 @@ HierarchicalExchanger::HierarchicalExchanger(bool is_server,
   node_leader_ = is_node_leader();
 
   std::string const ns = kv_namespace();
-  shm_ = std::make_unique<ShmExchanger>(ns);
-  if (!shm_ || !shm_->valid()) return;
-  // On root startup, clear stale entries in-place in the same shared segment.
-  // This avoids split-brain behavior that can happen with shm_unlink while
-  // other local processes still hold mappings to the previous object.
-  if (is_server_ && env_bool_or_default("UHM_OOB_CLEAN_START", true)) {
-    (void)shm_->reset_for_new_run();
-  }
-
-  running_.store(true, std::memory_order_release);
   if (node_leader_) {
+    shm_ = std::make_unique<ShmExchanger>(ns, /*create_if_missing=*/true);
+    if (!shm_ || !shm_->valid()) return;
+    if (!shm_->begin_leader_run()) return;
+    running_.store(true, std::memory_order_release);
     socket_ = std::make_unique<SocketExchanger>(
         is_server_, host_, port_, timeout_ms, max_line_bytes,
         [this](std::string const& key, std::string const& value) {
@@ -1404,14 +1511,29 @@ HierarchicalExchanger::HierarchicalExchanger(bool is_server,
       running_.store(false, std::memory_order_release);
       return;
     }
+    if (!shm_->mark_run_ready()) {
+      running_.store(false, std::memory_order_release);
+      return;
+    }
     last_replayed_epoch_ = 0;
     relay_thread_ = std::thread(&HierarchicalExchanger::relay_loop, this);
+  } else {
+    shm_ = std::make_unique<ShmExchanger>(ns, /*create_if_missing=*/false,
+                                          timeout_ms);
+    if (!shm_ || !shm_->valid()) return;
+    int const wait_ms =
+        env_int_or_default("UHM_OOB_LEADER_READY_TIMEOUT_MS", timeout_ms);
+    if (!shm_->wait_until_ready(wait_ms)) return;
+    running_.store(true, std::memory_order_release);
   }
 }
 
 HierarchicalExchanger::~HierarchicalExchanger() {
   running_.store(false, std::memory_order_release);
   if (relay_thread_.joinable()) relay_thread_.join();
+  if (node_leader_) {
+    (void)::shm_unlink(kv_namespace().c_str());
+  }
 }
 
 bool HierarchicalExchanger::valid() const {

--- a/experimental/ukernel/src/transport/oob/shmring_exchanger.h
+++ b/experimental/ukernel/src/transport/oob/shmring_exchanger.h
@@ -1,0 +1,159 @@
+#pragma once
+
+#include "../../include/gpu_rt.h"
+#include "../util/jring.h"
+#include <atomic>
+#include <cstdint>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace UKernel {
+namespace Transport {
+
+static constexpr uint16_t kTypeIpcCache = 1;
+static constexpr uint16_t kTypeAck = 2;
+
+#pragma pack(push, 1)
+struct IpcCacheWire {
+  gpuIpcMemHandle_t handle;
+  uint8_t is_send;
+  uint64_t offset;
+  uint64_t size;
+  uint32_t remote_gpu_idx_;
+  uint8_t use_bounce_buffer = 0;
+  char bounce_shm_name[128] = {};
+};
+#pragma pack(pop)
+
+struct AckWire {
+  uint32_t status;
+  uint32_t reserved;
+};
+
+enum class ShmCtrlMsgType : uint32_t {
+  Connect = 0,
+  ConnectAck = 1,
+  IpcCache = 2,
+  Ack = 3,
+  IpcCacheReq = 4,
+};
+
+struct ShmCtrlMsg {
+  uint32_t from_rank = 0;
+  uint32_t to_rank = 0;
+  ShmCtrlMsgType type = ShmCtrlMsgType::Connect;
+  uint32_t reserved = 0;
+  uint64_t seq = 0;
+  union {
+    IpcCacheWire cache;
+    AckWire ack;
+  };
+
+  ShmCtrlMsg() : cache{} {}
+};
+
+class ShmRingExchanger {
+ public:
+  ShmRingExchanger(int self_rank, int world_size, std::string ring_namespace,
+                   int self_local_id = -1);
+  ~ShmRingExchanger();
+
+  void set_peer_local_id(int peer_rank, int local_id);
+  bool ensure_server_started();
+  bool connect_to(int peer_rank, int timeout_ms = 30000);
+  bool accept_from(int peer_rank, int timeout_ms = 30000);
+
+  bool send(int peer_rank, uint16_t type, uint64_t seq, void const* payload,
+            uint32_t bytes);
+  bool send_ipc_cache(int peer_rank, uint64_t seq, IpcCacheWire const& cache);
+  bool send_ipc_cache_req(int peer_rank, uint64_t seq);
+  bool recv_ipc_cache(int peer_rank, IpcCacheWire& out_cache,
+                      uint64_t* out_seq = nullptr, int timeout_ms = 30000,
+                      uint64_t expected_seq = UINT64_MAX);
+  bool recv_ipc_cache_req(int peer_rank, uint64_t* out_seq = nullptr,
+                          int timeout_ms = 30000,
+                          uint64_t expected_seq = UINT64_MAX);
+  bool send_ack(int peer_rank, uint64_t seq, uint32_t status = 1);
+  bool recv_ack(int peer_rank, uint32_t* out_status = nullptr,
+                uint64_t* out_seq = nullptr, int timeout_ms = 30000,
+                uint64_t expected_seq = UINT64_MAX);
+
+  void close_peer(int peer_rank);
+  bool is_peer_connected(int peer_rank) const;
+
+ private:
+  struct ShmRingHandle {
+    jring_t* ring = nullptr;
+    int shm_fd = -1;
+    size_t shm_size = 0;
+    std::string shm_name;
+    bool attached = false;
+    bool creator = false;
+  };
+
+  struct PendingIpcCacheMsg {
+    uint64_t seq = 0;
+    IpcCacheWire cache{};
+  };
+
+  struct PendingAckMsg {
+    uint64_t seq = 0;
+    AckWire ack{};
+  };
+
+  struct PeerState {
+    std::mutex send_mu;
+    std::mutex recv_mu;
+    ShmRingHandle local_inbox;
+    ShmRingHandle remote_inbox;
+    bool connected = false;
+  };
+
+  std::string ring_name(int from_rank, int to_rank) const;
+  bool ensure_local_ring(int peer_rank);
+  bool ensure_remote_ring_attached(int peer_rank, int timeout_ms);
+  bool try_recv_one_locked(int peer_rank, ShmCtrlMsg& msg);
+  bool try_take_connect_locked(int peer_rank, uint64_t* out_seq = nullptr);
+  bool try_take_cached_connect_ack_locked(int peer_rank, uint64_t expected_seq,
+                                          uint64_t* out_seq);
+  bool try_take_cached_ipc_cache_locked(int peer_rank, uint64_t expected_seq,
+                                        IpcCacheWire& out_cache,
+                                        uint64_t* out_seq);
+  bool try_take_cached_ipc_cache_req_locked(int peer_rank,
+                                            uint64_t expected_seq,
+                                            uint64_t* out_seq);
+  bool try_take_cached_ack_locked(int peer_rank, uint64_t expected_seq,
+                                  AckWire& out_ack, uint64_t* out_seq);
+  void cache_connect_message(int peer_rank, uint64_t seq);
+  void cache_connect_ack_message(int peer_rank, uint64_t seq);
+  void cache_ipc_cache_message(int peer_rank, uint64_t seq,
+                               IpcCacheWire const& cache);
+  void cache_ipc_cache_req_message(int peer_rank, uint64_t seq);
+  void cache_ack_message(int peer_rank, uint64_t seq, AckWire const& ack);
+  bool send_msg(int peer_rank, ShmCtrlMsg const& msg);
+
+  int self_rank_;
+  int world_size_;
+  int self_local_id_;
+  std::string ring_namespace_;
+  std::atomic<bool> running_{false};
+
+  mutable std::mutex mu_;
+  std::vector<std::shared_ptr<PeerState>> peers_;
+  std::vector<int> peer_local_ids_;
+  mutable std::mutex pending_mu_;
+  std::unordered_map<int, std::deque<uint64_t>> pending_connect_;
+  std::unordered_map<int, std::deque<uint64_t>> pending_connect_acks_;
+  std::unordered_map<int, std::deque<PendingIpcCacheMsg>>
+      rank_to_pending_ipc_cache_;
+  std::unordered_map<int, std::deque<uint64_t>> rank_to_pending_ipc_cache_req_;
+  std::unordered_map<int, std::deque<PendingAckMsg>> rank_to_pending_acks_;
+  std::vector<uint64_t> next_connect_seq_;
+};
+
+}  // namespace Transport
+}  // namespace UKernel

--- a/experimental/ukernel/src/transport/test/unit/test_transport_core.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_core.cc
@@ -1,6 +1,7 @@
 #include "memory/ipc_manager.h"
 #include "memory/mr_manager.h"
 #include "oob/oob.h"
+#include "oob/shmring_exchanger.h"
 #include "test.h"
 #include "test_utils.h"
 #include <chrono>

--- a/experimental/ukernel/src/transport/test/unit/test_transport_oob_exchangeable.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_oob_exchangeable.cc
@@ -22,7 +22,9 @@ void test_exchangeable_round_trip() {
   meta.local_id = 7;
   meta.rdma_capable = true;
   CommunicatorMeta meta_rt;
-  meta_rt.from_map(meta.to_map());
+  std::string encoded;
+  require(meta.serialize(encoded), "CommunicatorMeta serialize failed");
+  require(meta_rt.deserialize(encoded), "CommunicatorMeta deserialize failed");
   require(meta_rt.host_id == meta.host_id, "CommunicatorMeta host_id mismatch");
   require(meta_rt.ip == meta.ip, "CommunicatorMeta ip mismatch");
   require(meta_rt.local_id == meta.local_id,
@@ -35,7 +37,8 @@ void test_exchangeable_round_trip() {
   infos.entries.push_back(NamedMR{3, MR{1, 0x1000ULL, 256, 0, 11}});
   infos.entries.push_back(NamedMR{7, MR{2, 0x2000ULL, 512, 0, 22}});
   NamedMRInfos infos_rt;
-  infos_rt.from_map(infos.to_map());
+  require(infos.serialize(encoded), "NamedMRInfos serialize failed");
+  require(infos_rt.deserialize(encoded), "NamedMRInfos deserialize failed");
   require(infos_rt.generation == infos.generation,
           "NamedMRInfos generation mismatch");
   require(infos_rt.entries.size() == 2, "NamedMRInfos size mismatch");
@@ -48,7 +51,8 @@ void test_exchangeable_round_trip() {
 
   UCCLP2PInfo uccl{"127.0.0.1", 12345, 6, 2};
   UCCLP2PInfo uccl_rt;
-  uccl_rt.from_map(uccl.to_map());
+  require(uccl.serialize(encoded), "UCCLP2PInfo serialize failed");
+  require(uccl_rt.deserialize(encoded), "UCCLP2PInfo deserialize failed");
   require(uccl_rt.ip == uccl.ip && uccl_rt.port == uccl.port,
           "UCCLP2PInfo endpoint mismatch");
   require(uccl_rt.dev_idx == uccl.dev_idx && uccl_rt.gpu_idx == uccl.gpu_idx,
@@ -56,7 +60,8 @@ void test_exchangeable_round_trip() {
 
   TcpP2PInfo tcp{"127.0.0.1", 23456};
   TcpP2PInfo tcp_rt;
-  tcp_rt.from_map(tcp.to_map());
+  require(tcp.serialize(encoded), "TcpP2PInfo serialize failed");
+  require(tcp_rt.deserialize(encoded), "TcpP2PInfo deserialize failed");
   require(tcp_rt.ip == tcp.ip && tcp_rt.port == tcp.port,
           "TcpP2PInfo round-trip mismatch");
 
@@ -72,7 +77,8 @@ void test_exchangeable_round_trip() {
   }
 
   IpcBufferInfo ipc_rt;
-  ipc_rt.from_map(ipc.to_map());
+  require(ipc.serialize(encoded), "IpcBufferInfo serialize failed");
+  require(ipc_rt.deserialize(encoded), "IpcBufferInfo deserialize failed");
   require(ipc_rt.ipc_id == ipc.ipc_id, "IpcBufferInfo ipc_id mismatch");
   require(ipc_rt.base_offset == ipc.base_offset,
           "IpcBufferInfo base_offset mismatch");

--- a/experimental/ukernel/src/transport/test/unit/test_transport_oob_shm.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_oob_shm.cc
@@ -1,4 +1,5 @@
 #include "oob/oob.h"
+#include "oob/shmring_exchanger.h"
 #include "test.h"
 #include "test_utils.h"
 #include <chrono>
@@ -7,11 +8,16 @@
 #include <exception>
 #include <mutex>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <vector>
 #include <unistd.h>
 
 using ShmRingExchanger = UKernel::Transport::ShmRingExchanger;
 using IpcCacheWire = UKernel::Transport::IpcCacheWire;
+using ShmExchanger = UKernel::Transport::ShmExchanger;
+using Exchanger = UKernel::Transport::Exchanger;
+using CommunicatorMeta = UKernel::Transport::CommunicatorMeta;
 
 namespace {
 
@@ -23,6 +29,82 @@ std::string unique_shm_namespace(char const* prefix) {
   oss << prefix << "-" << static_cast<long long>(::getpid()) << "-"
       << std::chrono::steady_clock::now().time_since_epoch().count();
   return oss.str();
+}
+
+std::string unique_posix_shm_name(char const* prefix) {
+  std::ostringstream oss;
+  oss << "/" << prefix << "-" << static_cast<long long>(::getpid()) << "-"
+      << std::chrono::steady_clock::now().time_since_epoch().count();
+  return oss.str();
+}
+
+bool contains_key(
+    std::vector<std::pair<std::string, std::string>> const& entries,
+    std::string const& key) {
+  for (auto const& entry : entries) {
+    if (entry.first == key) return true;
+  }
+  return false;
+}
+
+void test_shm_exchanger_put_wait_and_relay_state() {
+  std::string const ns = unique_posix_shm_name("oob-kv-shm");
+  ShmExchanger writer(ns);
+  ShmExchanger reader(ns);
+  require(writer.valid(), "writer shm exchanger should be valid");
+  require(reader.valid(), "reader shm exchanger should be valid");
+
+  CommunicatorMeta local{};
+  local.host_id = "writer";
+  local.ip = "127.0.0.1";
+  local.local_id = 0;
+  local.rdma_capable = true;
+  require(writer.put("meta:local", local), "writer put(meta:local) failed");
+
+  CommunicatorMeta fetched{};
+  require(reader.get("meta:local", fetched), "reader get(meta:local) failed");
+  require(fetched.host_id == "writer", "reader fetched host_id mismatch");
+
+  std::vector<std::pair<std::string, std::string>> unrelayed;
+  require(writer.collect_unrelayed(unrelayed, 16) > 0,
+          "writer should collect at least one unrelayed entry");
+  require(contains_key(unrelayed, "meta:local"),
+          "collect_unrelayed should include meta:local");
+  require(writer.mark_relayed("meta:local"),
+          "mark_relayed(meta:local) should succeed");
+  require(writer.collect_unrelayed(unrelayed, 16) == 0,
+          "meta:local should not stay unrelayed after mark");
+
+  CommunicatorMeta remote{};
+  remote.host_id = "remote";
+  remote.ip = "10.0.0.2";
+  remote.local_id = 1;
+  remote.rdma_capable = false;
+  std::string encoded_remote;
+  require(UKernel::Transport::serialize_object(remote, encoded_remote),
+          "serialize remote meta failed");
+  require(reader.apply_remote("meta:remote", encoded_remote),
+          "apply_remote(meta:remote) failed");
+
+  require(writer.collect_unrelayed(unrelayed, 16) == 0,
+          "apply_remote data should be marked relayed");
+
+  CommunicatorMeta waited{};
+  bool delayed_put_ok = true;
+  std::thread delayed_put([&]() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(80));
+    CommunicatorMeta delayed{};
+    delayed.host_id = "delayed";
+    delayed.ip = "127.0.0.1";
+    delayed.local_id = 9;
+    delayed.rdma_capable = false;
+    delayed_put_ok = writer.put("meta:delayed", delayed);
+  });
+  require(reader.wait("meta:delayed", waited, Exchanger::WaitOptions{120, 10}),
+          "reader wait(meta:delayed) failed");
+  delayed_put.join();
+  require(delayed_put_ok, "writer put(meta:delayed) failed");
+  require(waited.host_id == "delayed", "waited payload host_id mismatch");
 }
 
 void test_shm_ipc_cache_exchange() {
@@ -108,6 +190,8 @@ void test_shm_ipc_cache_exchange() {
 }  // namespace
 
 void test_shm_oob() {
+  run_case("transport unit", "shm exchanger put/wait/relay-state",
+           test_shm_exchanger_put_wait_and_relay_state);
   run_case("transport unit", "shm oob ipc cache exchange",
            test_shm_ipc_cache_exchange);
 }

--- a/experimental/ukernel/src/transport/test/unit/test_transport_oob_socket.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_oob_socket.cc
@@ -161,7 +161,7 @@ void test_socket_exchanger_direct_sync_and_publish() {
 void publisher_socket(int port) {
   HierarchicalExchanger ex(
       /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
-      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/1);
   require(ex.valid(), "publisher failed to connect to socket exchanger");
 
   NamedMRInfos remote{};
@@ -214,7 +214,7 @@ void rank_thread_socket(int rank, int world_size, std::string const& ip,
     bool is_server = (rank == 0);
     auto ex = std::make_shared<HierarchicalExchanger>(
         is_server, ip, port, /*timeout_ms=*/kTestTimeoutMs,
-        /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+        /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/rank);
     require(ex->valid(), "rank failed to init socket exchanger");
 
     CommunicatorMeta local;
@@ -285,7 +285,7 @@ void test_socket_valid_implies_snapshot_ready() {
 
   HierarchicalExchanger client(
       /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
-      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/1);
   require(client.valid(), "client failed to finish initial sync");
 
   NamedMRInfos fetched{};
@@ -313,7 +313,7 @@ void test_socket_reconnect_gets_full_snapshot() {
   {
     HierarchicalExchanger client(
         /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
-        /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+        /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/1);
     require(client.valid(), "first client failed to sync");
     CommunicatorMeta fetched{};
     require(client.get("meta:10", fetched),
@@ -328,7 +328,7 @@ void test_socket_reconnect_gets_full_snapshot() {
 
   HierarchicalExchanger reconnected(
       /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
-      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/1);
   require(reconnected.valid(), "reconnected client failed to sync");
 
   CommunicatorMeta fetched_first{};

--- a/experimental/ukernel/src/transport/test/unit/test_transport_oob_socket.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_oob_socket.cc
@@ -2,15 +2,23 @@
 #include "test.h"
 #include "test_utils.h"
 #include "util/utils.h"
+#include <arpa/inet.h>
+#include <atomic>
 #include <chrono>
+#include <cstdlib>
 #include <exception>
 #include <memory>
+#include <netinet/in.h>
+#include <sstream>
 #include <string>
+#include <sys/socket.h>
 #include <thread>
 #include <vector>
 #include <unistd.h>
 
-using SockExchanger = UKernel::Transport::SockExchanger;
+using SocketExchanger = UKernel::Transport::SocketExchanger;
+using HierarchicalExchanger = UKernel::Transport::HierarchicalExchanger;
+using Exchanger = UKernel::Transport::Exchanger;
 using CommunicatorMeta = UKernel::Transport::CommunicatorMeta;
 using MR = UKernel::Transport::MR;
 using NamedMR = UKernel::Transport::NamedMR;
@@ -20,11 +28,140 @@ namespace {
 
 using UKernel::Transport::TestUtil::require;
 using UKernel::Transport::TestUtil::run_case;
+using UKernel::Transport::TestUtil::ScopedEnvVar;
 
-int socket_test_port() { return 20379 + static_cast<int>(::getpid() % 1000); }
+constexpr int kTestTimeoutMs = 10000;
+constexpr int kMetaExchangeRetries = 150;
+constexpr int kMetaExchangeDelayMs = 100;
+
+int socket_test_port() {
+  int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+  if (fd < 0) {
+    return 20379 + static_cast<int>(::getpid() % 1000);
+  }
+  int opt = 1;
+  (void)::setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr.sin_port = htons(0);
+  if (::bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) != 0) {
+    ::close(fd);
+    return 20379 + static_cast<int>(::getpid() % 1000);
+  }
+  socklen_t addr_len = sizeof(addr);
+  if (::getsockname(fd, reinterpret_cast<sockaddr*>(&addr), &addr_len) != 0) {
+    ::close(fd);
+    return 20379 + static_cast<int>(::getpid() % 1000);
+  }
+  int const port = static_cast<int>(ntohs(addr.sin_port));
+  ::close(fd);
+  return port;
+}
+
+bool wait_for_listener(std::string const& ip, int port, int timeout_ms) {
+  auto const deadline = std::chrono::steady_clock::now() +
+                        std::chrono::milliseconds(timeout_ms);
+  while (std::chrono::steady_clock::now() < deadline) {
+    int fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (fd < 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(20));
+      continue;
+    }
+
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_port = htons(static_cast<uint16_t>(port));
+    if (::inet_pton(AF_INET, ip.c_str(), &addr.sin_addr) <= 0) {
+      ::close(fd);
+      return false;
+    }
+
+    if (::connect(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == 0) {
+      ::shutdown(fd, SHUT_RDWR);
+      ::close(fd);
+      return true;
+    }
+    ::close(fd);
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  }
+  return false;
+}
+
+std::string unique_oob_namespace(char const* prefix) {
+  std::ostringstream oss;
+  oss << prefix << "-" << static_cast<long long>(::getpid()) << "-"
+      << std::chrono::steady_clock::now().time_since_epoch().count();
+  return oss.str();
+}
+
+void test_socket_exchanger_direct_sync_and_publish() {
+  int port = socket_test_port() + 10;
+  SocketExchanger root(
+      /*is_root=*/true, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+      /*max_line_bytes=*/1 * 1024 * 1024,
+      [](std::string const&, std::string const&) {});
+  require(root.start(), "root socket exchanger start failed");
+  require(root.valid(), "root socket exchanger should be valid after start");
+  require(wait_for_listener("127.0.0.1", port, 1000),
+          "root socket listener not ready in time");
+
+  CommunicatorMeta seed{};
+  seed.host_id = "seed-root";
+  seed.ip = "127.0.0.1";
+  seed.local_id = 0;
+  seed.rdma_capable = true;
+  require(root.put("seed:key", seed), "root failed to publish seed payload");
+
+  std::atomic<int> client_callback_count{0};
+  SocketExchanger client(
+      /*is_root=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+      /*max_line_bytes=*/1 * 1024 * 1024,
+      [&](std::string const&, std::string const&) {
+        client_callback_count.fetch_add(1, std::memory_order_relaxed);
+      });
+  require(client.start(), "client socket exchanger start failed");
+  require(client.valid(), "client socket exchanger should be valid after sync");
+  require(client.connection_epoch() > 0,
+          "client connection epoch should advance after sync");
+
+  CommunicatorMeta from_snapshot{};
+  require(client.get("seed:key", from_snapshot),
+          "client should read root snapshot payload");
+  require(from_snapshot.host_id == "seed-root", "snapshot payload mismatch");
+
+  CommunicatorMeta from_client{};
+  from_client.host_id = "client";
+  from_client.ip = "127.0.0.1";
+  from_client.local_id = 7;
+  from_client.rdma_capable = false;
+  require(client.put("client:key", from_client),
+          "client failed to publish payload");
+
+  CommunicatorMeta root_seen{};
+  require(root.wait("client:key", root_seen, Exchanger::WaitOptions{80, 25}),
+          "root should receive client payload");
+  require(root_seen.host_id == "client", "root received payload mismatch");
+
+  CommunicatorMeta from_root{};
+  from_root.host_id = "root";
+  from_root.ip = "127.0.0.1";
+  from_root.local_id = 3;
+  from_root.rdma_capable = false;
+  require(root.put("root:key", from_root), "root failed to publish payload");
+
+  CommunicatorMeta client_seen{};
+  require(client.wait("root:key", client_seen, Exchanger::WaitOptions{80, 25}),
+          "client should receive root payload");
+  require(client_seen.host_id == "root", "client received payload mismatch");
+  require(client_callback_count.load(std::memory_order_relaxed) > 0,
+          "client callback should be invoked on incoming publish");
+}
 
 void publisher_socket(int port) {
-  SockExchanger ex(false, "127.0.0.1", port);
+  HierarchicalExchanger ex(
+      /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
   require(ex.valid(), "publisher failed to connect to socket exchanger");
 
   NamedMRInfos remote{};
@@ -32,18 +169,23 @@ void publisher_socket(int port) {
   remote.entries.push_back(NamedMR{8, MR{2, 0x12346000ULL, 8192, 0, 456}});
 
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
-  require(ex.publish("named-mr:peer:1:0", remote),
+  require(ex.put("named-mr:peer:1:0", remote),
           "publisher failed to publish MR info");
 }
 
 void test_socket_publish_fetch() {
   int port = socket_test_port();
-  SockExchanger ex(true, "127.0.0.1", port);
+  std::string const ns = unique_oob_namespace("oob-socket-publish");
+  ScopedEnvVar oob_ns_guard("UHM_OOB_NAMESPACE", ns.c_str());
+  HierarchicalExchanger ex(
+      /*is_server=*/true, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs);
   require(ex.valid(), "failed to start socket exchanger server");
+  require(wait_for_listener("127.0.0.1", port, 1000),
+          "socket listener not ready in time");
 
   NamedMRInfos local{};
   local.entries.push_back(NamedMR{9, MR{7, 0xABCDEF00ULL, 16384, 0, 789}});
-  require(ex.publish("named-mr:peer:0:0", local),
+  require(ex.put("named-mr:peer:0:0", local),
           "failed to publish local MR info");
 
   std::exception_ptr pub_error;
@@ -56,7 +198,7 @@ void test_socket_publish_fetch() {
   });
 
   NamedMRInfos remote{};
-  require(ex.wait_and_fetch("named-mr:peer:1:0", remote, 50, 100),
+  require(ex.wait("named-mr:peer:1:0", remote, Exchanger::WaitOptions{50, 100}),
           "timeout waiting for remote MR info");
   require(remote.entries.size() == 2, "remote MR count mismatch");
   require(remote.entries[0].mr.id == 1 && remote.entries[1].mr.id == 2,
@@ -70,7 +212,9 @@ void rank_thread_socket(int rank, int world_size, std::string const& ip,
                         int port, std::exception_ptr& error) {
   try {
     bool is_server = (rank == 0);
-    auto ex = std::make_shared<SockExchanger>(is_server, ip, port);
+    auto ex = std::make_shared<HierarchicalExchanger>(
+        is_server, ip, port, /*timeout_ms=*/kTestTimeoutMs,
+        /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
     require(ex->valid(), "rank failed to init socket exchanger");
 
     CommunicatorMeta local;
@@ -79,13 +223,15 @@ void rank_thread_socket(int rank, int world_size, std::string const& ip,
     local.ip = "127.0.0.1";
 
     std::string key = "meta:" + std::to_string(rank);
-    require(ex->publish(key, local), "rank failed to publish local meta");
+    require(ex->put(key, local), "rank failed to publish local meta");
 
     for (int r = 0; r < world_size; ++r) {
       if (r == rank) continue;
       std::string remote_key = "meta:" + std::to_string(r);
       CommunicatorMeta remote;
-      require(ex->wait_and_fetch(remote_key, remote, 50, 100),
+      require(ex->wait(remote_key, remote,
+                       Exchanger::WaitOptions{kMetaExchangeRetries,
+                                              kMetaExchangeDelayMs}),
               "timeout waiting for remote communicator meta");
       require(!remote.host_id.empty(), "remote host id should not be empty");
       require(remote.ip == "127.0.0.1", "remote ip mismatch");
@@ -96,13 +242,22 @@ void rank_thread_socket(int rank, int world_size, std::string const& ip,
 }
 
 void test_socket_meta_exchange(int world_size) {
-  int port = socket_test_port() + 1;
+  int port = socket_test_port();
+  std::string const ns = unique_oob_namespace("oob-socket-meta");
+  ScopedEnvVar oob_ns_guard("UHM_OOB_NAMESPACE", ns.c_str());
   std::vector<std::thread> threads;
   std::vector<std::exception_ptr> errors(world_size);
-  for (int rank = 0; rank < world_size; ++rank) {
+
+  // Launch rank0 first and wait for listener readiness to reduce startup races.
+  threads.emplace_back(rank_thread_socket, 0, world_size, "127.0.0.1", port,
+                       std::ref(errors[0]));
+  require(wait_for_listener("127.0.0.1", port, 2000),
+          "rank0 socket listener not ready in time");
+
+  for (int rank = 1; rank < world_size; ++rank) {
     threads.emplace_back(rank_thread_socket, rank, world_size, "127.0.0.1",
                          port, std::ref(errors[rank]));
-    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
   }
 
   for (auto& t : threads) t.join();
@@ -111,11 +266,165 @@ void test_socket_meta_exchange(int world_size) {
   }
 }
 
+void test_socket_valid_implies_snapshot_ready() {
+  int port = socket_test_port();
+  std::string const ns = unique_oob_namespace("oob-socket-snapshot");
+  ScopedEnvVar oob_ns_guard("UHM_OOB_NAMESPACE", ns.c_str());
+  HierarchicalExchanger server(
+      /*is_server=*/true, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs);
+  require(server.valid(), "failed to start socket exchanger server");
+  require(wait_for_listener("127.0.0.1", port, 1000),
+          "socket listener not ready in time");
+
+  NamedMRInfos payload{};
+  payload.generation = 7;
+  payload.entries.push_back(NamedMR{3, MR{11, 0x11111000ULL, 2048, 0, 11}});
+  payload.entries.push_back(NamedMR{4, MR{12, 0x22222000ULL, 4096, 0, 12}});
+  require(server.put("snapshot:key", payload),
+          "server failed to publish snapshot payload");
+
+  HierarchicalExchanger client(
+      /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+  require(client.valid(), "client failed to finish initial sync");
+
+  NamedMRInfos fetched{};
+  require(client.get("snapshot:key", fetched),
+          "client should see snapshot payload immediately after valid");
+  require(fetched.generation == 7, "snapshot generation mismatch");
+  require(fetched.entries.size() == 2, "snapshot entry count mismatch");
+}
+
+void test_socket_reconnect_gets_full_snapshot() {
+  int port = socket_test_port();
+  std::string const ns = unique_oob_namespace("oob-socket-reconnect");
+  ScopedEnvVar oob_ns_guard("UHM_OOB_NAMESPACE", ns.c_str());
+  HierarchicalExchanger server(
+      /*is_server=*/true, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs);
+  require(server.valid(), "failed to start socket exchanger server");
+  require(wait_for_listener("127.0.0.1", port, 1000),
+          "socket listener not ready in time");
+
+  CommunicatorMeta first{};
+  first.host_id = "node-a";
+  first.ip = "127.0.0.1";
+  require(server.put("meta:10", first), "failed to publish first snapshot key");
+
+  {
+    HierarchicalExchanger client(
+        /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+        /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+    require(client.valid(), "first client failed to sync");
+    CommunicatorMeta fetched{};
+    require(client.get("meta:10", fetched),
+            "first client missing first snapshot key");
+  }
+
+  CommunicatorMeta second{};
+  second.host_id = "node-b";
+  second.ip = "127.0.0.1";
+  require(server.put("meta:11", second),
+          "failed to publish second snapshot key");
+
+  HierarchicalExchanger reconnected(
+      /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+  require(reconnected.valid(), "reconnected client failed to sync");
+
+  CommunicatorMeta fetched_first{};
+  CommunicatorMeta fetched_second{};
+  require(reconnected.get("meta:10", fetched_first),
+          "reconnected client missing first snapshot key");
+  require(reconnected.get("meta:11", fetched_second),
+          "reconnected client missing second snapshot key");
+  require(fetched_first.host_id == "node-a",
+          "first snapshot payload mismatch after reconnect");
+  require(fetched_second.host_id == "node-b",
+          "second snapshot payload mismatch after reconnect");
+}
+
+void test_hierarchical_cross_namespace_relay() {
+  int port = socket_test_port();
+  std::string const root_ns = unique_oob_namespace("oob-root-ns");
+  std::string const client_ns = unique_oob_namespace("oob-client-ns");
+
+  ScopedEnvVar root_guard("UHM_OOB_NAMESPACE", root_ns.c_str());
+  HierarchicalExchanger root(
+      /*is_server=*/true, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+  require(root.valid(), "root hierarchical exchanger should be valid");
+  require(wait_for_listener("127.0.0.1", port, 1000),
+          "hierarchical root listener not ready in time");
+
+  CommunicatorMeta root_bootstrap{};
+  root_bootstrap.host_id = "root-bootstrap";
+  root_bootstrap.ip = "127.0.0.1";
+  root_bootstrap.local_id = 0;
+  root_bootstrap.rdma_capable = true;
+  require(root.put("bootstrap:key", root_bootstrap),
+          "root failed to publish bootstrap key");
+
+  ScopedEnvVar client_guard("UHM_OOB_NAMESPACE", client_ns.c_str());
+  HierarchicalExchanger client_leader(
+      /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/0);
+  require(client_leader.valid(), "client leader should be valid");
+
+  CommunicatorMeta bootstrap_seen{};
+  Exchanger::WaitOptions const wait_options{/*max_retries=*/120,
+                                            /*delay_ms=*/25};
+  require(client_leader.wait("bootstrap:key", bootstrap_seen, wait_options),
+          "client leader should receive root bootstrap payload");
+  require(bootstrap_seen.host_id == "root-bootstrap",
+          "client leader bootstrap payload mismatch");
+
+  HierarchicalExchanger client_worker(
+      /*is_server=*/false, "127.0.0.1", port, /*timeout_ms=*/kTestTimeoutMs,
+      /*max_line_bytes=*/1 * 1024 * 1024, /*local_id=*/1);
+  require(client_worker.valid(), "client worker should be valid via shm only");
+
+  CommunicatorMeta root_broadcast{};
+  root_broadcast.host_id = "root-broadcast";
+  root_broadcast.ip = "127.0.0.1";
+  root_broadcast.local_id = 0;
+  root_broadcast.rdma_capable = false;
+  require(root.put("broadcast:key", root_broadcast),
+          "root failed to publish broadcast key");
+
+  CommunicatorMeta worker_seen{};
+  require(client_worker.wait("broadcast:key", worker_seen, wait_options),
+          "client worker should receive root broadcast via local shm");
+  require(worker_seen.host_id == "root-broadcast",
+          "client worker received payload mismatch");
+
+  CommunicatorMeta client_payload{};
+  client_payload.host_id = "client-payload";
+  client_payload.ip = "127.0.0.1";
+  client_payload.local_id = 1;
+  client_payload.rdma_capable = false;
+  require(client_leader.put("client:key", client_payload),
+          "client leader failed to publish payload");
+
+  CommunicatorMeta root_seen{};
+  require(root.wait("client:key", root_seen, wait_options),
+          "root should receive client payload through socket relay");
+  require(root_seen.host_id == "client-payload",
+          "root received client payload mismatch");
+}
+
 }  // namespace
 
 void test_socket_oob() {
+  run_case("transport unit", "socket exchanger direct sync and publish",
+           test_socket_exchanger_direct_sync_and_publish);
   run_case("transport unit", "socket oob publish/fetch",
            test_socket_publish_fetch);
+  run_case("transport unit", "socket oob valid implies snapshot ready",
+           test_socket_valid_implies_snapshot_ready);
+  run_case("transport unit", "socket oob reconnect snapshot replay",
+           test_socket_reconnect_gets_full_snapshot);
+  run_case("transport unit", "hierarchical exchanger cross-namespace relay",
+           test_hierarchical_cross_namespace_relay);
 }
 
 void test_socket_meta_exchange_multi_threads(int world_size) {

--- a/experimental/ukernel/src/transport/test/unit/test_transport_oob_socket.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_oob_socket.cc
@@ -3,17 +3,17 @@
 #include "test_utils.h"
 #include "util/utils.h"
 #include <arpa/inet.h>
+#include <netinet/in.h>
 #include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <exception>
 #include <memory>
-#include <netinet/in.h>
 #include <sstream>
 #include <string>
-#include <sys/socket.h>
 #include <thread>
 #include <vector>
+#include <sys/socket.h>
 #include <unistd.h>
 
 using SocketExchanger = UKernel::Transport::SocketExchanger;
@@ -60,8 +60,8 @@ int socket_test_port() {
 }
 
 bool wait_for_listener(std::string const& ip, int port, int timeout_ms) {
-  auto const deadline = std::chrono::steady_clock::now() +
-                        std::chrono::milliseconds(timeout_ms);
+  auto const deadline =
+      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
   while (std::chrono::steady_clock::now() < deadline) {
     int fd = ::socket(AF_INET, SOCK_STREAM, 0);
     if (fd < 0) {


### PR DESCRIPTION
## Description
This PR introduces HierarchicalExchanger refactor and completes the follow-up changes required to make the new OOB/IPC design stable.

1. Core OOB architecture refactor (base commit)
- Introduced hierarchical OOB: intra-node `ShmExchanger` + inter-node `SocketExchanger`, unified by `HierarchicalExchanger`.  
- Unified Exchanger API and object serialization flow; refactored metadata exchange paths.  
- Split `ShmRingExchanger` into a dedicated header and updated call sites.  
- Added OOB tests (serde / shm / socket / meta / relay) and documentation.

2. Socket/Shm implementation cleanup and optimization
- Reworked `SocketExchanger` around a cleaner reactor/epoll model; optimized buffer handling (offset + compaction) to reduce copy/scanning overhead.  
- Improved `ShmExchanger` slot-index cache and metadata rebuild/recovery logic; removed redundant state.  
- Fixed formatting/build warnings and several edge-case behaviors.

3. Lifecycle control and run-to-run isolation
- Moved leader-init state into shm header (`init_done / owner_pid / owner_start_ticks`) so non-leaders wait on shm readiness directly.  
- Added explicit leader lifecycle (`begin_leader_run / mark_run_ready / wait_until_ready`).  
- Updated integration scripts to use unique namespaces and cleanup on exit, preventing stale shm contamination across runs.

4. IPC handshake stability fixes
- Fixed concurrent handshake races by serializing `ensure_peer` per peer.  
- Made handshake roles deterministic (lower rank connects, higher rank accepts), removing connect/accept collisions.  
- Added explicit close/cleanup on failure to avoid stale peer state.

5. IPC data-path robustness
- Added `gpuDeviceCanAccessPeer` checks before opening/using remote IPC handles.  
- On non-direct topology, route through relay/bounce instead of unsafe direct IPC.  
- Cleared CUDA error state after `gpuIpcOpenMemHandle` failure to prevent deferred error leakage.  
- Preserved same-node IPC-first semantics (no local TCP fallback).

6. Related compatibility updates
- Updated `bench_p2p.py` for the new API (BDF-based semantics).  
- Simplified and tuned transport/CCL integration scripts for correctness-focused regression coverage.

Fixes # (issue)

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
