### PR TITLE
[UK] Unify buffer_id semantics across Transport/CCL/Python and harden OOB/IPC runtime paths

### DIFF
--- a/experimental/ukernel/benchmarks/bench_transport.cc
+++ b/experimental/ukernel/benchmarks/bench_transport.cc
@@ -128,7 +128,8 @@ static std::vector<MR> register_slot_mrs(Communicator& comm,
   buffer_ids.reserve(slots.size());
   for (size_t i = 0; i < slots.size(); ++i) {
     void* ptr = slots[i];
-    uint32_t const buffer_id = kBenchRecvBufferIdBase + static_cast<uint32_t>(i);
+    uint32_t const buffer_id =
+        kBenchRecvBufferIdBase + static_cast<uint32_t>(i);
     if (!comm.reg_mr(buffer_id, ptr, msg_size, true)) {
       return {};
     }
@@ -153,7 +154,7 @@ static bool validate_recv_slots(char const* role, int rank,
   for (size_t i = 0; i < slots.size(); ++i) {
     if (!touched[i]) continue;
     if (gpuMemcpy(host.data(), slots[i], expected.size(),
-                   gpuMemcpyDeviceToHost) != gpuSuccess) {
+                  gpuMemcpyDeviceToHost) != gpuSuccess) {
       fprintf(stderr, "[%s %d] Failed to copy recv slot %zu to host\n", role,
               rank, i);
       return false;
@@ -172,7 +173,8 @@ static bool exchange_remote_recv_mrs(Communicator& comm, int peer_rank,
                                      std::vector<MR>& remote_recv_mrs) {
   remote_recv_mrs.assign(recv_slots, MR{});
   for (size_t i = 0; i < recv_slots; ++i) {
-    uint32_t const buffer_id = kBenchRecvBufferIdBase + static_cast<uint32_t>(i);
+    uint32_t const buffer_id =
+        kBenchRecvBufferIdBase + static_cast<uint32_t>(i);
     if (!comm.wait_mr(peer_rank, buffer_id)) return false;
     remote_recv_mrs[i] = comm.get_mr(peer_rank, buffer_id);
   }

--- a/experimental/ukernel/benchmarks/bench_transport.cc
+++ b/experimental/ukernel/benchmarks/bench_transport.cc
@@ -1,5 +1,4 @@
 #include "../include/config.h"
-#include "../include/gpu_rt.h"
 #include "../include/transport.h"
 #include <algorithm>
 #include <chrono>
@@ -24,8 +23,8 @@ static inline uint64_t now_ns() {
 static constexpr int kIpcThroughputWindow = 8;
 static constexpr int kUcclThroughputWindow = 4;
 static constexpr int kTcpThroughputWindow = 1;
-static constexpr uint64_t kBenchNamedMrGeneration = 1;
-static constexpr uint64_t kBenchIpcBindingVersion = 1;
+static constexpr uint32_t kBenchRecvBufferIdBase = 1;
+static constexpr uint32_t kBenchSendBufferId = 1000000;
 
 static PreferredTransport parse_transport(char const* value) {
   if (strcmp(value, "auto") == 0) return PreferredTransport::Auto;
@@ -49,7 +48,9 @@ static IpcPathMode parse_ipc_path(char const* value) {
 }
 
 static int throughput_window_for(PeerTransportKind kind) {
-  if (kind == PeerTransportKind::Uccl) return kUcclThroughputWindow;
+  if (kind == PeerTransportKind::Uccl) {
+    return kUcclThroughputWindow;
+  }
   if (kind == PeerTransportKind::Tcp) return kTcpThroughputWindow;
   return kIpcThroughputWindow;
 }
@@ -101,7 +102,7 @@ static bool allocate_device_slots(int count, size_t msg_size,
   for (int i = 0; i < count; ++i) {
     if (gpuMalloc(&slots[i], msg_size) != gpuSuccess || slots[i] == nullptr) {
       for (void* ptr : slots) {
-        if (ptr != nullptr) (void)gpuFree(ptr);
+        if (ptr != nullptr) gpuFree(ptr);
       }
       slots.clear();
       return false;
@@ -112,26 +113,35 @@ static bool allocate_device_slots(int count, size_t msg_size,
 
 static void free_device_slots(std::vector<void*>& slots) {
   for (void* ptr : slots) {
-    if (ptr != nullptr) GPU_RT_CHECK(gpuFree(ptr));
+    if (ptr != nullptr) gpuFree(ptr);
   }
   slots.clear();
 }
 
 static std::vector<MR> register_slot_mrs(Communicator& comm,
                                          std::vector<void*> const& slots,
-                                         size_t msg_size) {
+                                         size_t msg_size,
+                                         std::vector<uint32_t>& buffer_ids) {
   std::vector<MR> mrs;
   mrs.reserve(slots.size());
-  for (void* ptr : slots) {
-    mrs.push_back(comm.reg_mr(ptr, msg_size));
+  buffer_ids.clear();
+  buffer_ids.reserve(slots.size());
+  for (size_t i = 0; i < slots.size(); ++i) {
+    void* ptr = slots[i];
+    uint32_t const buffer_id = kBenchRecvBufferIdBase + static_cast<uint32_t>(i);
+    if (!comm.reg_mr(buffer_id, ptr, msg_size, true)) {
+      return {};
+    }
+    buffer_ids.push_back(buffer_id);
+    mrs.push_back(comm.get_mr(buffer_id));
   }
   return mrs;
 }
 
 static void deregister_slot_mrs(Communicator& comm,
-                                std::vector<void*> const& slots) {
-  for (void* ptr : slots) {
-    if (ptr != nullptr) comm.dereg_mr(ptr);
+                                std::vector<uint32_t> const& buffer_ids) {
+  for (uint32_t buffer_id : buffer_ids) {
+    if (buffer_id != 0) (void)comm.dereg_mr(buffer_id);
   }
 }
 
@@ -143,7 +153,7 @@ static bool validate_recv_slots(char const* role, int rank,
   for (size_t i = 0; i < slots.size(); ++i) {
     if (!touched[i]) continue;
     if (gpuMemcpy(host.data(), slots[i], expected.size(),
-                  gpuMemcpyDeviceToHost) != gpuSuccess) {
+                   gpuMemcpyDeviceToHost) != gpuSuccess) {
       fprintf(stderr, "[%s %d] Failed to copy recv slot %zu to host\n", role,
               rank, i);
       return false;
@@ -158,54 +168,21 @@ static bool validate_recv_slots(char const* role, int rank,
 }
 
 static bool exchange_remote_recv_mrs(Communicator& comm, int peer_rank,
-                                     std::vector<MR> const& local_recv_mrs,
-                                     std::vector<MR>& remote_recv_mrs,
-                                     bool notify_first) {
-  NamedMRInfos local_infos{};
-  local_infos.generation = kBenchNamedMrGeneration;
-  local_infos.entries.reserve(local_recv_mrs.size());
-  for (size_t i = 0; i < local_recv_mrs.size(); ++i) {
-    NamedMR named{};
-    named.buffer_id = static_cast<uint32_t>(i);
-    named.mr = local_recv_mrs[i];
-    local_infos.entries.push_back(named);
+                                     size_t recv_slots,
+                                     std::vector<MR>& remote_recv_mrs) {
+  remote_recv_mrs.assign(recv_slots, MR{});
+  for (size_t i = 0; i < recv_slots; ++i) {
+    uint32_t const buffer_id = kBenchRecvBufferIdBase + static_cast<uint32_t>(i);
+    if (!comm.wait_mr(peer_rank, buffer_id)) return false;
+    remote_recv_mrs[i] = comm.get_mr(peer_rank, buffer_id);
   }
-
-  auto decode_remote_infos = [&](NamedMRInfos const& remote_infos) -> bool {
-    remote_recv_mrs.assign(local_recv_mrs.size(), MR{});
-    std::vector<char> seen(local_recv_mrs.size(), 0);
-    for (auto const& entry : remote_infos.entries) {
-      size_t idx = static_cast<size_t>(entry.buffer_id);
-      if (idx >= remote_recv_mrs.size()) return false;
-      remote_recv_mrs[idx] = entry.mr;
-      seen[idx] = 1;
-    }
-    for (char v : seen) {
-      if (!v) return false;
-    }
-    return true;
-  };
-
-  NamedMRInfos remote_infos{};
-  if (notify_first) {
-    if (!comm.notify_named_mrs(peer_rank, kBenchNamedMrGeneration, local_infos))
-      return false;
-    if (!comm.wait_named_mrs(peer_rank, kBenchNamedMrGeneration, remote_infos))
-      return false;
-    return decode_remote_infos(remote_infos);
-  }
-
-  if (!comm.wait_named_mrs(peer_rank, kBenchNamedMrGeneration, remote_infos))
-    return false;
-  if (!comm.notify_named_mrs(peer_rank, kBenchNamedMrGeneration, local_infos))
-    return false;
-  return decode_remote_infos(remote_infos);
+  return true;
 }
 
 static uint32_t remote_recv_slot_id(PeerTransportKind kind,
                                     std::vector<MR> const& remote_recv_mrs,
                                     int slot) {
-  if (kind != PeerTransportKind::Uccl && kind != PeerTransportKind::Ipc) {
+  if (kind != PeerTransportKind::Uccl) {
     return 0;
   }
   return remote_recv_mrs.at(static_cast<size_t>(slot)).id;
@@ -215,42 +192,7 @@ static std::optional<RemoteSlice> remote_recv_slice(
     PeerTransportKind kind, std::vector<MR> const& remote_recv_mrs, int slot) {
   uint32_t remote_id = remote_recv_slot_id(kind, remote_recv_mrs, slot);
   if (remote_id == 0) return std::nullopt;
-  if (kind == PeerTransportKind::Ipc) {
-    // This benchmark keeps the recv slots stable for the communicator lifetime.
-    // Publish a fixed versioned IPC buffer view up front so sends can exercise
-    // the by-mem_id direct path instead of the request-level handshake.
-    return RemoteSlice{remote_id, 0, {}, kBenchIpcBindingVersion};
-  }
   return RemoteSlice{remote_id, 0};
-}
-
-static bool publish_ipc_recv_buffers(Communicator& comm, int peer_rank,
-                                     PeerTransportKind kind,
-                                     std::vector<MR> const& local_recv_mrs,
-                                     std::vector<void*> const& recv_slots,
-                                     size_t msg_size) {
-  if (kind != PeerTransportKind::Ipc) return true;
-  for (size_t i = 0; i < local_recv_mrs.size(); ++i) {
-    if (!comm.notify_ipc_buffer(peer_rank, local_recv_mrs[i].id, recv_slots[i],
-                                msg_size, kBenchIpcBindingVersion)) {
-      return false;
-    }
-  }
-  return true;
-}
-
-static bool prefetch_remote_ipc_recv_buffers(
-    Communicator& comm, int peer_rank, PeerTransportKind kind,
-    std::vector<MR> const& remote_recv_mrs) {
-  if (kind != PeerTransportKind::Ipc) return true;
-  for (auto const& remote_mr : remote_recv_mrs) {
-    if (remote_mr.id == 0) return false;
-    if (!comm.wait_ipc_buffer(peer_rank, remote_mr.id,
-                              kBenchIpcBindingVersion)) {
-      return false;
-    }
-  }
-  return true;
 }
 
 static unsigned submit_send(Communicator& comm, int peer_rank,
@@ -329,63 +271,58 @@ void run_sender(int gpu_id, int rank, int peer_rank, int world_size,
          rank, peer_rank, peer_transport_kind_name(transport_kind),
          throughput_window);
 
-  GPU_RT_CHECK(gpuSetDevice(gpu_id));
+  gpuSetDevice(gpu_id);
 
   void* send_buf = nullptr;
   std::vector<void*> recv_slots;
+  std::vector<uint32_t> local_recv_buffer_ids;
   if (gpuMalloc(&send_buf, msg_size) != gpuSuccess || send_buf == nullptr) {
     fprintf(stderr, "[Sender %d] Failed to allocate GPU memory\n", rank);
     return;
   }
   if (!allocate_device_slots(throughput_window, msg_size, recv_slots)) {
     fprintf(stderr, "[Sender %d] Failed to allocate GPU memory\n", rank);
-    (void)gpuFree(send_buf);
+    gpuFree(send_buf);
     return;
   }
   auto cleanup = [&]() {
     if (send_buf != nullptr) {
-      comm.dereg_mr(send_buf);
-      GPU_RT_CHECK(gpuFree(send_buf));
+      (void)comm.dereg_mr(kBenchSendBufferId);
+      gpuFree(send_buf);
     }
-    deregister_slot_mrs(comm, recv_slots);
+    deregister_slot_mrs(comm, local_recv_buffer_ids);
     free_device_slots(recv_slots);
   };
 
   std::vector<uint8_t> host_buf = make_pattern(msg_size, 0);
   std::vector<uint8_t> expected_recv = make_pattern(msg_size, 97);
-  GPU_RT_CHECK(
-      gpuMemcpy(send_buf, host_buf.data(), msg_size, gpuMemcpyHostToDevice));
+  gpuMemcpy(send_buf, host_buf.data(), msg_size, gpuMemcpyHostToDevice);
   for (void* recv_slot : recv_slots) {
-    GPU_RT_CHECK(gpuMemset(recv_slot, 0, msg_size));
+    gpuMemset(recv_slot, 0, msg_size);
   }
 
-  MR local_send_mr = comm.reg_mr(send_buf, msg_size);
+  if (!comm.reg_mr(kBenchSendBufferId, send_buf, msg_size, true)) {
+    fprintf(stderr, "[Sender %d] Failed to register send buffer MR\n", rank);
+    cleanup();
+    return;
+  }
+  MR local_send_mr = comm.get_mr(kBenchSendBufferId);
   std::vector<MR> local_recv_mrs =
-      register_slot_mrs(comm, recv_slots, msg_size);
+      register_slot_mrs(comm, recv_slots, msg_size, local_recv_buffer_ids);
+  if (local_recv_mrs.size() != recv_slots.size()) {
+    fprintf(stderr, "[Sender %d] Failed to register recv slot MRs\n", rank);
+    cleanup();
+    return;
+  }
 
   printf("[Sender %d] Memory registered: send_mr=%d, recv_slots=%d\n", rank,
          local_send_mr.id, throughput_window);
 
   std::vector<MR> remote_recv_mrs;
-  if (transport_kind == PeerTransportKind::Ipc ||
-      transport_kind == PeerTransportKind::Uccl) {
-    if (!publish_ipc_recv_buffers(comm, peer_rank, transport_kind,
-                                  local_recv_mrs, recv_slots, msg_size)) {
-      fprintf(stderr, "[Sender %d] Failed to publish IPC receive buffers\n",
-              rank);
-      cleanup();
-      return;
-    }
-    if (!exchange_remote_recv_mrs(comm, peer_rank, local_recv_mrs,
-                                  remote_recv_mrs, true)) {
+  if (transport_kind == PeerTransportKind::Uccl) {
+    if (!exchange_remote_recv_mrs(comm, peer_rank, recv_slots.size(),
+                                  remote_recv_mrs)) {
       fprintf(stderr, "[Sender %d] Failed to exchange remote receive MRs\n",
-              rank);
-      cleanup();
-      return;
-    }
-    if (!prefetch_remote_ipc_recv_buffers(comm, peer_rank, transport_kind,
-                                          remote_recv_mrs)) {
-      fprintf(stderr, "[Sender %d] Failed to prefetch remote IPC buffers\n",
               rank);
       cleanup();
       return;
@@ -617,63 +554,58 @@ void run_receiver(int gpu_id, int rank, int peer_rank, int world_size,
       rank, peer_rank, peer_transport_kind_name(transport_kind),
       throughput_window);
 
-  GPU_RT_CHECK(gpuSetDevice(gpu_id));
+  gpuSetDevice(gpu_id);
 
   void* send_buf = nullptr;
   std::vector<void*> recv_slots;
+  std::vector<uint32_t> local_recv_buffer_ids;
   if (gpuMalloc(&send_buf, msg_size) != gpuSuccess || send_buf == nullptr) {
     fprintf(stderr, "[Receiver %d] Failed to allocate GPU memory\n", rank);
     return;
   }
   if (!allocate_device_slots(throughput_window, msg_size, recv_slots)) {
     fprintf(stderr, "[Receiver %d] Failed to allocate GPU memory\n", rank);
-    (void)gpuFree(send_buf);
+    gpuFree(send_buf);
     return;
   }
   auto cleanup = [&]() {
     if (send_buf != nullptr) {
-      comm.dereg_mr(send_buf);
-      GPU_RT_CHECK(gpuFree(send_buf));
+      (void)comm.dereg_mr(kBenchSendBufferId);
+      gpuFree(send_buf);
     }
-    deregister_slot_mrs(comm, recv_slots);
+    deregister_slot_mrs(comm, local_recv_buffer_ids);
     free_device_slots(recv_slots);
   };
 
   std::vector<uint8_t> host_buf = make_pattern(msg_size, 97);
   std::vector<uint8_t> expected_recv = make_pattern(msg_size, 0);
-  GPU_RT_CHECK(
-      gpuMemcpy(send_buf, host_buf.data(), msg_size, gpuMemcpyHostToDevice));
+  gpuMemcpy(send_buf, host_buf.data(), msg_size, gpuMemcpyHostToDevice);
   for (void* recv_slot : recv_slots) {
-    GPU_RT_CHECK(gpuMemset(recv_slot, 0, msg_size));
+    gpuMemset(recv_slot, 0, msg_size);
   }
 
-  MR local_send_mr = comm.reg_mr(send_buf, msg_size);
+  if (!comm.reg_mr(kBenchSendBufferId, send_buf, msg_size, true)) {
+    fprintf(stderr, "[Receiver %d] Failed to register send buffer MR\n", rank);
+    cleanup();
+    return;
+  }
+  MR local_send_mr = comm.get_mr(kBenchSendBufferId);
   std::vector<MR> local_recv_mrs =
-      register_slot_mrs(comm, recv_slots, msg_size);
+      register_slot_mrs(comm, recv_slots, msg_size, local_recv_buffer_ids);
+  if (local_recv_mrs.size() != recv_slots.size()) {
+    fprintf(stderr, "[Receiver %d] Failed to register recv slot MRs\n", rank);
+    cleanup();
+    return;
+  }
 
   printf("[Receiver %d] Memory registered: send_mr=%d, recv_slots=%d\n", rank,
          local_send_mr.id, throughput_window);
 
   std::vector<MR> remote_recv_mrs;
-  if (transport_kind == PeerTransportKind::Ipc ||
-      transport_kind == PeerTransportKind::Uccl) {
-    if (!publish_ipc_recv_buffers(comm, peer_rank, transport_kind,
-                                  local_recv_mrs, recv_slots, msg_size)) {
-      fprintf(stderr, "[Receiver %d] Failed to publish IPC receive buffers\n",
-              rank);
-      cleanup();
-      return;
-    }
-    if (!exchange_remote_recv_mrs(comm, peer_rank, local_recv_mrs,
-                                  remote_recv_mrs, false)) {
+  if (transport_kind == PeerTransportKind::Uccl) {
+    if (!exchange_remote_recv_mrs(comm, peer_rank, recv_slots.size(),
+                                  remote_recv_mrs)) {
       fprintf(stderr, "[Receiver %d] Failed to exchange remote receive MRs\n",
-              rank);
-      cleanup();
-      return;
-    }
-    if (!prefetch_remote_ipc_recv_buffers(comm, peer_rank, transport_kind,
-                                          remote_recv_mrs)) {
-      fprintf(stderr, "[Receiver %d] Failed to prefetch remote IPC buffers\n",
               rank);
       cleanup();
       return;

--- a/experimental/ukernel/include/config.h
+++ b/experimental/ukernel/include/config.h
@@ -15,6 +15,7 @@ struct CommunicatorConfig {
   std::string exchanger_ip = DEFAULT_EXCHANGER_SERVER_IP;
   int exchanger_port = DEFAULT_EXCHANGER_SERVER_PORT;
   int local_id = -1;
+  std::string oob_namespace = "default";
   PreferredTransport preferred_transport = PreferredTransport::Auto;
 
   static CommunicatorConfig from_env() {
@@ -24,6 +25,7 @@ struct CommunicatorConfig {
     config.exchanger_port = getEnvOrDefault("UHM_EXCHANGER_SERVER_PORT",
                                             DEFAULT_EXCHANGER_SERVER_PORT);
     config.local_id = getLocalIdOrDefault();
+    config.oob_namespace = getEnvOrDefault("UHM_OOB_NAMESPACE", "default");
     return config;
   }
 

--- a/experimental/ukernel/py/bench_p2p.py
+++ b/experimental/ukernel/py/bench_p2p.py
@@ -23,77 +23,64 @@ def bench_p2p_ukernel(comm, peer, size_bytes, warmup, iters):
     n = size_bytes // 4  # float32
     send_buf = torch.empty(n, device="cuda", dtype=torch.float32)
     recv_buf = torch.empty(n, device="cuda", dtype=torch.float32)
-    send_mr_id = comm.pin_tensor(send_buf)
-    recv_mr_id = comm.pin_tensor(recv_buf)
+    send_buffer_id = 1
+    recv_buffer_id = 2
+    selected_transport = comm.peer_transport(peer)
+    if not comm.reg_rdma(send_buffer_id, send_buf, publish=True):
+        raise RuntimeError("reg_rdma(send) failed")
+    if not comm.reg_rdma(recv_buffer_id, recv_buf, publish=True):
+        raise RuntimeError("reg_rdma(recv) failed")
+    ipc_registered = False
+    if selected_transport == "ipc":
+        if not comm.reg_ipc(send_buffer_id, send_buf, publish=True):
+            raise RuntimeError("reg_ipc(send) failed")
+        if not comm.reg_ipc(recv_buffer_id, recv_buf, publish=True):
+            raise RuntimeError("reg_ipc(recv) failed")
+        if not comm.wait_ipc(peer, send_buffer_id):
+            raise RuntimeError("wait_ipc(peer send buffer) failed")
+        if not comm.wait_ipc(peer, recv_buffer_id):
+            raise RuntimeError("wait_ipc(peer recv buffer) failed")
+        ipc_registered = True
+
+    # Global synchronization after publishing transport metadata.
+    if not comm.barrier("p2p_resource_ready", 30000):
+        raise RuntimeError("ukernel barrier(p2p_resource_ready) failed")
+
+    def do_send():
+        # Sender writes into peer's recv buffer id.
+        comm.send(peer, send_buf, remote_buffer_id=recv_buffer_id, remote_offset=0)
+
+    def do_recv():
+        comm.recv(peer, recv_buf)
 
     rank = comm.rank
-    use_direct_ipc = comm.peer_transport(peer) == "ipc" and comm.same_host(peer)
-    remote_recv_mr_id = 0
-    ipc_binding_version = 1
-    if use_direct_ipc:
-        remote_recv_mr_id = _exchange_peer_i64(int(recv_mr_id), rank)
-        if not comm.notify_ipc_tensor(
-            peer, recv_mr_id, recv_buf, 0, size_bytes, ipc_binding_version
-        ):
-            raise RuntimeError(
-                f"notify_ipc_tensor(peer={peer}, mr={recv_mr_id}) failed"
-            )
-        if not comm.wait_ipc_buffer(peer, remote_recv_mr_id, ipc_binding_version):
-            raise RuntimeError(
-                f"wait_ipc_buffer(peer={peer}, mr={remote_recv_mr_id}) failed"
-            )
-        dist.barrier()
-
-    def _send():
-        if use_direct_ipc:
-            comm.send_direct(
-                peer, send_buf, remote_recv_mr_id, ipc_binding_version, 0, size_bytes, 0
-            )
-        else:
-            comm.send(peer, send_buf)
-
     # Server (rank 0) recv first, client (rank 1) send first
     if rank == 0:
         for _ in range(warmup):
-            if use_direct_ipc:
-                req = comm.irecv(peer, recv_buf)
-                comm.wait_finish(req)
-            else:
-                comm.recv(peer, recv_buf)
-            _send()  # echo back
+            do_recv()
+            do_send()  # echo back
         torch.cuda.synchronize()
         t0 = time.perf_counter()
         for _ in range(iters):
-            if use_direct_ipc:
-                req = comm.irecv(peer, recv_buf)
-                comm.wait_finish(req)
-            else:
-                comm.recv(peer, recv_buf)
-            _send()
+            do_recv()
+            do_send()
         torch.cuda.synchronize()
     else:
         for _ in range(warmup):
-            if use_direct_ipc:
-                req = comm.irecv(peer, recv_buf)
-            _send()
-            if use_direct_ipc:
-                comm.wait_finish(req)
-            else:
-                comm.recv(peer, recv_buf)
+            do_send()
+            do_recv()
         torch.cuda.synchronize()
         t0 = time.perf_counter()
         for _ in range(iters):
-            if use_direct_ipc:
-                req = comm.irecv(peer, recv_buf)
-            _send()
-            if use_direct_ipc:
-                comm.wait_finish(req)
-            else:
-                comm.recv(peer, recv_buf)
+            do_send()
+            do_recv()
         torch.cuda.synchronize()
     elapsed = time.perf_counter() - t0
-    comm.unpin_tensor(send_buf)
-    comm.unpin_tensor(recv_buf)
+    if ipc_registered:
+        comm.unreg_ipc(send_buffer_id)
+        comm.unreg_ipc(recv_buffer_id)
+    comm.unreg_rdma(send_buffer_id)
+    comm.unreg_rdma(recv_buffer_id)
     return elapsed
 
 
@@ -157,38 +144,23 @@ def _recv_bytes(src: int) -> bytes:
     return bytes(t.tolist())
 
 
-def _exchange_uccl_metadata(local_metadata: bytes, local_gpu_bdf: str, rank: int):
-    local_bdf_bytes = local_gpu_bdf.encode("utf-8")
+def _exchange_uccl_metadata(local_metadata: bytes, rank: int):
     if rank == 0:
         _send_bytes(local_metadata, dst=1)
-        _send_bytes(local_bdf_bytes, dst=1)
         remote_metadata = _recv_bytes(src=1)
-        remote_gpu_bdf = _recv_bytes(src=1).decode("utf-8")
     else:
         remote_metadata = _recv_bytes(src=0)
-        remote_gpu_bdf = _recv_bytes(src=0).decode("utf-8")
         _send_bytes(local_metadata, dst=0)
-        _send_bytes(local_bdf_bytes, dst=0)
-    return remote_metadata, remote_gpu_bdf
+    return remote_metadata
 
 
-def _exchange_local_gpu_bdf(local_gpu_bdf: str, rank: int) -> str:
-    local_bdf_bytes = local_gpu_bdf.encode("utf-8")
+def _exchange_local_gpu_idx(local_gpu_idx: int, rank: int) -> int:
     if rank == 0:
-        _send_bytes(local_bdf_bytes, dst=1)
-        return _recv_bytes(src=1).decode("utf-8")
-    remote_gpu_bdf = _recv_bytes(src=0).decode("utf-8")
-    _send_bytes(local_bdf_bytes, dst=0)
-    return remote_gpu_bdf
-
-
-def _exchange_peer_i64(local_value: int, rank: int) -> int:
-    if rank == 0:
-        _send_i64(local_value, dst=1)
+        _send_i64(local_gpu_idx, dst=1)
         return _recv_i64(src=1)
-    remote_value = _recv_i64(src=0)
-    _send_i64(local_value, dst=0)
-    return remote_value
+    remote_gpu_idx = _recv_i64(src=0)
+    _send_i64(local_gpu_idx, dst=0)
+    return remote_gpu_idx
 
 
 def _create_uccl_endpoint(local_gpu_idx: int, rank: int):
@@ -338,9 +310,6 @@ def main() -> None:
         uc_send_conn_id = None
         uc_recv_conn_id = None
         uc_ep = _create_uccl_endpoint(local_rank, rank)
-        local_meta = bytes(uc_ep.get_metadata())
-        _, _, local_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(local_meta)
-        local_gpu_bdf = str(local_gpu_bdf)
         if uc_mode == "ipc":
             required_ipc_api = ("connect_local", "accept_local", "send_ipc", "recv_ipc")
             missing = [name for name in required_ipc_api if not hasattr(uc_ep, name)]
@@ -348,36 +317,35 @@ def main() -> None:
                 raise RuntimeError(
                     f"[uccl] ipc mode requested but endpoint lacks API: {missing}"
                 )
-            remote_gpu_bdf = _exchange_local_gpu_bdf(local_gpu_bdf, rank)
+            remote_gpu_idx = _exchange_local_gpu_idx(local_rank, rank)
             if rank == 0:
-                ok, uc_send_conn_id = uc_ep.connect_local(remote_gpu_bdf)
+                ok, uc_send_conn_id = uc_ep.connect_local(remote_gpu_idx)
                 assert ok, "[uccl] connect_local(0->1) failed"
                 ok, _, uc_recv_conn_id = uc_ep.accept_local()
                 assert ok, "[uccl] accept_local(1->0) failed"
             else:
                 ok, _, uc_recv_conn_id = uc_ep.accept_local()
                 assert ok, "[uccl] accept_local(0->1) failed"
-                ok, uc_send_conn_id = uc_ep.connect_local(remote_gpu_bdf)
+                ok, uc_send_conn_id = uc_ep.connect_local(remote_gpu_idx)
                 assert ok, "[uccl] connect_local(1->0) failed"
         else:
-            remote_meta, remote_gpu_bdf = _exchange_uccl_metadata(
-                local_meta, local_gpu_bdf, rank
-            )
-            ip, port, meta_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(remote_meta)
-            target_gpu_bdf = str(meta_gpu_bdf) if meta_gpu_bdf else remote_gpu_bdf
+            local_meta = bytes(uc_ep.get_metadata())
+            _, _, local_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(local_meta)
+            local_gpu_bdf = str(local_gpu_bdf)
+            remote_meta = _exchange_uccl_metadata(local_meta, rank)
             if rank == 0:
-                ok, uc_send_conn_id = uc_ep.connect(
-                    ip, target_gpu_bdf, remote_port=port
-                )
+                ip, port, remote_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(remote_meta)
+                remote_gpu_bdf = str(remote_gpu_bdf)
+                ok, uc_send_conn_id = uc_ep.connect(ip, remote_gpu_bdf, remote_port=port)
                 assert ok, "[uccl] connect(0->1) failed"
                 ok, _, _, uc_recv_conn_id = uc_ep.accept()
                 assert ok, "[uccl] accept(1->0) failed"
             else:
                 ok, _, _, uc_recv_conn_id = uc_ep.accept()
                 assert ok, "[uccl] accept(0->1) failed"
-                ok, uc_send_conn_id = uc_ep.connect(
-                    ip, target_gpu_bdf, remote_port=port
-                )
+                ip, port, remote_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(remote_meta)
+                remote_gpu_bdf = str(remote_gpu_bdf)
+                ok, uc_send_conn_id = uc_ep.connect(ip, remote_gpu_bdf, remote_port=port)
                 assert ok, "[uccl] connect(1->0) failed"
         dist.barrier()
         if rank == 0:

--- a/experimental/ukernel/py/bench_p2p.py
+++ b/experimental/ukernel/py/bench_p2p.py
@@ -330,8 +330,7 @@ def main() -> None:
                 assert ok, "[uccl] connect_local(1->0) failed"
         else:
             local_meta = bytes(uc_ep.get_metadata())
-            _, _, local_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(local_meta)
-            local_gpu_bdf = str(local_gpu_bdf)
+            _, _, _ = uccl_p2p.Endpoint.parse_metadata(local_meta)
             remote_meta = _exchange_uccl_metadata(local_meta, rank)
             if rank == 0:
                 ip, port, remote_gpu_bdf = uccl_p2p.Endpoint.parse_metadata(remote_meta)

--- a/experimental/ukernel/py/test_p2p.py
+++ b/experimental/ukernel/py/test_p2p.py
@@ -27,12 +27,17 @@ def run_server() -> None:
         raise RuntimeError("accept_peer(1) failed")
     print(f"[rank {rank}] accepted client")
 
+    recv_buffer_id = 100
     recv = torch.empty(16, device="cuda", dtype=torch.float32)
+    if not comm.reg_rdma(recv_buffer_id, recv, publish=True):
+        raise RuntimeError("reg_rdma(recv) failed")
+
     comm.recv(1, recv)
     print(f"[rank {rank}] received: {recv}")
 
     if recv.sum() == 0:
         raise RuntimeError("No data received!")
+    comm.unreg_rdma(recv_buffer_id)
     print(f"[rank {rank}] P2P server test passed!")
 
 
@@ -55,8 +60,16 @@ def run_client() -> None:
         raise RuntimeError("connect_peer(0) failed")
     print(f"[rank {rank}] connected to server")
 
+    recv_buffer_id = 100
     send = torch.arange(0, 16, device="cuda", dtype=torch.float32)
-    comm.send(0, send)
+    send_buffer_id = 200
+    if not comm.reg_rdma(send_buffer_id, send, publish=True):
+        raise RuntimeError("reg_rdma(send) failed")
+    if not comm.wait_mr(0, recv_buffer_id):
+        raise RuntimeError("wait_mr(server recv buffer) failed")
+
+    comm.send(0, send, recv_buffer_id, remote_offset=0)
+    comm.unreg_rdma(send_buffer_id)
     print(f"[rank {rank}] sent: {send}")
     print(f"[rank {rank}] P2P client test passed!")
 

--- a/experimental/ukernel/py/ukernel_ccl.cpp
+++ b/experimental/ukernel/py/ukernel_ccl.cpp
@@ -281,11 +281,28 @@ class ProcessGroup {
         }),
         executor_(
             ExecutorBackends{&transport_backend_, &device_backend_, nullptr},
-            [this](int remote_rank, uint32_t mr_id, size_t offset, size_t bytes,
+            [this](int remote_rank, uint32_t remote_buffer_id, size_t offset,
+                   size_t bytes,
                    void** out_ptr, int* out_device_idx) {
-              return transport_backend_.communicator()
-                  .resolve_ipc_buffer_pointer(remote_rank, mr_id, offset, bytes,
-                                              out_ptr, out_device_idx);
+              if (out_ptr == nullptr) return false;
+              UKernel::Transport::IPCItem ipc{};
+              try {
+                ipc = transport_backend_.communicator().get_ipc(remote_rank,
+                                                                remote_buffer_id);
+              } catch (...) {
+                return false;
+              }
+              if (!ipc.valid || ipc.direct_ptr == nullptr) return false;
+              if (offset > ipc.bytes || bytes > ipc.bytes - offset) {
+                return false;
+              }
+              *out_ptr = reinterpret_cast<void*>(
+                  reinterpret_cast<uintptr_t>(ipc.direct_ptr) +
+                  ipc.base_offset + offset);
+              if (out_device_idx != nullptr) {
+                *out_device_idx = ipc.device_idx;
+              }
+              return true;
             }) {
     if (world_size_ < 2) {
       throw std::invalid_argument("world_size must be >= 2");

--- a/experimental/ukernel/py/ukernel_ccl.cpp
+++ b/experimental/ukernel/py/ukernel_ccl.cpp
@@ -269,6 +269,7 @@ class ProcessGroup {
                     exchanger_ip,
                     exchanger_port,
                     rank,
+                    "default",
                     parse_transport(transport),
                 }),
         }),
@@ -441,8 +442,8 @@ class ProcessGroup {
             ? roles_
             : CollectiveBufferRoles{
                   kDefaultInputBufferId,
-                  2,
                   kDefaultScratchBufferId,
+                  static_cast<BufferId>(kDefaultScratchBufferId + 1),
               };
     CollectivePlan plan =
         build_plan(make_plan_request(CollectiveKind::AllToAll, config, roles));

--- a/experimental/ukernel/py/ukernel_ccl.cpp
+++ b/experimental/ukernel/py/ukernel_ccl.cpp
@@ -283,13 +283,12 @@ class ProcessGroup {
         executor_(
             ExecutorBackends{&transport_backend_, &device_backend_, nullptr},
             [this](int remote_rank, uint32_t remote_buffer_id, size_t offset,
-                   size_t bytes,
-                   void** out_ptr, int* out_device_idx) {
+                   size_t bytes, void** out_ptr, int* out_device_idx) {
               if (out_ptr == nullptr) return false;
               UKernel::Transport::IPCItem ipc{};
               try {
-                ipc = transport_backend_.communicator().get_ipc(remote_rank,
-                                                                remote_buffer_id);
+                ipc = transport_backend_.communicator().get_ipc(
+                    remote_rank, remote_buffer_id);
               } catch (...) {
                 return false;
               }

--- a/experimental/ukernel/py/ukernel_p2p.cpp
+++ b/experimental/ukernel/py/ukernel_p2p.cpp
@@ -6,6 +6,8 @@
 #include <nanobind/stl/vector.h>
 #include <torch/csrc/autograd/python_variable.h>
 #include <torch/extension.h>
+#include <algorithm>
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -13,6 +15,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace nb = nanobind;
@@ -60,19 +63,31 @@ class Communicator {
   }
 
   ~Communicator() {
-    std::vector<void*> pinned_ptrs;
+    std::vector<uint32_t> rdma_buffer_ids;
+    std::vector<uint32_t> ipc_buffer_ids;
     {
       std::lock_guard<std::mutex> lk(mu_);
-      pinned_ptrs.reserve(pinned_tensors_.size());
-      for (auto const& it : pinned_tensors_) {
-        pinned_ptrs.push_back(it.first);
+      rdma_buffer_ids.reserve(rdma_buffer_to_ptr_.size());
+      for (auto const& it : rdma_buffer_to_ptr_) {
+        rdma_buffer_ids.push_back(it.first);
       }
-      pinned_tensors_.clear();
+      ipc_buffer_ids.reserve(ipc_buffer_to_ptr_.size());
+      for (auto const& it : ipc_buffer_to_ptr_) {
+        ipc_buffer_ids.push_back(it.first);
+      }
+      tensor_bindings_.clear();
+      rdma_buffer_to_ptr_.clear();
+      ipc_buffer_to_ptr_.clear();
       pending_requests_.clear();
     }
-    for (void* ptr : pinned_ptrs) {
-      if (ptr != nullptr) {
-        comm_->dereg_mr(ptr);
+    for (uint32_t buffer_id : rdma_buffer_ids) {
+      if (buffer_id != 0) {
+        (void)comm_->dereg_mr(buffer_id);
+      }
+    }
+    for (uint32_t buffer_id : ipc_buffer_ids) {
+      if (buffer_id != 0) {
+        (void)comm_->dereg_ipc(buffer_id);
       }
     }
   }
@@ -83,59 +98,85 @@ class Communicator {
   bool connect_peer(int peer_rank) { return comm_->connect(peer_rank); }
   bool accept_peer(int peer_rank) { return comm_->accept(peer_rank); }
 
-  uint32_t pin_tensor(nb::handle tensor) {
+  bool reg_rdma(uint32_t buffer_id, nb::handle tensor, bool publish = true) {
+    if (buffer_id == 0) throw std::invalid_argument("buffer_id must be non-zero");
     torch::Tensor t = tensor_from_python(tensor, "tensor");
-    if (!t.is_cuda()) {
-      throw std::invalid_argument("pin_tensor requires a CUDA tensor");
-    }
+    if (!t.is_cuda()) throw std::invalid_argument("reg_rdma requires CUDA tensor");
     if (!t.is_contiguous()) {
-      throw std::invalid_argument("pin_tensor requires a contiguous tensor");
+      throw std::invalid_argument("reg_rdma requires contiguous tensor");
     }
     size_t total_bytes =
         static_cast<size_t>(t.numel()) * static_cast<size_t>(t.element_size());
-    if (total_bytes == 0) {
-      throw std::invalid_argument("pin_tensor requires non-empty tensor");
-    }
-
+    if (total_bytes == 0) throw std::invalid_argument("reg_rdma requires non-empty tensor");
     void* ptr = t.data_ptr();
+    if (!comm_->reg_mr(buffer_id, ptr, total_bytes, publish)) return false;
     {
       std::lock_guard<std::mutex> lk(mu_);
-      auto it = pinned_tensors_.find(ptr);
-      if (it != pinned_tensors_.end()) {
-        if (it->second.bytes != total_bytes) {
-          throw std::runtime_error(
-              "pinned tensor size changed for the same pointer");
-        }
-        return it->second.mr_id;
-      }
+      tensor_bindings_[ptr] = PinnedTensor{std::move(t), buffer_id, total_bytes};
+      rdma_buffer_to_ptr_[buffer_id] = ptr;
     }
-
-    auto mr = comm_->reg_mr(ptr, total_bytes);
-    if (mr.id == 0) {
-      throw std::runtime_error("pin_tensor failed to register MR");
-    }
-
-    std::lock_guard<std::mutex> lk(mu_);
-    pinned_tensors_[ptr] = PinnedTensor{std::move(t), mr.id, total_bytes};
-    return mr.id;
+    return true;
   }
 
-  bool unpin_tensor(nb::handle tensor) {
-    torch::Tensor t = tensor_from_python(tensor, "tensor");
-    void* ptr = t.data_ptr();
-    PinnedTensor pinned;
+  bool unreg_rdma(uint32_t buffer_id) {
+    void* ptr = nullptr;
     {
       std::lock_guard<std::mutex> lk(mu_);
-      auto it = pinned_tensors_.find(ptr);
-      if (it == pinned_tensors_.end()) return false;
-      pinned = std::move(it->second);
-      pinned_tensors_.erase(it);
+      auto it = rdma_buffer_to_ptr_.find(buffer_id);
+      if (it != rdma_buffer_to_ptr_.end()) {
+        ptr = it->second;
+        rdma_buffer_to_ptr_.erase(it);
+      }
+      if (ptr != nullptr) tensor_bindings_.erase(ptr);
     }
-    return comm_->dereg_mr(ptr);
+    return comm_->dereg_mr(buffer_id);
+  }
+
+  bool reg_ipc(uint32_t buffer_id, nb::handle tensor, bool publish = true) {
+    if (buffer_id == 0) throw std::invalid_argument("buffer_id must be non-zero");
+    torch::Tensor t = tensor_from_python(tensor, "tensor");
+    if (!t.is_cuda()) throw std::invalid_argument("reg_ipc requires CUDA tensor");
+    if (!t.is_contiguous()) {
+      throw std::invalid_argument("reg_ipc requires contiguous tensor");
+    }
+    size_t total_bytes =
+        static_cast<size_t>(t.numel()) * static_cast<size_t>(t.element_size());
+    if (total_bytes == 0) throw std::invalid_argument("reg_ipc requires non-empty tensor");
+    void* ptr = t.data_ptr();
+    if (!comm_->reg_ipc(buffer_id, ptr, total_bytes, publish)) return false;
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      tensor_bindings_[ptr] = PinnedTensor{std::move(t), buffer_id, total_bytes};
+      ipc_buffer_to_ptr_[buffer_id] = ptr;
+    }
+    return true;
+  }
+
+  bool unreg_ipc(uint32_t buffer_id) {
+    void* ptr = nullptr;
+    {
+      std::lock_guard<std::mutex> lk(mu_);
+      auto it = ipc_buffer_to_ptr_.find(buffer_id);
+      if (it != ipc_buffer_to_ptr_.end()) {
+        ptr = it->second;
+        ipc_buffer_to_ptr_.erase(it);
+      }
+      if (ptr != nullptr) tensor_bindings_.erase(ptr);
+    }
+    return comm_->dereg_ipc(buffer_id);
+  }
+
+  bool wait_ipc(int peer_rank, uint32_t buffer_id) {
+    return comm_->wait_ipc(peer_rank, buffer_id);
+  }
+
+  bool wait_mr(int peer_rank, uint32_t buffer_id) {
+    return comm_->wait_mr(peer_rank, buffer_id);
   }
 
   uint64_t isend(int peer_rank, nb::handle tensor, size_t offset = 0,
-                 size_t len = 0) {
+                 size_t len = 0, uint32_t remote_buffer_id = 0,
+                 size_t remote_offset = 0) {
     torch::Tensor t = tensor_from_python(tensor, "tensor");
     if (!t.is_cuda()) {
       throw std::invalid_argument("isend requires a CUDA tensor");
@@ -149,21 +190,37 @@ class Communicator {
     if (offset + len > total_bytes) {
       throw std::invalid_argument("isend offset+len exceeds tensor size");
     }
-    auto pinned_mr = find_pinned_mr_id(t.data_ptr(), total_bytes);
-    uint32_t mr_id = pinned_mr.has_value()
-                         ? *pinned_mr
-                         : comm_->reg_mr(t.data_ptr(), total_bytes).id;
-    uint64_t req = comm_->isend(
-        peer_rank, UKernel::Transport::LocalSlice{mr_id, offset, len},
-        std::nullopt);
+    auto binding = find_tensor_binding(t.data_ptr(), total_bytes);
+    uint32_t buffer_id = 0;
+    if (binding.has_value()) {
+      buffer_id = binding->buffer_id;
+    } else {
+      buffer_id = next_temporary_buffer_id_.fetch_add(1, std::memory_order_relaxed);
+      if (!comm_->reg_mr(buffer_id, t.data_ptr(), total_bytes, false)) {
+        throw std::runtime_error("isend failed to register temporary MR");
+      }
+    }
+    std::optional<UKernel::Transport::RemoteSlice> dst_hint = std::nullopt;
+    uint32_t dst_buffer_id = remote_buffer_id;
+    if (dst_buffer_id == 0 && binding.has_value()) {
+      // By default, use the same logical buffer_id on peer side.
+      dst_buffer_id = binding->buffer_id;
+    }
+    if (dst_buffer_id != 0) {
+      dst_hint = UKernel::Transport::RemoteSlice{dst_buffer_id, remote_offset,
+                                                 {}};
+    }
+    uint64_t req =
+        comm_->isend(peer_rank,
+                     UKernel::Transport::LocalSlice{buffer_id, offset, len},
+                     dst_hint);
     if (req == 0) {
-      if (!pinned_mr.has_value()) {
-        comm_->dereg_mr(t.data_ptr());
+      if (!binding.has_value()) {
+        comm_->dereg_mr(buffer_id);
       }
       return 0;
     }
-    track_request(req, std::move(t),
-                  pinned_mr.has_value() ? nullptr : t.data_ptr());
+    track_request(req, std::move(t), binding.has_value() ? 0 : buffer_id);
     return req;
   }
 
@@ -182,95 +239,26 @@ class Communicator {
     if (offset + len > total_bytes) {
       throw std::invalid_argument("irecv offset+len exceeds tensor size");
     }
-    auto pinned_mr = find_pinned_mr_id(t.data_ptr(), total_bytes);
-    uint32_t mr_id = pinned_mr.has_value()
-                         ? *pinned_mr
-                         : comm_->reg_mr(t.data_ptr(), total_bytes).id;
+    auto binding = find_tensor_binding(t.data_ptr(), total_bytes);
+    uint32_t buffer_id = 0;
+    if (binding.has_value()) {
+      buffer_id = binding->buffer_id;
+    } else {
+      buffer_id = next_temporary_buffer_id_.fetch_add(1, std::memory_order_relaxed);
+      if (!comm_->reg_mr(buffer_id, t.data_ptr(), total_bytes, false)) {
+        throw std::runtime_error("irecv failed to register temporary MR");
+      }
+    }
     uint64_t req = comm_->irecv(
-        peer_rank, UKernel::Transport::LocalSlice{mr_id, offset, len});
+        peer_rank, UKernel::Transport::LocalSlice{buffer_id, offset, len});
     if (req == 0) {
-      if (!pinned_mr.has_value()) {
-        comm_->dereg_mr(t.data_ptr());
+      if (!binding.has_value()) {
+        comm_->dereg_mr(buffer_id);
       }
       return 0;
     }
-    track_request(req, std::move(t),
-                  pinned_mr.has_value() ? nullptr : t.data_ptr());
+    track_request(req, std::move(t), binding.has_value() ? 0 : buffer_id);
     return req;
-  }
-
-  uint64_t isend_direct(int peer_rank, nb::handle tensor, uint32_t remote_mr_id,
-                        uint64_t binding_version = 1, size_t offset = 0,
-                        size_t len = 0, size_t remote_offset = 0) {
-    if (remote_mr_id == 0) {
-      throw std::invalid_argument(
-          "isend_direct requires non-zero remote_mr_id");
-    }
-    torch::Tensor t = tensor_from_python(tensor, "tensor");
-    if (!t.is_cuda()) {
-      throw std::invalid_argument("isend_direct requires a CUDA tensor");
-    }
-    if (!t.is_contiguous()) {
-      throw std::invalid_argument("isend_direct requires a contiguous tensor");
-    }
-    size_t elem_bytes = static_cast<size_t>(t.element_size());
-    size_t total_bytes = static_cast<size_t>(t.numel()) * elem_bytes;
-    if (len == 0) len = total_bytes;
-    if (offset + len > total_bytes) {
-      throw std::invalid_argument(
-          "isend_direct offset+len exceeds tensor size");
-    }
-    auto pinned_mr = find_pinned_mr_id(t.data_ptr(), total_bytes);
-    uint32_t mr_id = pinned_mr.has_value()
-                         ? *pinned_mr
-                         : comm_->reg_mr(t.data_ptr(), total_bytes).id;
-    uint64_t req = comm_->isend(
-        peer_rank, UKernel::Transport::LocalSlice{mr_id, offset, len},
-        UKernel::Transport::RemoteSlice{
-            remote_mr_id, remote_offset, {}, binding_version});
-    if (req == 0) {
-      if (!pinned_mr.has_value()) {
-        comm_->dereg_mr(t.data_ptr());
-      }
-      return 0;
-    }
-    track_request(req, std::move(t),
-                  pinned_mr.has_value() ? nullptr : t.data_ptr());
-    return req;
-  }
-
-  bool notify_ipc_tensor(int peer_rank, uint32_t ipc_id, nb::handle tensor,
-                         size_t offset = 0, size_t len = 0,
-                         uint64_t binding_version = 0) {
-    torch::Tensor t = tensor_from_python(tensor, "tensor");
-    if (!t.is_cuda()) {
-      throw std::invalid_argument("notify_ipc_tensor requires a CUDA tensor");
-    }
-    if (!t.is_contiguous()) {
-      throw std::invalid_argument(
-          "notify_ipc_tensor requires a contiguous tensor");
-    }
-    size_t elem_bytes = static_cast<size_t>(t.element_size());
-    size_t total_bytes = static_cast<size_t>(t.numel()) * elem_bytes;
-    if (offset > total_bytes) {
-      throw std::invalid_argument(
-          "notify_ipc_tensor offset exceeds tensor size");
-    }
-    if (len == 0) len = total_bytes - offset;
-    if (offset + len > total_bytes) {
-      throw std::invalid_argument(
-          "notify_ipc_tensor offset+len exceeds tensor size");
-    }
-    void* ptr =
-        reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(t.data_ptr()) +
-                                static_cast<uintptr_t>(offset));
-    return comm_->notify_ipc_buffer(peer_rank, ipc_id, ptr, len,
-                                    binding_version);
-  }
-
-  bool wait_ipc_buffer(int peer_rank, uint32_t ipc_id,
-                       uint64_t binding_version = 0) {
-    return comm_->wait_ipc_buffer(peer_rank, ipc_id, binding_version);
   }
 
   bool poll(uint64_t req) {
@@ -328,16 +316,15 @@ class Communicator {
 
   bool same_host(int peer_rank) const { return comm_->same_host(peer_rank); }
 
-  void send(int peer_rank, nb::handle tensor) {
-    uint64_t req = isend(peer_rank, tensor);
-    wait_finish(req);
+  bool barrier(std::string const& barrier_namespace = "default",
+               int timeout_ms = -1) {
+    return comm_->barrier(barrier_namespace, timeout_ms);
   }
 
-  void send_direct(int peer_rank, nb::handle tensor, uint32_t remote_mr_id,
-                   uint64_t binding_version = 1, size_t offset = 0,
-                   size_t len = 0, size_t remote_offset = 0) {
-    uint64_t req = isend_direct(peer_rank, tensor, remote_mr_id,
-                                binding_version, offset, len, remote_offset);
+  void send(int peer_rank, nb::handle tensor, uint32_t remote_buffer_id = 0,
+            size_t remote_offset = 0) {
+    uint64_t req =
+        isend(peer_rank, tensor, 0, 0, remote_buffer_id, remote_offset);
     wait_finish(req);
   }
 
@@ -349,28 +336,30 @@ class Communicator {
  private:
   struct PendingTensorRequest {
     torch::Tensor tensor;
-    void* local_buf = nullptr;
+    uint32_t temporary_buffer_id = 0;
   };
 
   struct PinnedTensor {
     torch::Tensor tensor;
-    uint32_t mr_id = 0;
+    uint32_t buffer_id = 0;
     size_t bytes = 0;
   };
 
-  std::optional<uint32_t> find_pinned_mr_id(void* ptr, size_t bytes) const {
+  std::optional<PinnedTensor> find_tensor_binding(void* ptr, size_t bytes) const {
     std::lock_guard<std::mutex> lk(mu_);
-    auto it = pinned_tensors_.find(ptr);
-    if (it == pinned_tensors_.end()) return std::nullopt;
+    auto it = tensor_bindings_.find(ptr);
+    if (it == tensor_bindings_.end()) return std::nullopt;
     if (it->second.bytes != bytes) {
-      throw std::runtime_error("pinned tensor size mismatch");
+      throw std::runtime_error("registered tensor size mismatch");
     }
-    return it->second.mr_id;
+    return it->second;
   }
 
-  void track_request(uint64_t req, torch::Tensor tensor, void* local_buf) {
+  void track_request(uint64_t req, torch::Tensor tensor,
+                     uint32_t temporary_buffer_id) {
     std::lock_guard<std::mutex> lk(mu_);
-    pending_requests_[req] = PendingTensorRequest{std::move(tensor), local_buf};
+    pending_requests_[req] =
+        PendingTensorRequest{std::move(tensor), temporary_buffer_id};
   }
 
   void cleanup_request(uint64_t req) {
@@ -382,14 +371,17 @@ class Communicator {
       pending = std::move(it->second);
       pending_requests_.erase(it);
     }
-    if (pending.local_buf != nullptr) {
-      comm_->dereg_mr(pending.local_buf);
+    if (pending.temporary_buffer_id != 0) {
+      comm_->dereg_mr(pending.temporary_buffer_id);
     }
   }
 
   std::shared_ptr<UKernel::Transport::Communicator> comm_;
-  std::unordered_map<void*, PinnedTensor> pinned_tensors_;
+  std::unordered_map<void*, PinnedTensor> tensor_bindings_;
+  std::unordered_map<uint32_t, void*> rdma_buffer_to_ptr_;
+  std::unordered_map<uint32_t, void*> ipc_buffer_to_ptr_;
   std::unordered_map<uint64_t, PendingTensorRequest> pending_requests_;
+  std::atomic<uint32_t> next_temporary_buffer_id_{0x80000000u};
   mutable std::mutex mu_;
 };
 
@@ -410,23 +402,21 @@ NB_MODULE(TORCH_EXTENSION_NAME, m) {
       .def_prop_ro("world_size", &Communicator::world_size)
       .def("connect_peer", &Communicator::connect_peer, nb::arg("peer_rank"))
       .def("accept_peer", &Communicator::accept_peer, nb::arg("peer_rank"))
-      .def("pin_tensor", &Communicator::pin_tensor, nb::arg("tensor"))
-      .def("unpin_tensor", &Communicator::unpin_tensor, nb::arg("tensor"))
+      .def("reg_rdma", &Communicator::reg_rdma, nb::arg("buffer_id"),
+           nb::arg("tensor"), nb::arg("publish") = true)
+      .def("unreg_rdma", &Communicator::unreg_rdma, nb::arg("buffer_id"))
+      .def("reg_ipc", &Communicator::reg_ipc, nb::arg("buffer_id"),
+           nb::arg("tensor"), nb::arg("publish") = true)
+      .def("unreg_ipc", &Communicator::unreg_ipc, nb::arg("buffer_id"))
+      .def("wait_mr", &Communicator::wait_mr, nb::arg("peer_rank"),
+           nb::arg("buffer_id"))
+      .def("wait_ipc", &Communicator::wait_ipc, nb::arg("peer_rank"),
+           nb::arg("buffer_id"))
       .def("isend", &Communicator::isend, nb::arg("peer_rank"),
-           nb::arg("tensor"), nb::arg("offset") = 0, nb::arg("len") = 0)
-      .def("isend_direct", &Communicator::isend_direct, nb::arg("peer_rank"),
-           nb::arg("tensor"), nb::arg("remote_mr_id"),
-           nb::arg("binding_version") = 1, nb::arg("offset") = 0,
-           nb::arg("len") = 0, nb::arg("remote_offset") = 0)
+           nb::arg("tensor"), nb::arg("offset") = 0, nb::arg("len") = 0,
+           nb::arg("remote_buffer_id") = 0, nb::arg("remote_offset") = 0)
       .def("irecv", &Communicator::irecv, nb::arg("peer_rank"),
            nb::arg("tensor"), nb::arg("offset") = 0, nb::arg("len") = 0)
-      .def("notify_ipc_tensor", &Communicator::notify_ipc_tensor,
-           nb::arg("peer_rank"), nb::arg("ipc_id"), nb::arg("tensor"),
-           nb::arg("offset") = 0, nb::arg("len") = 0,
-           nb::arg("binding_version") = 0)
-      .def("wait_ipc_buffer", &Communicator::wait_ipc_buffer,
-           nb::arg("peer_rank"), nb::arg("ipc_id"),
-           nb::arg("binding_version") = 0)
       .def("poll", &Communicator::poll, nb::arg("req"))
       .def("release", &Communicator::release, nb::arg("req"))
       .def("wait_finish", &Communicator::wait_finish, nb::arg("req"))
@@ -435,11 +425,11 @@ NB_MODULE(TORCH_EXTENSION_NAME, m) {
       .def("peer_transport", &Communicator::peer_transport,
            nb::arg("peer_rank"))
       .def("same_host", &Communicator::same_host, nb::arg("peer_rank"))
-      .def("send", &Communicator::send, nb::arg("peer_rank"), nb::arg("tensor"))
-      .def("send_direct", &Communicator::send_direct, nb::arg("peer_rank"),
-           nb::arg("tensor"), nb::arg("remote_mr_id"),
-           nb::arg("binding_version") = 1, nb::arg("offset") = 0,
-           nb::arg("len") = 0, nb::arg("remote_offset") = 0)
+      .def("barrier", &Communicator::barrier,
+           nb::arg("barrier_namespace") = "default",
+           nb::arg("timeout_ms") = -1)
+      .def("send", &Communicator::send, nb::arg("peer_rank"), nb::arg("tensor"),
+           nb::arg("remote_buffer_id") = 0, nb::arg("remote_offset") = 0)
       .def("recv", &Communicator::recv, nb::arg("peer_rank"),
            nb::arg("tensor"));
 }

--- a/experimental/ukernel/py/ukernel_p2p.cpp
+++ b/experimental/ukernel/py/ukernel_p2p.cpp
@@ -57,6 +57,7 @@ class Communicator {
                     exchanger_ip,
                     exchanger_port,
                     local_id,
+                    "default",
                     parse_transport(transport),
                 }))) {
     GPU_RT_CHECK(gpuSetDevice(gpu_id));

--- a/experimental/ukernel/py/ukernel_p2p.cpp
+++ b/experimental/ukernel/py/ukernel_p2p.cpp
@@ -100,20 +100,24 @@ class Communicator {
   bool accept_peer(int peer_rank) { return comm_->accept(peer_rank); }
 
   bool reg_rdma(uint32_t buffer_id, nb::handle tensor, bool publish = true) {
-    if (buffer_id == 0) throw std::invalid_argument("buffer_id must be non-zero");
+    if (buffer_id == 0)
+      throw std::invalid_argument("buffer_id must be non-zero");
     torch::Tensor t = tensor_from_python(tensor, "tensor");
-    if (!t.is_cuda()) throw std::invalid_argument("reg_rdma requires CUDA tensor");
+    if (!t.is_cuda())
+      throw std::invalid_argument("reg_rdma requires CUDA tensor");
     if (!t.is_contiguous()) {
       throw std::invalid_argument("reg_rdma requires contiguous tensor");
     }
     size_t total_bytes =
         static_cast<size_t>(t.numel()) * static_cast<size_t>(t.element_size());
-    if (total_bytes == 0) throw std::invalid_argument("reg_rdma requires non-empty tensor");
+    if (total_bytes == 0)
+      throw std::invalid_argument("reg_rdma requires non-empty tensor");
     void* ptr = t.data_ptr();
     if (!comm_->reg_mr(buffer_id, ptr, total_bytes, publish)) return false;
     {
       std::lock_guard<std::mutex> lk(mu_);
-      tensor_bindings_[ptr] = PinnedTensor{std::move(t), buffer_id, total_bytes};
+      tensor_bindings_[ptr] =
+          PinnedTensor{std::move(t), buffer_id, total_bytes};
       rdma_buffer_to_ptr_[buffer_id] = ptr;
     }
     return true;
@@ -134,20 +138,24 @@ class Communicator {
   }
 
   bool reg_ipc(uint32_t buffer_id, nb::handle tensor, bool publish = true) {
-    if (buffer_id == 0) throw std::invalid_argument("buffer_id must be non-zero");
+    if (buffer_id == 0)
+      throw std::invalid_argument("buffer_id must be non-zero");
     torch::Tensor t = tensor_from_python(tensor, "tensor");
-    if (!t.is_cuda()) throw std::invalid_argument("reg_ipc requires CUDA tensor");
+    if (!t.is_cuda())
+      throw std::invalid_argument("reg_ipc requires CUDA tensor");
     if (!t.is_contiguous()) {
       throw std::invalid_argument("reg_ipc requires contiguous tensor");
     }
     size_t total_bytes =
         static_cast<size_t>(t.numel()) * static_cast<size_t>(t.element_size());
-    if (total_bytes == 0) throw std::invalid_argument("reg_ipc requires non-empty tensor");
+    if (total_bytes == 0)
+      throw std::invalid_argument("reg_ipc requires non-empty tensor");
     void* ptr = t.data_ptr();
     if (!comm_->reg_ipc(buffer_id, ptr, total_bytes, publish)) return false;
     {
       std::lock_guard<std::mutex> lk(mu_);
-      tensor_bindings_[ptr] = PinnedTensor{std::move(t), buffer_id, total_bytes};
+      tensor_bindings_[ptr] =
+          PinnedTensor{std::move(t), buffer_id, total_bytes};
       ipc_buffer_to_ptr_[buffer_id] = ptr;
     }
     return true;
@@ -196,7 +204,8 @@ class Communicator {
     if (binding.has_value()) {
       buffer_id = binding->buffer_id;
     } else {
-      buffer_id = next_temporary_buffer_id_.fetch_add(1, std::memory_order_relaxed);
+      buffer_id =
+          next_temporary_buffer_id_.fetch_add(1, std::memory_order_relaxed);
       if (!comm_->reg_mr(buffer_id, t.data_ptr(), total_bytes, false)) {
         throw std::runtime_error("isend failed to register temporary MR");
       }
@@ -208,13 +217,12 @@ class Communicator {
       dst_buffer_id = binding->buffer_id;
     }
     if (dst_buffer_id != 0) {
-      dst_hint = UKernel::Transport::RemoteSlice{dst_buffer_id, remote_offset,
-                                                 {}};
+      dst_hint =
+          UKernel::Transport::RemoteSlice{dst_buffer_id, remote_offset, {}};
     }
-    uint64_t req =
-        comm_->isend(peer_rank,
-                     UKernel::Transport::LocalSlice{buffer_id, offset, len},
-                     dst_hint);
+    uint64_t req = comm_->isend(
+        peer_rank, UKernel::Transport::LocalSlice{buffer_id, offset, len},
+        dst_hint);
     if (req == 0) {
       if (!binding.has_value()) {
         comm_->dereg_mr(buffer_id);
@@ -245,7 +253,8 @@ class Communicator {
     if (binding.has_value()) {
       buffer_id = binding->buffer_id;
     } else {
-      buffer_id = next_temporary_buffer_id_.fetch_add(1, std::memory_order_relaxed);
+      buffer_id =
+          next_temporary_buffer_id_.fetch_add(1, std::memory_order_relaxed);
       if (!comm_->reg_mr(buffer_id, t.data_ptr(), total_bytes, false)) {
         throw std::runtime_error("irecv failed to register temporary MR");
       }
@@ -346,7 +355,8 @@ class Communicator {
     size_t bytes = 0;
   };
 
-  std::optional<PinnedTensor> find_tensor_binding(void* ptr, size_t bytes) const {
+  std::optional<PinnedTensor> find_tensor_binding(void* ptr,
+                                                  size_t bytes) const {
     std::lock_guard<std::mutex> lk(mu_);
     auto it = tensor_bindings_.find(ptr);
     if (it == tensor_bindings_.end()) return std::nullopt;
@@ -427,8 +437,7 @@ NB_MODULE(TORCH_EXTENSION_NAME, m) {
            nb::arg("peer_rank"))
       .def("same_host", &Communicator::same_host, nb::arg("peer_rank"))
       .def("barrier", &Communicator::barrier,
-           nb::arg("barrier_namespace") = "default",
-           nb::arg("timeout_ms") = -1)
+           nb::arg("barrier_namespace") = "default", nb::arg("timeout_ms") = -1)
       .def("send", &Communicator::send, nb::arg("peer_rank"), nb::arg("tensor"),
            nb::arg("remote_buffer_id") = 0, nb::arg("remote_offset") = 0)
       .def("recv", &Communicator::recv, nb::arg("peer_rank"),

--- a/experimental/ukernel/src/ccl/backend/transport_backend.cc
+++ b/experimental/ukernel/src/ccl/backend/transport_backend.cc
@@ -153,12 +153,12 @@ void CommunicatorTransportBackend::ensure_memory_bindings_initialized(
           !buffer.remotely_accessible) {
         continue;
       }
-      if (buffer.local_mr_id == 0) {
+      if (buffer.local_buffer_id == 0) {
         return false;
       }
       for (int peer = 0; peer < communicator_->world_size(); ++peer) {
         if (peer == communicator_->rank()) continue;
-        if (buffer.peer_views[static_cast<size_t>(peer)].mr_id == 0) {
+        if (buffer.peer_views[static_cast<size_t>(peer)].buffer_id == 0) {
           return false;
         }
       }
@@ -172,9 +172,6 @@ void CommunicatorTransportBackend::ensure_memory_bindings_initialized(
       binding.transport_initialized_signature !=
           binding.transport_signature()) {
     binding.invalidate_transport_cache();
-    binding.transport_binding_version = next_binding_version_++;
-  } else if (binding.transport_binding_version == 0) {
-    binding.transport_binding_version = next_binding_version_++;
   }
   initialize_memory_bindings(binding);
 }
@@ -187,21 +184,25 @@ void CommunicatorTransportBackend::initialize_memory_bindings(
   }
 
   std::vector<BufferId> buffer_ids = binding.registry->registered_buffer_ids();
-  Transport::NamedMRInfos local_infos;
-  local_infos.generation = binding.transport_binding_version;
-  local_infos.entries.reserve(buffer_ids.size());
   for (BufferId id : buffer_ids) {
     RegisteredBuffer& buffer = binding.buffer(id);
     buffer.peer_views.resize(static_cast<size_t>(communicator_->world_size()));
-    Transport::MR local_mr{};
     if (buffer.local_ptr != nullptr && buffer.bytes != 0 &&
         buffer.remotely_accessible) {
-      local_mr = communicator_->reg_mr(buffer.local_ptr, buffer.bytes);
-      buffer.local_mr_id = local_mr.id;
+      if (!communicator_->reg_mr(id, buffer.local_ptr, buffer.bytes, true)) {
+        throw std::runtime_error("transport backend reg_mr failed for buffer " +
+                                 std::to_string(id));
+      }
+      buffer.local_buffer_id = id;
     } else {
-      buffer.local_mr_id = 0;
+      buffer.local_buffer_id = 0;
     }
-    local_infos.entries.push_back(Transport::NamedMR{id, local_mr});
+    if (buffer.local_ptr != nullptr && buffer.bytes != 0 &&
+        buffer.remotely_accessible) {
+      (void)communicator_->reg_ipc(id, buffer.local_ptr, buffer.bytes, true);
+    } else {
+      (void)communicator_->reg_ipc(id, nullptr, 0, true);
+    }
   }
 
   for (int peer = 0; peer < communicator_->world_size(); ++peer) {
@@ -212,68 +213,28 @@ void CommunicatorTransportBackend::initialize_memory_bindings(
       buffer.peer_views[static_cast<size_t>(peer)].same_node = same_node;
     }
     if (peer == communicator_->rank()) continue;
-    if (!communicator_->notify_named_mrs(
-            peer, binding.transport_binding_version, local_infos)) {
-      throw std::runtime_error(
-          "transport backend notify_named_mrs failed for peer " +
-          std::to_string(peer));
-    }
-    for (auto const& entry : local_infos.entries) {
-      RegisteredBuffer const& buffer = binding.buffer(entry.buffer_id);
-      if (same_node && entry.mr.id != 0 &&
-          !communicator_->notify_ipc_buffer(
-              peer, entry.mr.id, buffer.local_ptr, buffer.bytes,
-              binding.transport_binding_version)) {
-        throw std::runtime_error(
-            "transport backend notify ipc buffer failed for peer " +
-            std::to_string(peer));
-      }
-    }
   }
 
   for (int peer = 0; peer < communicator_->world_size(); ++peer) {
     if (peer == communicator_->rank()) continue;
-    Transport::NamedMRInfos remote_infos;
-    if (!communicator_->wait_named_mrs(peer, binding.transport_binding_version,
-                                       remote_infos)) {
-      throw std::runtime_error(
-          "transport backend wait_named_mrs failed for peer " +
-          std::to_string(peer));
-    }
-
-    std::unordered_map<BufferId, Transport::MR> remote_mr_by_id;
-    remote_mr_by_id.reserve(remote_infos.entries.size());
     for (BufferId id : buffer_ids) {
-      binding.buffer(id).peer_views[static_cast<size_t>(peer)].mr_id = 0;
-    }
-    for (auto const& entry : remote_infos.entries) {
-      if (!binding.has_buffer(entry.buffer_id)) {
-        throw std::runtime_error(
-            "transport backend received unexpected remote buffer id " +
-            std::to_string(entry.buffer_id) + " from peer " +
-            std::to_string(peer));
-      }
-      auto [it, inserted] = remote_mr_by_id.emplace(entry.buffer_id, entry.mr);
-      if (!inserted) {
-        throw std::runtime_error(
-            "transport backend received duplicate remote buffer id " +
-            std::to_string(entry.buffer_id) + " from peer " +
-            std::to_string(peer));
-      }
-    }
-    for (BufferId id : buffer_ids) {
-      auto it = remote_mr_by_id.find(id);
-      if (it == remote_mr_by_id.end()) {
-        throw std::runtime_error("transport backend missing remote buffer id " +
-                                 std::to_string(id) + " from peer " +
-                                 std::to_string(peer));
-      }
       RegisteredBuffer& buffer = binding.buffer(id);
-      buffer.peer_views[static_cast<size_t>(peer)].mr_id = it->second.id;
+      if (buffer.local_ptr != nullptr && buffer.bytes != 0 &&
+          buffer.remotely_accessible &&
+          !communicator_->wait_mr(peer, id)) {
+        throw std::runtime_error("transport backend wait_mr failed for peer " +
+                                 std::to_string(peer) + ", buffer " +
+                                 std::to_string(id));
+      }
+      if (buffer.local_ptr != nullptr && buffer.bytes != 0 &&
+          buffer.remotely_accessible) {
+        buffer.peer_views[static_cast<size_t>(peer)].buffer_id = id;
+      } else {
+        buffer.peer_views[static_cast<size_t>(peer)].buffer_id = 0;
+      }
       if (buffer.peer_views[static_cast<size_t>(peer)].same_node &&
-          it->second.id != 0 &&
-          !communicator_->wait_ipc_buffer(peer, it->second.id,
-                                          binding.transport_binding_version)) {
+          buffer.peer_views[static_cast<size_t>(peer)].buffer_id != 0 &&
+          !communicator_->wait_ipc(peer, id)) {
         throw std::runtime_error(
             "transport backend wait ipc buffer failed for peer " +
             std::to_string(peer));
@@ -301,22 +262,22 @@ BackendToken CommunicatorTransportBackend::submit(ExecOp const& op,
   if (op.kind == ExecOpKind::TransportSend) {
     (void)resolve_const(binding, op.src, op.tile.size_bytes);
     Transport::LocalSlice src_slice{
-        resolve_local_mem_id(binding, op.src, op.tile.size_bytes),
+        resolve_local_buffer_id(binding, op.src, op.tile.size_bytes),
         op.src.offset_bytes,
         op.tile.size_bytes,
     };
     std::optional<Transport::RemoteSlice> dst_hint = std::nullopt;
     if (op.dst.kind == BufferKind::Remote) {
-      dst_hint = Transport::RemoteSlice{resolve_remote_mem_id(binding, op.dst),
-                                        op.dst.offset_bytes,
-                                        {},
-                                        binding.transport_binding_version};
+      // Communicator::isend auto-enriches write hints (addr/rkey/capacity)
+      // from exchanged remote metadata when only buffer_id/offset are provided.
+      dst_hint = Transport::RemoteSlice{
+          resolve_remote_buffer_id(binding, op.dst), op.dst.offset_bytes, {}};
     }
     request_id = communicator_->isend(peer_rank, src_slice, dst_hint);
   } else {
     (void)resolve_mutable(binding, op.dst, op.tile.size_bytes);
     Transport::LocalSlice dst_slice{
-        resolve_local_mem_id(binding, op.dst, op.tile.size_bytes),
+        resolve_local_buffer_id(binding, op.dst, op.tile.size_bytes),
         op.dst.offset_bytes,
         op.tile.size_bytes,
     };
@@ -409,19 +370,19 @@ void const* CommunicatorTransportBackend::resolve_const(
   return byte_offset(buffer.local_ptr, ref.offset_bytes);
 }
 
-uint32_t CommunicatorTransportBackend::resolve_local_mem_id(
+uint32_t CommunicatorTransportBackend::resolve_local_buffer_id(
     CollectiveBinding const& binding, BufferRef const& ref,
     size_t bytes) const {
   if (ref.kind == BufferKind::Remote) {
     throw std::invalid_argument(
-        "transport backend local MR requires local buffer ref");
+        "transport backend local buffer id requires local buffer ref");
   }
   RegisteredBuffer const& buffer = binding.buffer(ref.buffer_id);
-  if (buffer.local_mr_id != 0) {
-    return buffer.local_mr_id;
+  if (buffer.local_buffer_id != 0) {
+    return buffer.local_buffer_id;
   }
-  void* ptr = resolve_mutable(binding, ref, bytes);
-  return communicator_->get_local_mr(ptr).id;
+  (void)bytes;
+  return ref.buffer_id;
 }
 
 int CommunicatorTransportBackend::resolve_peer_rank(ExecOp const& op) const {
@@ -443,10 +404,11 @@ int CommunicatorTransportBackend::resolve_peer_rank(ExecOp const& op) const {
       "transport peer rank requested for non-transport op");
 }
 
-uint32_t CommunicatorTransportBackend::resolve_remote_mem_id(
+uint32_t CommunicatorTransportBackend::resolve_remote_buffer_id(
     CollectiveBinding const& binding, BufferRef const& ref) const {
   if (!is_peer_ref(ref) || ref.rank < 0) {
-    throw std::invalid_argument("transport remote MR requires peer buffer ref");
+    throw std::invalid_argument(
+        "transport remote buffer id requires peer buffer ref");
   }
   int peer_rank = ref.rank;
   RegisteredBuffer const& buffer = binding.buffer(ref.buffer_id);
@@ -454,11 +416,12 @@ uint32_t CommunicatorTransportBackend::resolve_remote_mem_id(
       static_cast<size_t>(peer_rank) >= buffer.peer_views.size()) {
     throw std::invalid_argument("transport peer rank out of range");
   }
-  uint32_t mr_id = buffer.peer_views[static_cast<size_t>(peer_rank)].mr_id;
-  if (mr_id == 0) {
-    throw std::invalid_argument("transport remote MR id is missing");
+  uint32_t remote_buffer_id =
+      buffer.peer_views[static_cast<size_t>(peer_rank)].buffer_id;
+  if (remote_buffer_id == 0) {
+    throw std::invalid_argument("transport remote buffer id is missing");
   }
-  return mr_id;
+  return remote_buffer_id;
 }
 
 void CommunicatorTransportBackend::on_transport_completion(

--- a/experimental/ukernel/src/ccl/backend/transport_backend.cc
+++ b/experimental/ukernel/src/ccl/backend/transport_backend.cc
@@ -220,8 +220,7 @@ void CommunicatorTransportBackend::initialize_memory_bindings(
     for (BufferId id : buffer_ids) {
       RegisteredBuffer& buffer = binding.buffer(id);
       if (buffer.local_ptr != nullptr && buffer.bytes != 0 &&
-          buffer.remotely_accessible &&
-          !communicator_->wait_mr(peer, id)) {
+          buffer.remotely_accessible && !communicator_->wait_mr(peer, id)) {
         throw std::runtime_error("transport backend wait_mr failed for peer " +
                                  std::to_string(peer) + ", buffer " +
                                  std::to_string(id));

--- a/experimental/ukernel/src/ccl/backend/transport_backend.h
+++ b/experimental/ukernel/src/ccl/backend/transport_backend.h
@@ -54,11 +54,11 @@ class CommunicatorTransportBackend final : public Backend {
                         size_t bytes) const;
   void const* resolve_const(CollectiveBinding const& binding,
                             BufferRef const& ref, size_t bytes) const;
-  uint32_t resolve_local_mem_id(CollectiveBinding const& binding,
-                                BufferRef const& ref, size_t bytes) const;
+  uint32_t resolve_local_buffer_id(CollectiveBinding const& binding,
+                               BufferRef const& ref, size_t bytes) const;
   int resolve_peer_rank(ExecOp const& op) const;
-  uint32_t resolve_remote_mem_id(CollectiveBinding const& binding,
-                                 BufferRef const& ref) const;
+  uint32_t resolve_remote_buffer_id(CollectiveBinding const& binding,
+                                BufferRef const& ref) const;
   void ensure_plan_paths(ExecutionPlan const& plan) const;
   void ensure_peer_paths(int peer_rank) const;
   void on_transport_completion(unsigned request_id);
@@ -76,7 +76,6 @@ class CommunicatorTransportBackend final : public Backend {
   mutable std::mutex path_mu_;
   uint64_t backend_cache_key_ = 0;
   mutable std::vector<bool> peer_paths_ready_;
-  mutable uint64_t next_binding_version_ = 1;
 };
 
 }  // namespace CCL

--- a/experimental/ukernel/src/ccl/backend/transport_backend.h
+++ b/experimental/ukernel/src/ccl/backend/transport_backend.h
@@ -55,10 +55,10 @@ class CommunicatorTransportBackend final : public Backend {
   void const* resolve_const(CollectiveBinding const& binding,
                             BufferRef const& ref, size_t bytes) const;
   uint32_t resolve_local_buffer_id(CollectiveBinding const& binding,
-                               BufferRef const& ref, size_t bytes) const;
+                                   BufferRef const& ref, size_t bytes) const;
   int resolve_peer_rank(ExecOp const& op) const;
   uint32_t resolve_remote_buffer_id(CollectiveBinding const& binding,
-                                BufferRef const& ref) const;
+                                    BufferRef const& ref) const;
   void ensure_plan_paths(ExecutionPlan const& plan) const;
   void ensure_peer_paths(int peer_rank) const;
   void on_transport_completion(unsigned request_id);

--- a/experimental/ukernel/src/ccl/collective_memory.h
+++ b/experimental/ukernel/src/ccl/collective_memory.h
@@ -12,10 +12,10 @@ namespace CCL {
 
 using BufferId = uint32_t;
 
-inline constexpr BufferId kInvalidBufferId = UINT32_MAX;
-inline constexpr BufferId kDefaultInputBufferId = 0;
+inline constexpr BufferId kInvalidBufferId = 0;
+inline constexpr BufferId kDefaultInputBufferId = 1;
 inline constexpr BufferId kDefaultOutputBufferId = kDefaultInputBufferId;
-inline constexpr BufferId kDefaultScratchBufferId = 1;
+inline constexpr BufferId kDefaultScratchBufferId = 2;
 
 struct TensorLayout {
   // Torch-style tensor metadata: sizes/strides/storage_offset are all
@@ -51,14 +51,14 @@ inline BufferRef remote_buffer_ref(BufferId buffer_id, int rank,
 }
 
 struct PeerBufferView {
-  uint32_t mr_id = 0;
+  uint32_t buffer_id = 0;
   bool same_node = false;
 };
 
 struct RegisteredBuffer {
   bool registered = false;
   void* local_ptr = nullptr;
-  uint32_t local_mr_id = 0;
+  uint32_t local_buffer_id = 0;
   size_t bytes = 0;
   TensorLayout layout{};
   bool remotely_accessible = true;
@@ -164,7 +164,6 @@ struct CollectiveBufferRoles {
 struct CollectiveBinding {
   std::shared_ptr<BufferRegistry> registry;
   CollectiveBufferRoles roles{};
-  uint64_t transport_binding_version = 0;
   uint64_t transport_initialized_backend_key = 0;
   uint64_t transport_initialized_signature = 0;
 
@@ -210,7 +209,6 @@ struct CollectiveBinding {
   }
 
   void invalidate_transport_cache() {
-    transport_binding_version = 0;
     transport_initialized_backend_key = 0;
     transport_initialized_signature = 0;
   }

--- a/experimental/ukernel/src/ccl/executor.cc
+++ b/experimental/ukernel/src/ccl/executor.cc
@@ -40,17 +40,18 @@ void const* local_const_ptr(CollectiveBinding const& binding,
   return local_mutable_ptr(binding, ref, bytes);
 }
 
-uint32_t remote_mr_id(CollectiveBinding const& binding, BufferRef const& ref) {
+uint32_t remote_buffer_id_for_ipc(CollectiveBinding const& binding,
+                                  BufferRef const& ref) {
   if (!is_remote_ref(ref) || ref.rank < 0) {
     throw std::invalid_argument(
-        "remote MR lookup requires a remote buffer ref");
+        "remote IPC lookup requires a remote buffer ref");
   }
   size_t peer = static_cast<size_t>(ref.rank);
   RegisteredBuffer const& buffer = binding.buffer(ref.buffer_id);
   if (peer >= buffer.peer_views.size()) {
     throw std::invalid_argument("remote buffer peer rank out of range");
   }
-  return buffer.peer_views[peer].mr_id;
+  return ref.buffer_id;
 }
 
 ExecOp bind_device_exec_op(
@@ -60,11 +61,11 @@ ExecOp bind_device_exec_op(
   ExecOp bound = op;
 
   if (is_remote_ref(op.src)) {
-    uint32_t mr_id = remote_mr_id(binding, op.src);
+    uint32_t remote_buffer_id = remote_buffer_id_for_ipc(binding, op.src);
     void* ptr = nullptr;
     int device_idx = -1;
     if (!resolve_remote_ptr ||
-        !resolve_remote_ptr(op.src.rank, mr_id, op.src.offset_bytes,
+        !resolve_remote_ptr(op.src.rank, remote_buffer_id, op.src.offset_bytes,
                             op.tile.size_bytes, &ptr, &device_idx)) {
       throw std::runtime_error("failed to resolve remote source pointer");
     }
@@ -75,11 +76,11 @@ ExecOp bind_device_exec_op(
   }
 
   if (is_remote_ref(op.dst)) {
-    uint32_t mr_id = remote_mr_id(binding, op.dst);
+    uint32_t remote_buffer_id = remote_buffer_id_for_ipc(binding, op.dst);
     void* ptr = nullptr;
     int device_idx = -1;
     if (!resolve_remote_ptr ||
-        !resolve_remote_ptr(op.dst.rank, mr_id, op.dst.offset_bytes,
+        !resolve_remote_ptr(op.dst.rank, remote_buffer_id, op.dst.offset_bytes,
                             op.tile.size_bytes, &ptr, &device_idx)) {
       throw std::runtime_error("failed to resolve remote destination pointer");
     }

--- a/experimental/ukernel/src/ccl/executor.h
+++ b/experimental/ukernel/src/ccl/executor.h
@@ -71,6 +71,7 @@ class Executor {
   // successor ops.
   explicit Executor(
       ExecutorBackends backends,
+      // Callback contract: second argument is remote `buffer_id` (not MR id).
       std::function<bool(int, uint32_t, size_t, size_t, void**, int*)>
           resolve_ipc_buffer_pointer = {});
   Executor(ExecutorConfig const& config = {});

--- a/experimental/ukernel/src/ccl/executor_real.cc
+++ b/experimental/ukernel/src/ccl/executor_real.cc
@@ -3,6 +3,7 @@
 #include "backend/transport_backend.h"
 #include "executor.h"
 #include "executor_impl.h"
+#include <cstdint>
 #include <memory>
 #include <utility>
 
@@ -24,10 +25,11 @@ Executor::Executor(ExecutorConfig const& config) : impl_(nullptr) {
           config.smem_size,
       }));
   impl_->resolve_ipc_buffer_pointer =
-      [communicator](int remote_rank, uint32_t mr_id, size_t offset,
+      [communicator](int remote_rank, uint32_t remote_buffer_id, size_t offset,
                      size_t bytes, void** out_ptr, int* out_device_idx) {
-        return communicator->resolve_ipc_buffer_pointer(
-            remote_rank, mr_id, offset, bytes, out_ptr, out_device_idx);
+        return communicator->try_resolve_remote_ipc_pointer(
+            remote_rank, remote_buffer_id, offset, bytes, out_ptr,
+            out_device_idx);
       };
 }
 

--- a/experimental/ukernel/src/ccl/test/common/backend_test_utils.h
+++ b/experimental/ukernel/src/ccl/test/common/backend_test_utils.h
@@ -33,11 +33,11 @@ inline void init_registered_buffer(RegisteredBuffer& buffer, size_t bytes,
   buffer.layout.sizes = {static_cast<int64_t>(bytes)};
   buffer.layout.strides = {1};
   buffer.local_ptr = local_ptr;
-  buffer.local_mr_id = 1;
+  buffer.local_buffer_id = 1;
   buffer.peer_views.resize(static_cast<size_t>(nranks));
   for (int peer = 0; peer < nranks; ++peer) {
     auto& peer_view = buffer.peer_views[static_cast<size_t>(peer)];
-    peer_view.mr_id = static_cast<uint32_t>(peer + 1);
+    peer_view.buffer_id = static_cast<uint32_t>(peer + 1);
     peer_view.same_node = true;
   }
 }

--- a/experimental/ukernel/src/ccl/test/integration/test_multiprocess_collective.cc
+++ b/experimental/ukernel/src/ccl/test/integration/test_multiprocess_collective.cc
@@ -289,7 +289,7 @@ CollectiveBinding build_collective_memory(int rank, int world_size,
   RegisteredBuffer& staging =
       binding.ensure_buffer(binding.buffer_id(CollectiveBufferRole::Scratch));
   staging.local_ptr = staging_ptr;
-  staging.local_mr_id = 0;
+  staging.local_buffer_id = 0;
   staging.bytes = staging_bytes;
   staging.layout.sizes = {static_cast<int64_t>(staging_bytes)};
   staging.layout.strides = {1};

--- a/experimental/ukernel/src/transport/adapter/ipc_adapter.cc
+++ b/experimental/ukernel/src/transport/adapter/ipc_adapter.cc
@@ -5,10 +5,6 @@
 #include <chrono>
 #include <cstring>
 #include <string>
-#include <fcntl.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <unistd.h>
 
 namespace UKernel {
 namespace Transport {
@@ -19,7 +15,6 @@ constexpr int kIpcControlPollTimeoutMs = 50;
 constexpr size_t kTaskRingSize = 1024;
 constexpr size_t kIpcSizePerEngine = 1ul << 20;
 constexpr int kIpcControlTimeoutMs = 50000;
-constexpr int kWorkerIdleSpinIters = 256;
 
 bool ipc_force_relay_enabled() {
   char const* env = std::getenv("UHM_IPC_FORCE_RELAY");
@@ -46,76 +41,17 @@ bool enqueue_one_request_id(jring_t* ring, unsigned elem,
   return !stop.load(std::memory_order_acquire);
 }
 
-void wait_for_worker_work(std::atomic<bool> const& stop,
-                          std::atomic<int> const& pending, std::mutex& cv_mu,
-                          std::condition_variable& cv) {
-  for (int i = 0; i < kWorkerIdleSpinIters; ++i) {
-    if (stop.load(std::memory_order_relaxed) ||
-        pending.load(std::memory_order_relaxed) > 0) {
-      return;
-    }
-    std::this_thread::yield();
-  }
-
-  std::unique_lock<std::mutex> lk(cv_mu);
-  cv.wait(lk, [&] {
-    return stop.load(std::memory_order_relaxed) ||
-           pending.load(std::memory_order_relaxed) > 0;
-  });
-}
-
-// POSIX SHM helpers for per-peer done_seq channel.
-// Lower rank creates, higher rank opens. One file per (lo,hi) pair.
-
-static IpcChannelPair* create_ipc_channel_pair(std::string const& name) {
-  shm_unlink(name.c_str());
-  int fd = shm_open(name.c_str(), O_CREAT | O_RDWR, 0600);
-  if (fd < 0) return nullptr;
-  if (ftruncate(fd, sizeof(IpcChannelPair)) < 0) {
-    close(fd);
-    shm_unlink(name.c_str());
-    return nullptr;
-  }
-  void* ptr = mmap(nullptr, sizeof(IpcChannelPair), PROT_READ | PROT_WRITE,
-                   MAP_SHARED, fd, 0);
-  close(fd);
-  if (ptr == MAP_FAILED) {
-    shm_unlink(name.c_str());
-    return nullptr;
-  }
-  return new (ptr) IpcChannelPair{};
-}
-
-static IpcChannelPair* open_ipc_channel_pair(std::string const& name,
-                                             int timeout_ms) {
-  auto deadline =
-      std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
-  while (true) {
-    int fd = shm_open(name.c_str(), O_RDWR, 0);
-    if (fd >= 0) {
-      void* ptr = mmap(nullptr, sizeof(IpcChannelPair), PROT_READ | PROT_WRITE,
-                       MAP_SHARED, fd, 0);
-      close(fd);
-      if (ptr != MAP_FAILED) return static_cast<IpcChannelPair*>(ptr);
-    }
-    if (std::chrono::steady_clock::now() >= deadline) return nullptr;
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-  }
-}
-
 }  // namespace
 
 IpcAdapter::IpcAdapter(Communicator* comm, std::string ring_namespace,
-                       int self_local_id)
-    : ring_namespace_(ring_namespace),
-      next_match_seq_per_peer_(comm->world_size(),
+                       int self_local_id, int local_gpu_idx)
+    : next_match_seq_per_peer_(comm->world_size(),
                                std::array<uint64_t, 2>{1, 1}),
-      peer_connect_mu_(comm->world_size()),
       shm_control_(std::make_shared<ShmRingExchanger>(
           comm->rank(), comm->world_size(), std::move(ring_namespace),
           self_local_id)),
-      comm_(comm) {
-  done_channels_.resize(comm->world_size());
+      comm_(comm),
+      local_gpu_idx_(local_gpu_idx) {
   send_task_ring_ =
       UKernel::Transport::create_ring(sizeof(unsigned), kTaskRingSize);
   recv_task_ring_ =
@@ -126,7 +62,7 @@ IpcAdapter::IpcAdapter(Communicator* comm, std::string ring_namespace,
   recv_thread_ = std::thread([this] { recv_thread_func(); });
 
   int n_streams = 2;
-  GPU_RT_CHECK(gpuSetDevice(comm->local_gpu_idx()));
+  GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
   ipc_streams_.resize(n_streams);
   for (int i = 0; i < n_streams; ++i) {
     GPU_RT_CHECK(
@@ -141,14 +77,10 @@ void IpcAdapter::shutdown() {
   if (!shutdown_started_.compare_exchange_strong(expected, true)) return;
 
   stop_.store(true, std::memory_order_release);
-  send_cv_.notify_all();
-  recv_cv_.notify_all();
+  cv_.notify_all();
   if (send_thread_.joinable()) send_thread_.join();
   if (recv_thread_.joinable()) recv_thread_.join();
 
-  for (int peer_rank = 0; peer_rank < comm_->world_size(); ++peer_rank) {
-    if (peer_rank != comm_->rank()) teardown_done_channel(peer_rank);
-  }
   if (shm_control_ != nullptr) {
     for (int peer_rank = 0; peer_rank < comm_->world_size(); ++peer_rank) {
       if (peer_rank == comm_->rank()) continue;
@@ -160,11 +92,12 @@ void IpcAdapter::shutdown() {
 
   int orig_device = -1;
   GPU_RT_CHECK(gpuGetDevice(&orig_device));
-  GPU_RT_CHECK(gpuSetDevice(comm_->local_gpu_idx()));
+  GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
   for (auto& stream : ipc_streams_) {
     if (stream != nullptr) GPU_RT_CHECK(gpuStreamDestroy(stream));
   }
   ipc_streams_.clear();
+  clear_remote_handle_cache();
   GPU_RT_CHECK(gpuSetDevice(orig_device));
 
   if (send_task_ring_) {
@@ -174,95 +107,6 @@ void IpcAdapter::shutdown() {
   if (recv_task_ring_) {
     free(recv_task_ring_);
     recv_task_ring_ = nullptr;
-  }
-}
-
-bool IpcAdapter::setup_done_channel(int peer_rank) {
-  if (peer_rank < 0 || peer_rank >= (int)done_channels_.size()) return false;
-  auto& ch = done_channels_[peer_rank];
-  if (ch.shm_base) return true;
-
-  int self = comm_->rank();
-  int lo = std::min(self, peer_rank);
-  int hi = std::max(self, peer_rank);
-  ch.is_creator = (self == lo);
-  ch.shm_name = "/" + ring_namespace_ + "_ipc_" + std::to_string(lo) + "_" +
-                std::to_string(hi);
-
-  IpcChannelPair* pair = nullptr;
-  if (ch.is_creator) {
-    pair = create_ipc_channel_pair(ch.shm_name);
-    if (!pair) {
-      fprintf(stderr, "[IPC] failed to create channel SHM %s\n",
-              ch.shm_name.c_str());
-      return false;
-    }
-  } else {
-    pair = open_ipc_channel_pair(ch.shm_name, /*timeout_ms=*/10000);
-    if (!pair) {
-      fprintf(stderr, "[IPC] failed to open channel SHM %s\n",
-              ch.shm_name.c_str());
-      return false;
-    }
-  }
-  ch.shm_base = pair;
-  // Lower rank owns done_seq_lo_to_hi (its sends); higher rank owns hi_to_lo.
-  if (ch.is_creator) {
-    ch.local_ptr = &pair->done_seq_lo_to_hi;
-    ch.remote_ptr = &pair->done_seq_hi_to_lo;
-    // Creator's pointers are set now, but the fast path is NOT active until
-    // wait_done_channel_peer_ready() confirms the opener has mapped this SHM.
-    // Until then local_ptr is non-null but send_one must not use it — that
-    // gate is enforced in wait_done_channel_peer_ready (which clears the
-    // pointers on timeout).
-  } else {
-    ch.local_ptr = &pair->done_seq_hi_to_lo;
-    ch.remote_ptr = &pair->done_seq_lo_to_hi;
-    // Signal to the creator that we have successfully mapped the SHM.
-    pair->opener_ready.store(1, std::memory_order_release);
-  }
-  return true;
-}
-
-void IpcAdapter::teardown_done_channel(int peer_rank) {
-  if (peer_rank < 0 || peer_rank >= (int)done_channels_.size()) return;
-  auto& ch = done_channels_[peer_rank];
-  if (ch.shm_base) {
-    munmap(ch.shm_base, sizeof(IpcChannelPair));
-    ch.shm_base = nullptr;
-    ch.local_ptr = nullptr;
-    ch.remote_ptr = nullptr;
-  }
-  if (ch.is_creator && !ch.shm_name.empty()) shm_unlink(ch.shm_name.c_str());
-  ch.shm_name.clear();
-  ch.is_creator = false;
-}
-
-// Called by the creator (lower rank) after connect_to() returns.
-// Polls the opener_ready flag that the higher rank writes when it maps the SHM.
-// If the opener does not confirm within the timeout the done_seq channel is
-// torn down on BOTH sides (creator tears down locally; opener's remote_ptr
-// becomes stale but it will find done_seq.load() == 0 and keep retrying until
-// it detects the channel is gone or falls back via the SHM ring).
-// Result: both sides end up with local_ptr == nullptr → consistent fallback.
-void IpcAdapter::wait_done_channel_peer_ready(int peer_rank) {
-  if (peer_rank < 0 || peer_rank >= (int)done_channels_.size()) return;
-  auto& ch = done_channels_[peer_rank];
-  if (!ch.shm_base || !ch.is_creator) return;
-
-  constexpr int kReadyTimeoutMs = 5000;
-  auto deadline = std::chrono::steady_clock::now() +
-                  std::chrono::milliseconds(kReadyTimeoutMs);
-  while (ch.shm_base->opener_ready.load(std::memory_order_acquire) == 0) {
-    if (std::chrono::steady_clock::now() >= deadline) {
-      fprintf(stderr,
-              "[IPC] done_seq opener did not signal ready in %dms for %s; "
-              "disabling done_seq fast path\n",
-              kReadyTimeoutMs, ch.shm_name.c_str());
-      teardown_done_channel(peer_rank);
-      return;
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
 }
 
@@ -276,39 +120,15 @@ bool IpcAdapter::accept_from(int rank) {
 
 bool IpcAdapter::ensure_peer(PeerConnectSpec const& spec) {
   if (spec.peer_rank < 0) return false;
+  if (has_peer(spec.peer_rank)) return true;
   if (!(std::holds_alternative<IpcPeerConnectSpec>(spec.detail) ||
         std::holds_alternative<std::monostate>(spec.detail))) {
     return false;
   }
-  int peer_rank = spec.peer_rank;
-  if (peer_rank >= static_cast<int>(peer_connect_mu_.size())) return false;
-  std::lock_guard<std::mutex> peer_lk(
-      peer_connect_mu_[static_cast<size_t>(peer_rank)]);
-  if (has_peer(peer_rank)) return true;
-
-  // Lower rank creates the done_seq SHM *before* the connection handshake so
-  // the higher rank can open it by name right after the handshake completes.
-  bool is_lower = (comm_->rank() < peer_rank);
-  if (is_lower) setup_done_channel(peer_rank);
-
-  // Keep peer handshake role deterministic to avoid connect/accept races when
-  // multiple request paths concurrently establish the same peer.
-  bool const use_connect = is_lower;
-  bool ok = use_connect ? connect_to(peer_rank) : accept_from(peer_rank);
-  if (!ok) return false;
-
-  if (!is_lower) {
-    // Higher rank: open the SHM created by lower rank.  On success, this also
-    // writes opener_ready = 1 so the lower rank can proceed past its poll.
-    setup_done_channel(peer_rank);
-  } else {
-    // Lower rank: wait for the opener to confirm it has mapped the SHM before
-    // allowing send_one to use the done_seq fast path.  If the opener never
-    // signals (e.g., name mismatch, OS error), we tear down our side too so
-    // both peers stay on the same (fallback) control path.
-    wait_done_channel_peer_ready(peer_rank);
+  if (spec.type == PeerConnectType::Connect) {
+    return connect_to(spec.peer_rank);
   }
-  return true;
+  return accept_from(spec.peer_rank);
 }
 
 void IpcAdapter::set_peer_local_id(int peer_rank, int local_id) {
@@ -318,7 +138,6 @@ void IpcAdapter::set_peer_local_id(int peer_rank, int local_id) {
 }
 
 void IpcAdapter::close_peer(int peer_rank) {
-  teardown_done_channel(peer_rank);
   if (shm_control_ != nullptr) {
     shm_control_->close_peer(peer_rank);
   }
@@ -446,37 +265,35 @@ bool IpcAdapter::enqueue_request(unsigned request_id, IpcReqType type) {
       return false;
     }
     pending_send_.fetch_add(1, std::memory_order_relaxed);
-    send_cv_.notify_one();
   } else {
     if (recv_task_ring_ == nullptr ||
         !enqueue_one_request_id(recv_task_ring_, request_id, stop_)) {
       return false;
     }
     pending_recv_.fetch_add(1, std::memory_order_relaxed);
-    recv_cv_.notify_one();
   }
+  cv_.notify_all();
   return true;
 }
 
 unsigned IpcAdapter::send_async(int peer_rank, void* local_ptr, size_t len,
-                                uint64_t local_mr_id,
+                                uint32_t local_buffer_id,
                                 std::optional<RemoteSlice> remote_hint,
                                 BounceBufferProvider bounce_provider) {
-  (void)local_mr_id;
+  (void)local_buffer_id;
 
-  uint32_t remote_mem_id = 0;
+  uint32_t remote_buffer_id = 0;
   size_t remote_offset = 0;
   if (remote_hint.has_value()) {
-    remote_mem_id = remote_hint->mem_id;
+    remote_buffer_id = remote_hint->buffer_id;
     remote_offset = remote_hint->offset;
   }
   uint64_t match_seq = next_send_match_seq(peer_rank);
   RemoteSlice remote_slice{};
-  remote_slice.mem_id = remote_mem_id;
+  remote_slice.buffer_id = remote_buffer_id;
   remote_slice.offset = remote_offset;
   if (remote_hint.has_value()) {
     remote_slice.write = remote_hint->write;
-    remote_slice.binding_version = remote_hint->binding_version;
   }
   unsigned request_id = 0;
   IpcRequestSlot* req = try_acquire_request_slot(&request_id);
@@ -497,9 +314,9 @@ unsigned IpcAdapter::send_async(int peer_rank, void* local_ptr, size_t len,
 }
 
 unsigned IpcAdapter::recv_async(int peer_rank, void* local_ptr, size_t len,
-                                uint64_t local_mr_id,
+                                uint32_t local_buffer_id,
                                 BounceBufferProvider bounce_provider) {
-  (void)local_mr_id;
+  (void)local_buffer_id;
 
   void* bounce_ptr = nullptr;
   std::string bounce_shm_name;
@@ -552,6 +369,62 @@ bool IpcAdapter::request_failed(unsigned id) {
 
 void IpcAdapter::release_request(unsigned id) { release_request_slot(id); }
 
+bool IpcAdapter::find_or_open_remote_ipc_handle(int remote_rank,
+                                                gpuIpcMemHandle_t const& handle,
+                                                size_t offset, size_t bytes,
+                                                int remote_gpu_idx,
+                                                IPCItem* out) {
+  if (out == nullptr) return false;
+  auto key = make_ipc_handle_key(handle);
+  {
+    std::lock_guard<std::mutex> lk(remote_handle_mu_);
+    auto rank_it = remote_handle_cache_.find(remote_rank);
+    if (rank_it != remote_handle_cache_.end()) {
+      auto it = rank_it->second.find(key);
+      if (it != rank_it->second.end()) {
+        *out = it->second;
+        return out->direct_ptr != nullptr;
+      }
+    }
+  }
+
+  void* base = nullptr;
+  gpuError_t err =
+      gpuIpcOpenMemHandle(&base, handle, gpuIpcMemLazyEnablePeerAccess);
+  if (err != gpuSuccess) {
+    return false;
+  }
+
+  IPCItem opened{};
+  opened.handle = handle;
+  opened.direct_ptr = base;
+  opened.base_offset = static_cast<uintptr_t>(offset);
+  opened.bytes = bytes;
+  opened.device_idx = remote_gpu_idx;
+  opened.valid = true;
+
+  {
+    std::lock_guard<std::mutex> lk(remote_handle_mu_);
+    remote_handle_cache_[remote_rank][key] = opened;
+  }
+  *out = opened;
+  return true;
+}
+
+void IpcAdapter::clear_remote_handle_cache() {
+  std::lock_guard<std::mutex> lk(remote_handle_mu_);
+  for (auto& rank_kv : remote_handle_cache_) {
+    for (auto& handle_kv : rank_kv.second) {
+      auto& item = handle_kv.second;
+      if (item.direct_ptr != nullptr) {
+        GPU_RT_CHECK(gpuIpcCloseMemHandle(item.direct_ptr));
+        item.direct_ptr = nullptr;
+      }
+    }
+  }
+  remote_handle_cache_.clear();
+}
+
 bool IpcAdapter::send_one(IpcRequestSlot* creq) {
   if (!creq) return false;
   int to_rank = creq->peer_rank;
@@ -566,7 +439,7 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
   auto dev_reset = UKernel::Transport::finally(
       [&]() { GPU_RT_CHECK(gpuSetDevice(orig_device)); });
 
-  GPU_RT_CHECK(gpuSetDevice(comm_->local_gpu_idx()));
+  GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
   auto wait_sender_ack = [&](int timeout_ms, uint32_t* out_status) -> int {
     uint64_t out_seq = 0;
     uint32_t status = 0;
@@ -600,12 +473,12 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
           reinterpret_cast<uintptr_t>(dst_ptr) + i * chunk_size);
       size_t copy_size =
           i == n_streams - 1 ? creq->size_bytes - i * chunk_size : chunk_size;
-      if (remote_gpu_idx == comm_->local_gpu_idx()) {
+      if (remote_gpu_idx == local_gpu_idx_) {
         GPU_RT_CHECK(gpuMemcpyAsync(chunk_dst, chunk_src, copy_size,
                                     gpuMemcpyDeviceToDevice, ipc_streams_[i]));
       } else {
         GPU_RT_CHECK(gpuMemcpyPeerAsync(chunk_dst, remote_gpu_idx, chunk_src,
-                                        comm_->local_gpu_idx(), copy_size,
+                                        local_gpu_idx_, copy_size,
                                         ipc_streams_[i]));
       }
     }
@@ -635,7 +508,7 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
     IpcCacheWire relay_cache{};
     relay_cache.size = creq->size_bytes;
     relay_cache.is_send = 1;
-    relay_cache.remote_gpu_idx_ = comm_->local_gpu_idx();
+    relay_cache.remote_gpu_idx_ = local_gpu_idx_;
     relay_cache.offset = 0;
     relay_cache.use_bounce_buffer = 1;
     std::strncpy(relay_cache.bounce_shm_name, relay_bounce_shm_name.c_str(),
@@ -656,41 +529,40 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
     return true;
   };
 
-  // IPC direct-path safety rule:
-  // only attempt by-mem_id fast path when binding_version is explicit.
-  // Otherwise force handshake to avoid stale metadata reuse.
-  if (creq->remote_slice.mem_id != 0 &&
-      creq->remote_slice.binding_version != 0) {
+  if (creq->remote_slice.buffer_id != 0) {
     auto try_direct_by_remote_slice = [&](void** out_dst,
                                           int* out_remote_gpu) -> bool {
-      if (!comm_->resolve_ipc_buffer_pointer(
-              to_rank, creq->remote_slice.mem_id, creq->remote_slice.offset,
-              creq->size_bytes, out_dst, out_remote_gpu)) {
+      IPCItem remote_ipc{};
+      try {
+        remote_ipc = comm_->get_ipc(to_rank, creq->remote_slice.buffer_id);
+      } catch (...) {
         return false;
       }
-      bool can_use_direct_peer = !ipc_force_relay_enabled() &&
-                                 (*out_remote_gpu == comm_->local_gpu_idx());
+      if (!remote_ipc.valid || remote_ipc.direct_ptr == nullptr) {
+        return false;
+      }
+      if (creq->remote_slice.offset > remote_ipc.bytes ||
+          creq->size_bytes > remote_ipc.bytes - creq->remote_slice.offset) {
+        return false;
+      }
+      *out_dst = reinterpret_cast<void*>(
+          reinterpret_cast<uintptr_t>(remote_ipc.direct_ptr) +
+          remote_ipc.base_offset + creq->remote_slice.offset);
+      *out_remote_gpu = remote_ipc.device_idx;
+      bool can_use_direct_peer =
+          !ipc_force_relay_enabled() && (*out_remote_gpu == local_gpu_idx_);
       if (!can_use_direct_peer && !ipc_force_relay_enabled() &&
           *out_remote_gpu >= 0) {
         int can_access_peer = 0;
         GPU_RT_CHECK(gpuDeviceCanAccessPeer(
-            &can_access_peer, comm_->local_gpu_idx(), *out_remote_gpu));
+            &can_access_peer, local_gpu_idx_, *out_remote_gpu));
         can_use_direct_peer = (can_access_peer != 0);
       }
       return can_use_direct_peer;
     };
 
-    bool have_fresh_meta = comm_->ipc_has_fresh_remote_ipc_buffer(
-        to_rank, creq->remote_slice.mem_id, creq->remote_slice.binding_version);
-    if (!have_fresh_meta) {
-      have_fresh_meta = comm_->ipc_fetch_remote_ipc_buffer(
-          to_rank, creq->remote_slice.mem_id,
-          creq->remote_slice.binding_version);
-      if (!have_fresh_meta) {
-        comm_->ipc_invalidate_remote_ipc_buffer(to_rank,
-                                                creq->remote_slice.mem_id);
-      }
-    }
+    bool have_fresh_meta = comm_->wait_ipc(to_rank, creq->remote_slice.buffer_id,
+                                           /*timeout_ms=*/0);
 
     void* cached_dst = nullptr;
     int cached_remote_gpu = -1;
@@ -698,23 +570,18 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
         have_fresh_meta &&
         try_direct_by_remote_slice(&cached_dst, &cached_remote_gpu);
     if (can_use_direct && cached_dst != nullptr && cached_remote_gpu >= 0) {
-      bool can_use_direct_peer = !ipc_force_relay_enabled() &&
-                                 (cached_remote_gpu == comm_->local_gpu_idx());
+      bool can_use_direct_peer =
+          !ipc_force_relay_enabled() && (cached_remote_gpu == local_gpu_idx_);
       if (!can_use_direct_peer && !ipc_force_relay_enabled()) {
         int can_access_peer = 0;
         GPU_RT_CHECK(gpuDeviceCanAccessPeer(
-            &can_access_peer, comm_->local_gpu_idx(), cached_remote_gpu));
+            &can_access_peer, local_gpu_idx_, cached_remote_gpu));
         can_use_direct_peer = (can_access_peer != 0);
       }
       if (can_use_direct_peer) {
         copy_to_remote(cached_dst, cached_remote_gpu);
-        // Signal completion via done_seq atomic (fast path).
-        // Fall back to SHM ring ack only if channel not set up.
-        auto& done_ch = done_channels_[to_rank];
-        if (done_ch.local_ptr) {
-          done_ch.local_ptr->store(creq->match_seq, std::memory_order_release);
-        } else if (!shm_control_->send_ack(to_rank, creq->match_seq,
-                                           kAckStatusOkDirect)) {
+        if (!shm_control_->send_ack(to_rank, creq->match_seq,
+                                    kAckStatusOkDirect)) {
           std::cerr << "[ERROR] send direct cached ack(" << to_rank
                     << ") failed for req " << creq->id << " match_seq "
                     << creq->match_seq << std::endl;
@@ -757,12 +624,12 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
 
   bool can_use_direct_peer =
       !ipc_force_relay_enabled() &&
-      (got.remote_gpu_idx_ == static_cast<uint32_t>(comm_->local_gpu_idx()));
+      (got.remote_gpu_idx_ == static_cast<uint32_t>(local_gpu_idx_));
   if (!can_use_direct_peer) {
     int can_access_peer = 0;
     if (!ipc_force_relay_enabled()) {
       GPU_RT_CHECK(
-          gpuDeviceCanAccessPeer(&can_access_peer, comm_->local_gpu_idx(),
+          gpuDeviceCanAccessPeer(&can_access_peer, local_gpu_idx_,
                                  static_cast<int>(got.remote_gpu_idx_)));
       can_use_direct_peer = (can_access_peer != 0);
     }
@@ -772,31 +639,19 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
     return relay_via_bounce(seq);
   }
 
-  IPCItem ipc = comm_->get_remote_ipc_cache(to_rank, got.handle);
-  void* base = ipc.direct_ptr;
-  if (base == nullptr) {
-    GPU_RT_CHECK(
-        gpuIpcOpenMemHandle(&base, got.handle, gpuIpcMemLazyEnablePeerAccess));
-
-    IPCItem new_ipc{};
-    new_ipc.handle = got.handle;
-    new_ipc.direct_ptr = base;
-    new_ipc.base_offset = got.offset;
-    new_ipc.bytes = got.size;
-    new_ipc.device_idx = static_cast<int>(got.remote_gpu_idx_);
-    new_ipc.valid = true;
-    comm_->register_remote_ipc_cache(to_rank, got.handle, new_ipc);
+  IPCItem ipc{};
+  if (!find_or_open_remote_ipc_handle(
+          to_rank, got.handle, got.offset, got.size,
+          static_cast<int>(got.remote_gpu_idx_), &ipc)) {
+    return false;
   }
+  void* base = ipc.direct_ptr;
 
   void* dst_ptr =
       reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(base) + got.offset);
   copy_to_remote(dst_ptr, static_cast<int>(got.remote_gpu_idx_));
 
-  // Signal via done_seq (same as direct path), fallback to SHM ring ack.
-  auto& done_ch = done_channels_[to_rank];
-  if (done_ch.local_ptr) {
-    done_ch.local_ptr->store(seq, std::memory_order_release);
-  } else if (!shm_control_->send_ack(to_rank, seq, kAckStatusOkDirect)) {
+  if (!shm_control_->send_ack(to_rank, seq, kAckStatusOkDirect)) {
     std::cerr << "[ERROR] send_ack(" << to_rank << ") failed for req "
               << creq->id << " match_seq " << creq->match_seq << std::endl;
     return false;
@@ -835,13 +690,12 @@ bool IpcAdapter::recv_one(IpcRequestSlot* creq) {
   };
 
   // Phase 1: receiver waits for either:
-  // 1) done_seq >= match_seq  → direct-path copy complete (fast atomic spin);
-  // or 2) ipc_cache_req from sender → cold path, must export IPC handle; or 3)
-  // ipc_cache(use_bounce_buffer=1) → relay path.
+  // 1) direct completion ACK from sender; or
+  // 2) sender's bounce relay notification (ipc_cache/use_bounce_buffer=1); or
+  // 3) sender's ipc_cache_req asking receiver to advertise destination handle.
   auto phase1_deadline = std::chrono::steady_clock::now() +
                          std::chrono::milliseconds(kIpcControlTimeoutMs);
   bool got_cache_req = false;
-  auto& done_ch = done_channels_[from_rank];
   auto handle_relay_cache = [&](IpcCacheWire const& relay_cache,
                                 uint64_t relay_seq) -> bool {
     if (relay_seq != creq->match_seq) {
@@ -865,7 +719,7 @@ bool IpcAdapter::recv_one(IpcRequestSlot* creq) {
       return false;
     }
 
-    GPU_RT_CHECK(gpuSetDevice(comm_->local_gpu_idx()));
+    GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
     void* actual_dst = creq->data();
     GPU_RT_CHECK(gpuMemcpy(actual_dst, relay_bounce_ptr, creq->size_bytes,
                            gpuMemcpyHostToDevice));
@@ -878,18 +732,11 @@ bool IpcAdapter::recv_one(IpcRequestSlot* creq) {
     return true;
   };
   while (!stop_.load(std::memory_order_acquire)) {
-    // Fast path: spin on done_seq atomic (no sleep, no SHM ring message).
-    if (done_ch.remote_ptr) {
-      if (done_ch.remote_ptr->load(std::memory_order_acquire) >=
-          creq->match_seq) {
-        return true;
-      }
-    } else {
-      // Fallback when done_seq channel is unavailable: poll SHM ring ack.
-      uint32_t status = 0;
-      int ack_result = wait_sender_ack(/*timeout_ms=*/0, &status);
-      if (ack_result < 0) return false;
-      if (ack_result > 0) return true;
+    uint32_t status = 0;
+    int ack_result = wait_sender_ack(/*timeout_ms=*/0, &status);
+    if (ack_result < 0) return false;
+    if (ack_result > 0) {
+      return true;
     }
     uint64_t req_seq = 0;
     if (shm_control_->recv_ipc_cache_req(from_rank, &req_seq,
@@ -909,26 +756,23 @@ bool IpcAdapter::recv_one(IpcRequestSlot* creq) {
           << creq->id << " match_seq " << creq->match_seq << std::endl;
       return false;
     }
-    std::this_thread::yield();  // no sleep — yield to other threads only
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   if (stop_.load(std::memory_order_acquire) || !got_cache_req) return false;
 
-  GPU_RT_CHECK(gpuSetDevice(comm_->local_gpu_idx()));
+  GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
   IpcCacheWire transfer_info{};
   transfer_info.size = creq->size_bytes;
   transfer_info.is_send = 0;
-  transfer_info.remote_gpu_idx_ = comm_->local_gpu_idx();
+  transfer_info.remote_gpu_idx_ = local_gpu_idx_;
   void* actual_dst = creq->data();
-  IPCItem exported =
-      comm_->export_local_ipc_buffer(actual_dst, creq->size_bytes);
-  if (!exported.valid) {
-    std::cerr << "[ERROR] export_local_ipc_buffer failed for req " << creq->id
-              << " match_seq " << creq->match_seq << std::endl;
-    return false;
-  }
-  transfer_info.handle = exported.handle;
-  transfer_info.offset =
-      reinterpret_cast<uintptr_t>(actual_dst) - exported.base_addr;
+
+  void* base = nullptr;
+  size_t base_size = 0;
+  GPU_RT_CHECK(gpuMemGetAddressRange(&base, &base_size, actual_dst));
+  GPU_RT_CHECK(gpuIpcGetMemHandle(&transfer_info.handle, base));
+  transfer_info.offset = reinterpret_cast<uintptr_t>(actual_dst) -
+                         reinterpret_cast<uintptr_t>(base);
 
   if (!shm_control_->send_ipc_cache(from_rank, creq->match_seq,
                                     transfer_info)) {
@@ -937,22 +781,16 @@ bool IpcAdapter::recv_one(IpcRequestSlot* creq) {
     return false;
   }
 
-  // Phase 2: sender has the IPC handle; wait for it to finish the copy.
-  // Sender signals via done_seq (same channel as direct path).
+  // Phase 2: after advertising IPC cache, sender may either:
+  // 1) copy directly and send ACK; or
+  // 2) fall back to bounce relay and send ipc_cache(use_bounce_buffer=1).
   auto final_deadline = std::chrono::steady_clock::now() +
                         std::chrono::milliseconds(kIpcControlTimeoutMs);
   while (!stop_.load(std::memory_order_acquire)) {
-    if (done_ch.remote_ptr) {
-      if (done_ch.remote_ptr->load(std::memory_order_acquire) >=
-          creq->match_seq) {
-        return true;
-      }
-    } else {
-      uint32_t status = 0;
-      int ack_result = wait_sender_ack(/*timeout_ms=*/0, &status);
-      if (ack_result < 0) return false;
-      if (ack_result > 0) return true;
-    }
+    uint32_t status = 0;
+    int ack_result = wait_sender_ack(/*timeout_ms=*/0, &status);
+    if (ack_result < 0) return false;
+    if (ack_result > 0) return true;
 
     IpcCacheWire relay_cache{};
     uint64_t relay_seq = 0;
@@ -967,7 +805,7 @@ bool IpcAdapter::recv_one(IpcRequestSlot* creq) {
                 << std::endl;
       return false;
     }
-    std::this_thread::yield();  // no sleep
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
   return false;
 }
@@ -983,7 +821,13 @@ void IpcAdapter::complete_task(IpcRequestSlot* req, bool ok) {
 
 void IpcAdapter::send_thread_func() {
   while (!stop_.load(std::memory_order_relaxed)) {
-    wait_for_worker_work(stop_, pending_send_, send_cv_mu_, send_cv_);
+    {
+      std::unique_lock<std::mutex> lk(cv_mu_);
+      cv_.wait(lk, [&] {
+        return stop_.load(std::memory_order_relaxed) ||
+               pending_send_.load(std::memory_order_relaxed) > 0;
+      });
+    }
     if (stop_.load(std::memory_order_relaxed)) break;
 
     unsigned request_id = 0;
@@ -1009,7 +853,13 @@ void IpcAdapter::send_thread_func() {
 
 void IpcAdapter::recv_thread_func() {
   while (!stop_.load(std::memory_order_relaxed)) {
-    wait_for_worker_work(stop_, pending_recv_, recv_cv_mu_, recv_cv_);
+    {
+      std::unique_lock<std::mutex> lk(cv_mu_);
+      cv_.wait(lk, [&] {
+        return stop_.load(std::memory_order_relaxed) ||
+               pending_recv_.load(std::memory_order_relaxed) > 0;
+      });
+    }
     if (stop_.load(std::memory_order_relaxed)) break;
 
     unsigned request_id = 0;

--- a/experimental/ukernel/src/transport/adapter/ipc_adapter.cc
+++ b/experimental/ukernel/src/transport/adapter/ipc_adapter.cc
@@ -554,15 +554,16 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
       if (!can_use_direct_peer && !ipc_force_relay_enabled() &&
           *out_remote_gpu >= 0) {
         int can_access_peer = 0;
-        GPU_RT_CHECK(gpuDeviceCanAccessPeer(
-            &can_access_peer, local_gpu_idx_, *out_remote_gpu));
+        GPU_RT_CHECK(gpuDeviceCanAccessPeer(&can_access_peer, local_gpu_idx_,
+                                            *out_remote_gpu));
         can_use_direct_peer = (can_access_peer != 0);
       }
       return can_use_direct_peer;
     };
 
-    bool have_fresh_meta = comm_->wait_ipc(to_rank, creq->remote_slice.buffer_id,
-                                           /*timeout_ms=*/0);
+    bool have_fresh_meta =
+        comm_->wait_ipc(to_rank, creq->remote_slice.buffer_id,
+                        /*timeout_ms=*/0);
 
     void* cached_dst = nullptr;
     int cached_remote_gpu = -1;
@@ -574,8 +575,8 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
           !ipc_force_relay_enabled() && (cached_remote_gpu == local_gpu_idx_);
       if (!can_use_direct_peer && !ipc_force_relay_enabled()) {
         int can_access_peer = 0;
-        GPU_RT_CHECK(gpuDeviceCanAccessPeer(
-            &can_access_peer, local_gpu_idx_, cached_remote_gpu));
+        GPU_RT_CHECK(gpuDeviceCanAccessPeer(&can_access_peer, local_gpu_idx_,
+                                            cached_remote_gpu));
         can_use_direct_peer = (can_access_peer != 0);
       }
       if (can_use_direct_peer) {
@@ -640,9 +641,9 @@ bool IpcAdapter::send_one(IpcRequestSlot* creq) {
   }
 
   IPCItem ipc{};
-  if (!find_or_open_remote_ipc_handle(
-          to_rank, got.handle, got.offset, got.size,
-          static_cast<int>(got.remote_gpu_idx_), &ipc)) {
+  if (!find_or_open_remote_ipc_handle(to_rank, got.handle, got.offset, got.size,
+                                      static_cast<int>(got.remote_gpu_idx_),
+                                      &ipc)) {
     return false;
   }
   void* base = ipc.direct_ptr;

--- a/experimental/ukernel/src/transport/adapter/ipc_adapter.h
+++ b/experimental/ukernel/src/transport/adapter/ipc_adapter.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "../oob/oob.h"
+#include "../memory/ipc_manager.h"
+#include "../oob/shmring_exchanger.h"
 #include "../util/jring.h"
 #include "config.h"
 #include "gpu_rt.h"

--- a/experimental/ukernel/src/transport/adapter/ipc_adapter.h
+++ b/experimental/ukernel/src/transport/adapter/ipc_adapter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../oob/shmring_exchanger.h"
+#include "../oob/oob.h"
 #include "../util/jring.h"
 #include "config.h"
 #include "gpu_rt.h"
@@ -10,11 +10,13 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 namespace UKernel {
@@ -22,21 +24,11 @@ namespace Transport {
 
 class Communicator;
 
-// Per-peer-pair POSIX SHM layout: two cache-line-aligned done_seq slots,
-// one per direction (lo→hi and hi→lo), plus an opener_ready handshake flag.
-// The opener (higher rank) writes opener_ready = 1 after mmap; the creator
-// (lower rank) polls it after connect_to returns to ensure both sides are
-// live before activating the done_seq fast path.
-struct IpcChannelPair {
-  alignas(64) std::atomic<uint64_t> done_seq_lo_to_hi{0};
-  alignas(64) std::atomic<uint64_t> done_seq_hi_to_lo{0};
-  alignas(64) std::atomic<uint32_t> opener_ready{0};
-};
-
 class IpcAdapter final : public TransportAdapter {
  public:
   // Lifecycle.
-  IpcAdapter(Communicator* comm, std::string ring_namespace, int self_local_id);
+  IpcAdapter(Communicator* comm, std::string ring_namespace, int self_local_id,
+             int local_gpu_idx);
   ~IpcAdapter() override;
   void shutdown();
 
@@ -48,11 +40,11 @@ class IpcAdapter final : public TransportAdapter {
 
   // Async data-plane requests.
   unsigned send_async(int peer_rank, void* local_ptr, size_t len,
-                      uint64_t local_mr_id,
+                      uint32_t local_buffer_id,
                       std::optional<RemoteSlice> remote_hint,
                       BounceBufferProvider bounce_provider = nullptr) override;
   unsigned recv_async(int peer_rank, void* local_ptr, size_t len,
-                      uint64_t local_mr_id,
+                      uint32_t local_buffer_id,
                       BounceBufferProvider bounce_provider = nullptr) override;
 
   // Request completion API.
@@ -145,26 +137,35 @@ class IpcAdapter final : public TransportAdapter {
   IpcRequestSlot* resolve_request_slot_const(unsigned request_id) const;
   void release_request_slot(unsigned request_id);
 
-  struct PeerDoneChannel {
-    IpcChannelPair* shm_base = nullptr;
-    std::atomic<uint64_t>* local_ptr =
-        nullptr;  // we write after send completes
-    std::atomic<uint64_t>* remote_ptr =
-        nullptr;  // we read to detect peer send done
-    std::string shm_name;
-    bool is_creator = false;
-  };
-
   // Task queue / worker execution.
   bool enqueue_request(unsigned request_id, IpcReqType type);
   bool send_one(IpcRequestSlot* creq);
   bool recv_one(IpcRequestSlot* creq);
+  bool find_or_open_remote_ipc_handle(int remote_rank,
+                                      gpuIpcMemHandle_t const& handle,
+                                      size_t offset, size_t bytes,
+                                      int remote_gpu_idx, IPCItem* out);
+  void clear_remote_handle_cache();
   void send_thread_func();
   void recv_thread_func();
   void complete_task(IpcRequestSlot* req, bool ok);
-  bool setup_done_channel(int peer_rank);
-  void teardown_done_channel(int peer_rank);
-  void wait_done_channel_peer_ready(int peer_rank);
+
+  using IpcHandleKey = std::array<uint8_t, sizeof(gpuIpcMemHandle_t)>;
+  struct IpcHandleHash {
+    size_t operator()(IpcHandleKey const& k) const noexcept {
+      uint64_t hash = 1469598103934665603ull;
+      for (uint8_t b : k) {
+        hash ^= b;
+        hash *= 1099511628211ull;
+      }
+      return static_cast<size_t>(hash);
+    }
+  };
+  static IpcHandleKey make_ipc_handle_key(gpuIpcMemHandle_t const& h) {
+    IpcHandleKey k{};
+    std::memcpy(k.data(), &h, k.size());
+    return k;
+  }
 
   jring_t* send_task_ring_;
   jring_t* recv_task_ring_;
@@ -172,17 +173,13 @@ class IpcAdapter final : public TransportAdapter {
   std::atomic<bool> shutdown_started_{false};
   std::thread send_thread_;
   std::thread recv_thread_;
-  std::mutex send_cv_mu_;
-  std::condition_variable send_cv_;
-  std::mutex recv_cv_mu_;
-  std::condition_variable recv_cv_;
+  std::mutex cv_mu_;
+  std::condition_variable cv_;
   std::atomic<int> pending_send_{0};
   std::atomic<int> pending_recv_{0};
   std::vector<gpuStream_t> ipc_streams_;
 
-  std::string ring_namespace_;
   std::mutex match_seq_mu_;
-  std::vector<std::mutex> peer_connect_mu_;
   // Two directed-edge counters per peer:
   // dir=0 -> low-rank to high-rank, dir=1 -> high-rank to low-rank.
   std::vector<std::array<uint64_t, 2>> next_match_seq_per_peer_;
@@ -191,7 +188,10 @@ class IpcAdapter final : public TransportAdapter {
 
   std::shared_ptr<ShmRingExchanger> shm_control_;
   Communicator* comm_;
-  std::vector<PeerDoneChannel> done_channels_;
+  int local_gpu_idx_ = -1;
+  std::mutex remote_handle_mu_;
+  std::unordered_map<int, std::unordered_map<IpcHandleKey, IPCItem, IpcHandleHash>>
+      remote_handle_cache_;
 };
 
 }  // namespace Transport

--- a/experimental/ukernel/src/transport/adapter/ipc_adapter.h
+++ b/experimental/ukernel/src/transport/adapter/ipc_adapter.h
@@ -191,7 +191,8 @@ class IpcAdapter final : public TransportAdapter {
   Communicator* comm_;
   int local_gpu_idx_ = -1;
   std::mutex remote_handle_mu_;
-  std::unordered_map<int, std::unordered_map<IpcHandleKey, IPCItem, IpcHandleHash>>
+  std::unordered_map<int,
+                     std::unordered_map<IpcHandleKey, IPCItem, IpcHandleHash>>
       remote_handle_cache_;
 };
 

--- a/experimental/ukernel/src/transport/adapter/tcp_adapter.cc
+++ b/experimental/ukernel/src/transport/adapter/tcp_adapter.cc
@@ -249,10 +249,10 @@ bool TcpTransportAdapter::has_peer(int peer_rank) const {
 }
 
 unsigned TcpTransportAdapter::send_async(int peer_rank, void* local_ptr,
-                                         size_t len, uint64_t local_mr_id,
+                                         size_t len, uint32_t local_buffer_id,
                                          std::optional<RemoteSlice> remote_hint,
                                          BounceBufferProvider bounce_provider) {
-  (void)local_mr_id;
+  (void)local_buffer_id;
   (void)remote_hint;
   if (!has_peer(peer_rank)) return 0;
 
@@ -281,9 +281,9 @@ unsigned TcpTransportAdapter::send_async(int peer_rank, void* local_ptr,
 }
 
 unsigned TcpTransportAdapter::recv_async(int peer_rank, void* local_ptr,
-                                         size_t len, uint64_t local_mr_id,
+                                         size_t len, uint32_t local_buffer_id,
                                          BounceBufferProvider bounce_provider) {
-  (void)local_mr_id;
+  (void)local_buffer_id;
   if (!has_peer(peer_rank)) return 0;
   void* recv_ptr = local_ptr;
   if (bounce_provider) {

--- a/experimental/ukernel/src/transport/adapter/tcp_adapter.h
+++ b/experimental/ukernel/src/transport/adapter/tcp_adapter.h
@@ -32,11 +32,11 @@ class TcpTransportAdapter final : public TransportAdapter {
   bool has_peer(int peer_rank) const override;
 
   unsigned send_async(int peer_rank, void* local_ptr, size_t len,
-                      uint64_t local_mr_id,
+                      uint32_t local_buffer_id,
                       std::optional<RemoteSlice> remote_hint,
                       BounceBufferProvider bounce_provider = nullptr) override;
   unsigned recv_async(int peer_rank, void* local_ptr, size_t len,
-                      uint64_t local_mr_id,
+                      uint32_t local_buffer_id,
                       BounceBufferProvider bounce_provider = nullptr) override;
 
   bool poll_completion(unsigned id) override;

--- a/experimental/ukernel/src/transport/adapter/transport_adapter.h
+++ b/experimental/ukernel/src/transport/adapter/transport_adapter.h
@@ -14,7 +14,7 @@ namespace Transport {
 
 struct BounceBufferInfo {
   void* ptr = nullptr;
-  uint32_t mr_id = 0;
+  uint32_t buffer_id = 0;
   std::string shm_name;
   bool valid() const { return ptr != nullptr; }
 };
@@ -56,11 +56,13 @@ class TransportAdapter {
   virtual bool has_peer(int peer_rank) const = 0;
 
   virtual unsigned send_async(
-      int peer_rank, void* local_ptr, size_t len, uint64_t local_mr_id,
+      // Adapter-facing id is always local registered buffer id.
+      int peer_rank, void* local_ptr, size_t len, uint32_t local_buffer_id,
       std::optional<RemoteSlice> remote_hint,
       BounceBufferProvider bounce_provider = nullptr) = 0;
   virtual unsigned recv_async(
-      int peer_rank, void* local_ptr, size_t len, uint64_t local_mr_id,
+      // Adapter-facing id is always local registered buffer id.
+      int peer_rank, void* local_ptr, size_t len, uint32_t local_buffer_id,
       BounceBufferProvider bounce_provider = nullptr) = 0;
 
   virtual bool poll_completion(unsigned id) = 0;

--- a/experimental/ukernel/src/transport/adapter/uccl_adapter.cc
+++ b/experimental/ukernel/src/transport/adapter/uccl_adapter.cc
@@ -345,7 +345,8 @@ unsigned UcclTransportAdapter::recv_async(
   }
   unsigned request_id = 0;
   if (try_acquire_request_slot(&request_id) == nullptr) return 0;
-  int ret = recv_async_uccl(peer_rank, recv_ptr, len, recv_buffer_id, request_id);
+  int ret =
+      recv_async_uccl(peer_rank, recv_ptr, len, recv_buffer_id, request_id);
   if (ret != 0) {
     std::lock_guard<std::mutex> lk(mu_);
     release_request_slot_locked(request_id);

--- a/experimental/ukernel/src/transport/adapter/uccl_adapter.cc
+++ b/experimental/ukernel/src/transport/adapter/uccl_adapter.cc
@@ -146,9 +146,9 @@ bool UcclTransportAdapter::ensure_peer(PeerConnectSpec const& spec) {
                           u.remote_gpu_idx, u.remote_port);
 }
 
-bool UcclTransportAdapter::is_memory_registered(uint64_t mr_id) const {
+bool UcclTransportAdapter::is_memory_registered(uint32_t buffer_id) const {
   std::lock_guard<std::mutex> lk(mu_);
-  return mr_id_to_mhandle_.find(mr_id) != mr_id_to_mhandle_.end();
+  return buffer_id_to_mhandle_.find(buffer_id) != buffer_id_to_mhandle_.end();
 }
 
 bool UcclTransportAdapter::connect_to_peer(int peer_rank, std::string remote_ip,
@@ -262,12 +262,12 @@ bool UcclTransportAdapter::accept_from_peer(
   return has_send_peer(peer_rank) && has_recv_peer(peer_rank);
 }
 
-bool UcclTransportAdapter::register_memory(uint64_t mr_id, void* ptr,
+bool UcclTransportAdapter::register_memory(uint32_t buffer_id, void* ptr,
                                            size_t len) {
   if (!endpoint_ || ptr == nullptr || len == 0) return false;
   {
     std::lock_guard<std::mutex> lk(mu_);
-    if (mr_id_to_mhandle_.find(mr_id) != mr_id_to_mhandle_.end()) {
+    if (buffer_id_to_mhandle_.find(buffer_id) != buffer_id_to_mhandle_.end()) {
       return true;
     }
   }
@@ -281,48 +281,48 @@ bool UcclTransportAdapter::register_memory(uint64_t mr_id, void* ptr,
 
   {
     std::lock_guard<std::mutex> lk(mu_);
-    mr_id_to_mhandle_[mr_id] = mhandle;
+    buffer_id_to_mhandle_[buffer_id] = mhandle;
   }
 
   return true;
 }
 
-void UcclTransportAdapter::deregister_memory(uint64_t mr_id) {
+void UcclTransportAdapter::deregister_memory(uint32_t buffer_id) {
   if (!endpoint_) return;
   std::lock_guard<std::mutex> lk(mu_);
-  auto it = mr_id_to_mhandle_.find(mr_id);
-  if (it != mr_id_to_mhandle_.end()) {
+  auto it = buffer_id_to_mhandle_.find(buffer_id);
+  if (it != buffer_id_to_mhandle_.end()) {
     endpoint_->uccl_deregmr(it->second);
-    mr_id_to_mhandle_.erase(it);
+    buffer_id_to_mhandle_.erase(it);
   }
 }
 
 unsigned UcclTransportAdapter::send_async(
-    int peer_rank, void* local_ptr, size_t len, uint64_t local_mr_id,
+    int peer_rank, void* local_ptr, size_t len, uint32_t local_buffer_id,
     std::optional<RemoteSlice> remote_hint,
     BounceBufferProvider bounce_provider) {
   void* send_ptr = local_ptr;
-  uint64_t send_mr_id = local_mr_id;
+  uint32_t send_buffer_id = local_buffer_id;
 
   if (bounce_provider) {
     BounceBufferInfo info = bounce_provider(len);
     if (info.ptr != nullptr) {
       GPU_RT_CHECK(gpuMemcpy(info.ptr, local_ptr, len, gpuMemcpyDeviceToHost));
       send_ptr = info.ptr;
-      send_mr_id = info.mr_id;
+      send_buffer_id = info.buffer_id;
     }
   }
 
-  uint64_t remote_mr_id = 0;
+  uint32_t remote_buffer_id = 0;
   RemoteSlice const* remote_slice_ptr = nullptr;
   if (remote_hint.has_value()) {
-    remote_mr_id = remote_hint->mem_id;
+    remote_buffer_id = remote_hint->buffer_id;
     remote_slice_ptr = &(*remote_hint);
   }
   unsigned request_id = 0;
   if (try_acquire_request_slot(&request_id) == nullptr) return 0;
-  int ret = send_async_uccl(peer_rank, send_ptr, len, send_mr_id, remote_mr_id,
-                            request_id, remote_slice_ptr);
+  int ret = send_async_uccl(peer_rank, send_ptr, len, send_buffer_id,
+                            remote_buffer_id, request_id, remote_slice_ptr);
   if (ret != 0) {
     std::lock_guard<std::mutex> lk(mu_);
     release_request_slot_locked(request_id);
@@ -332,20 +332,20 @@ unsigned UcclTransportAdapter::send_async(
 }
 
 unsigned UcclTransportAdapter::recv_async(
-    int peer_rank, void* local_ptr, size_t len, uint64_t local_mr_id,
+    int peer_rank, void* local_ptr, size_t len, uint32_t local_buffer_id,
     BounceBufferProvider bounce_provider) {
   void* recv_ptr = local_ptr;
-  uint64_t recv_mr_id = local_mr_id;
+  uint32_t recv_buffer_id = local_buffer_id;
   if (bounce_provider) {
     BounceBufferInfo info = bounce_provider(len);
     if (info.ptr != nullptr) {
       recv_ptr = info.ptr;
-      recv_mr_id = info.mr_id;
+      recv_buffer_id = info.buffer_id;
     }
   }
   unsigned request_id = 0;
   if (try_acquire_request_slot(&request_id) == nullptr) return 0;
-  int ret = recv_async_uccl(peer_rank, recv_ptr, len, recv_mr_id, request_id);
+  int ret = recv_async_uccl(peer_rank, recv_ptr, len, recv_buffer_id, request_id);
   if (ret != 0) {
     std::lock_guard<std::mutex> lk(mu_);
     release_request_slot_locked(request_id);
@@ -361,8 +361,8 @@ bool UcclTransportAdapter::request_failed(unsigned id) {
 }
 
 int UcclTransportAdapter::send_async_uccl(int peer_rank, void* local_ptr,
-                                          size_t len, uint64_t local_mr_id,
-                                          uint64_t remote_mr_id,
+                                          size_t len, uint32_t local_buffer_id,
+                                          uint32_t remote_buffer_id,
                                           uint64_t request_id,
                                           RemoteSlice const* remote_slice) {
   ::uccl::UcclFlow* flow = nullptr;
@@ -378,8 +378,8 @@ int UcclTransportAdapter::send_async_uccl(int peer_rank, void* local_ptr,
     }
     flow = peer_it->second.send_flow;
 
-    auto mh_it = mr_id_to_mhandle_.find(local_mr_id);
-    if (mh_it != mr_id_to_mhandle_.end()) {
+    auto mh_it = buffer_id_to_mhandle_.find(local_buffer_id);
+    if (mh_it != buffer_id_to_mhandle_.end()) {
       local_mh = mh_it->second;
     }
 
@@ -396,8 +396,8 @@ int UcclTransportAdapter::send_async_uccl(int peer_rank, void* local_ptr,
   if (!flow || !local_mh || !ureq) {
     std::cerr << "[ERROR] UCCL send_async missing "
               << (!flow ? "send flow" : "memory handle") << " for peer "
-              << peer_rank << ", request " << request_id << ", mr_id "
-              << local_mr_id << ", len " << len << ", ptr " << local_ptr
+              << peer_rank << ", request " << request_id << ", buffer_id "
+              << local_buffer_id << ", len " << len << ", ptr " << local_ptr
               << std::endl;
     return -1;
   }
@@ -407,7 +407,7 @@ int UcclTransportAdapter::send_async_uccl(int peer_rank, void* local_ptr,
 
   // Optional one-sided path: if caller provides explicit remote write hint and
   // remote memory id, submit directly via write_async.
-  if (remote_slice != nullptr && remote_mr_id != 0 &&
+  if (remote_slice != nullptr && remote_buffer_id != 0 &&
       remote_slice->has_write_hint()) {
     one_sided_attempted = true;
     ::uccl::FifoItem slot_item{};
@@ -425,8 +425,9 @@ int UcclTransportAdapter::send_async_uccl(int peer_rank, void* local_ptr,
                                       ureq);
     if (ret != 0) {
       std::cerr << "[WARN] UCCL one-sided write submit failed for peer "
-                << peer_rank << ", request " << request_id << ", remote_mr_id "
-                << remote_mr_id << "; fallback to send/recv path" << std::endl;
+                << peer_rank << ", request " << request_id
+                << ", remote_buffer_id " << remote_buffer_id
+                << "; fallback to send/recv path" << std::endl;
     }
   }
 
@@ -443,9 +444,9 @@ int UcclTransportAdapter::send_async_uccl(int peer_rank, void* local_ptr,
     std::cerr << "[ERROR] UCCL "
               << (one_sided_attempted ? "write/send fallback" : "send")
               << " submit failed for peer " << peer_rank << ", request "
-              << request_id << ", mr_id " << local_mr_id << ", remote_mr_id "
-              << remote_mr_id << ", len " << len << ", ptr " << local_ptr
-              << std::endl;
+              << request_id << ", buffer_id " << local_buffer_id
+              << ", remote_buffer_id " << remote_buffer_id << ", len " << len
+              << ", ptr " << local_ptr << std::endl;
     std::lock_guard<std::mutex> lk(mu_);
     PendingRequestSlot* slot = resolve_request_slot_locked(request_id);
     if (slot != nullptr) {
@@ -467,7 +468,7 @@ int UcclTransportAdapter::send_async_uccl(int peer_rank, void* local_ptr,
 }
 
 int UcclTransportAdapter::recv_async_uccl(int peer_rank, void* local_ptr,
-                                          size_t len, uint64_t local_mr_id,
+                                          size_t len, uint32_t local_buffer_id,
                                           uint64_t request_id) {
   ::uccl::UcclFlow* flow = nullptr;
   ::uccl::Mhandle* local_mh = nullptr;
@@ -482,8 +483,8 @@ int UcclTransportAdapter::recv_async_uccl(int peer_rank, void* local_ptr,
     }
     flow = peer_it->second.recv_flow;
 
-    auto mh_it = mr_id_to_mhandle_.find(local_mr_id);
-    if (mh_it != mr_id_to_mhandle_.end()) {
+    auto mh_it = buffer_id_to_mhandle_.find(local_buffer_id);
+    if (mh_it != buffer_id_to_mhandle_.end()) {
       local_mh = mh_it->second;
     }
 
@@ -500,8 +501,8 @@ int UcclTransportAdapter::recv_async_uccl(int peer_rank, void* local_ptr,
   if (!flow || !local_mh || !ureq) {
     std::cerr << "[ERROR] UCCL recv_async missing "
               << (!flow ? "recv flow" : "memory handle") << " for peer "
-              << peer_rank << ", request " << request_id << ", mr_id "
-              << local_mr_id << ", len " << len << ", ptr " << local_ptr
+              << peer_rank << ", request " << request_id << ", buffer_id "
+              << local_buffer_id << ", len " << len << ", ptr " << local_ptr
               << std::endl;
     return -1;
   }
@@ -521,7 +522,7 @@ int UcclTransportAdapter::recv_async_uccl(int peer_rank, void* local_ptr,
   }
   if (ret != 0) {
     std::cerr << "[ERROR] UCCL recv_async submit failed for peer " << peer_rank
-              << ", request " << request_id << ", mr_id " << local_mr_id
+              << ", request " << request_id << ", buffer_id " << local_buffer_id
               << ", len " << len << ", ptr " << local_ptr << std::endl;
     std::lock_guard<std::mutex> lk(mu_);
     PendingRequestSlot* slot = resolve_request_slot_locked(request_id);

--- a/experimental/ukernel/src/transport/adapter/uccl_adapter.h
+++ b/experimental/ukernel/src/transport/adapter/uccl_adapter.h
@@ -39,9 +39,9 @@ class UcclTransportAdapter final : public TransportAdapter {
   int get_best_dev_idx(int gpu_idx) const;
 
   // Memory registration.
-  bool is_memory_registered(uint64_t mr_id) const;
-  bool register_memory(uint64_t mr_id, void* ptr, size_t len);
-  void deregister_memory(uint64_t mr_id);
+  bool is_memory_registered(uint32_t buffer_id) const;
+  bool register_memory(uint32_t buffer_id, void* ptr, size_t len);
+  void deregister_memory(uint32_t buffer_id);
   bool is_initialized() const { return endpoint_ != nullptr; }
 
   // TransportAdapter path-state overrides.
@@ -52,11 +52,11 @@ class UcclTransportAdapter final : public TransportAdapter {
 
   // TransportAdapter async data path overrides.
   unsigned send_async(int peer_rank, void* local_ptr, size_t len,
-                      uint64_t local_mr_id,
+                      uint32_t local_buffer_id,
                       std::optional<RemoteSlice> remote_hint,
                       BounceBufferProvider bounce_provider = nullptr) override;
   unsigned recv_async(int peer_rank, void* local_ptr, size_t len,
-                      uint64_t local_mr_id,
+                      uint32_t local_buffer_id,
                       BounceBufferProvider bounce_provider = nullptr) override;
 
   // TransportAdapter completion overrides.
@@ -94,7 +94,7 @@ class UcclTransportAdapter final : public TransportAdapter {
 
   std::unique_ptr<::uccl::RDMAEndpoint> endpoint_;
   std::unordered_map<int, PeerContext> peer_contexts_;
-  std::unordered_map<uint64_t, ::uccl::Mhandle*> mr_id_to_mhandle_;
+  std::unordered_map<uint32_t, ::uccl::Mhandle*> buffer_id_to_mhandle_;
 
   // Internal peer-connection helpers.
   bool connect_to_peer(int peer_rank, std::string remote_ip,
@@ -108,11 +108,11 @@ class UcclTransportAdapter final : public TransportAdapter {
 
   // Internal async submit helpers.
   int send_async_uccl(int peer_rank, void* local_ptr, size_t len,
-                      uint64_t local_mr_id, uint64_t remote_mr_id,
+                      uint32_t local_buffer_id, uint32_t remote_buffer_id,
                       uint64_t request_id,
                       RemoteSlice const* remote_slice = nullptr);
   int recv_async_uccl(int peer_rank, void* local_ptr, size_t len,
-                      uint64_t local_mr_id, uint64_t request_id);
+                      uint32_t local_buffer_id, uint64_t request_id);
 
   // Internal peer-state helpers.
   bool has_send_peer(int peer_rank) const;

--- a/experimental/ukernel/src/transport/communicator.cc
+++ b/experimental/ukernel/src/transport/communicator.cc
@@ -1,8 +1,8 @@
 #include "communicator.h"
 #include "adapter/ipc_adapter.h"
-#include "adapter/uccl_adapter.h"
 #include "adapter/tcp_adapter.h"
 #include "adapter/transport_adapter.h"
+#include "adapter/uccl_adapter.h"
 #include "util/utils.h"
 #include <arpa/inet.h>
 #include <infiniband/verbs.h>
@@ -128,13 +128,13 @@ std::string tcp_p2p_key(int src_rank, int dst_rank) {
 }
 
 std::string ipc_global_buffer_key(int owner_rank, uint32_t buffer_id) {
-  return "ipc:rank:" + std::to_string(owner_rank) + ":buf:" +
-         std::to_string(buffer_id);
+  return "ipc:rank:" + std::to_string(owner_rank) +
+         ":buf:" + std::to_string(buffer_id);
 }
 
 std::string mr_global_buffer_key(int owner_rank, uint32_t buffer_id) {
-  return "mr:rank:" + std::to_string(owner_rank) + ":buf:" +
-         std::to_string(buffer_id);
+  return "mr:rank:" + std::to_string(owner_rank) +
+         ":buf:" + std::to_string(buffer_id);
 }
 
 std::string oob_scoped_key(std::string const& ns, std::string const& key) {
@@ -172,8 +172,7 @@ void validate_dst_hint_for_transport(PeerTransportKind kind,
   }
   // IPC/TCP use common (`buffer_id`, `offset`) hint and ignore `write`.
   // UCCL validates write-capacity hints when provided.
-  if (kind == PeerTransportKind::Uccl &&
-      hint.has_write_hint() &&
+  if (kind == PeerTransportKind::Uccl && hint.has_write_hint() &&
       hint.write.capacity != 0 && hint.write.capacity < src_bytes) {
     throw std::invalid_argument(
         "dst_hint.write.capacity is smaller than send size");
@@ -215,7 +214,8 @@ Communicator::Communicator(int gpu_id, int rank, int world_size,
       peer_states_(static_cast<size_t>(world_size)),
       config_(config) {
   if (!config_) {
-    config_ = std::make_shared<CommunicatorConfig>(CommunicatorConfig::from_env());
+    config_ =
+        std::make_shared<CommunicatorConfig>(CommunicatorConfig::from_env());
   }
   if (config_->oob_namespace.empty()) {
     config_->oob_namespace = "default";
@@ -597,9 +597,9 @@ UcclTransportAdapter& Communicator::ensure_uccl_adapter(
   return *uccl_adapter_;
 }
 
-bool Communicator::exchange_uccl_peer_info(
-    int rank, UcclTransportAdapter& uccl_adapter,
-    UCCLP2PInfo* out_remote_p2p_info) {
+bool Communicator::exchange_uccl_peer_info(int rank,
+                                           UcclTransportAdapter& uccl_adapter,
+                                           UCCLP2PInfo* out_remote_p2p_info) {
   if (out_remote_p2p_info == nullptr) return false;
 
   int dev_idx = uccl_adapter.get_best_dev_idx(local_gpu_idx_);
@@ -624,7 +624,8 @@ bool Communicator::exchange_uccl_peer_info(
     return false;
   }
 
-  UCCLP2PInfo local_p2p_info(local_ip_addr, local_port, dev_idx, local_gpu_idx_);
+  UCCLP2PInfo local_p2p_info(local_ip_addr, local_port, dev_idx,
+                             local_gpu_idx_);
   std::string p2p_key = uccl_p2p_key(global_rank_, rank);
   std::string peer_p2p_key = uccl_p2p_key(rank, global_rank_);
 
@@ -679,8 +680,7 @@ bool Communicator::try_fallback_tcp_connect(
                             tcp_adapter.get_listen_port());
   std::string p2p_key = tcp_p2p_key(global_rank_, rank);
   std::string peer_p2p_key = tcp_p2p_key(rank, global_rank_);
-  if (!oob_put(*exchanger_client_, oob_namespace(), p2p_key,
-               local_p2p_info))
+  if (!oob_put(*exchanger_client_, oob_namespace(), p2p_key, local_p2p_info))
     return false;
 
   TcpP2PInfo remote_p2p_info;
@@ -705,8 +705,8 @@ bool Communicator::try_fallback_tcp_connect(
   return true;
 }
 
-bool Communicator::try_fallback_tcp_accept(
-    int rank, CommunicatorMeta const& local_meta) {
+bool Communicator::try_fallback_tcp_accept(int rank,
+                                           CommunicatorMeta const& local_meta) {
   if (config_->preferred_transport != PreferredTransport::Auto) return false;
   auto& tcp_adapter = ensure_tcp_adapter(local_meta);
   if (tcp_adapter.has_peer(rank)) {
@@ -1002,7 +1002,8 @@ bool Communicator::ensure_uccl_memory_registered(uint32_t buffer_id, void* ptr,
 
     auto item = mr_manager_.get_mr(static_cast<uint32_t>(buffer_id));
     if (item.valid) {
-      base_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(item.mr.address));
+      base_ptr =
+          reinterpret_cast<void*>(static_cast<uintptr_t>(item.mr.address));
       mr_len = static_cast<size_t>(item.mr.length);
       is_direct_local_mr = true;
     }
@@ -1147,8 +1148,8 @@ unsigned Communicator::isend(int rank, LocalSlice src,
   // Auto-enrich one-sided write hint from exchanged remote MR metadata when the
   // caller only provides {remote buffer_id, offset}. This keeps Python/CCL APIs
   // simple while still enabling UCCL fast paths.
-  if (peer_kind == PeerTransportKind::Uccl &&
-      effective_dst_hint.has_value() && !effective_dst_hint->has_write_hint() &&
+  if (peer_kind == PeerTransportKind::Uccl && effective_dst_hint.has_value() &&
+      !effective_dst_hint->has_write_hint() &&
       effective_dst_hint->buffer_id != 0) {
     try {
       MR remote_mr = get_mr(rank, effective_dst_hint->buffer_id);
@@ -1164,8 +1165,8 @@ unsigned Communicator::isend(int rank, LocalSlice src,
         }
         enriched.write.addr = addr;
         enriched.write.key = remote_mr.key;
-        enriched.write.capacity = static_cast<uint32_t>(
-            std::min<uint64_t>(remaining, std::numeric_limits<uint32_t>::max()));
+        enriched.write.capacity = static_cast<uint32_t>(std::min<uint64_t>(
+            remaining, std::numeric_limits<uint32_t>::max()));
         effective_dst_hint = enriched;
       }
     } catch (std::exception const&) {
@@ -1348,9 +1349,8 @@ unsigned Communicator::irecv(int rank, LocalSlice dst) {
     return info;
   };
 
-  unsigned result =
-      adapter->recv_async(rank, local_ptr, dst.bytes, dst.buffer_id,
-                          bounce_provider);
+  unsigned result = adapter->recv_async(rank, local_ptr, dst.bytes,
+                                        dst.buffer_id, bounce_provider);
   if (result == 0) {
     slot->state.store(TrackedRequest::SlotState::Releasing,
                       std::memory_order_release);
@@ -1694,7 +1694,8 @@ bool Communicator::dereg_ipc(uint32_t buffer_id) {
   return true;
 }
 
-bool Communicator::wait_ipc(int owner_rank, uint32_t buffer_id, int timeout_ms) {
+bool Communicator::wait_ipc(int owner_rank, uint32_t buffer_id,
+                            int timeout_ms) {
   if (buffer_id == 0) return false;
   if (owner_rank == global_rank_) {
     std::lock_guard<std::mutex> lk(resource_mu_);
@@ -1790,7 +1791,8 @@ bool Communicator::try_resolve_remote_ipc_pointer(int remote_rank,
     gpuError_t restore_err = gpuSetDevice(original_device);
     if (restore_err != gpuSuccess) return false;
     if (open_err != gpuSuccess || item.direct_ptr == nullptr) return false;
-    if (!ipc_manager_.register_remote_ipc(remote_rank, remote_buffer_id, item)) {
+    if (!ipc_manager_.register_remote_ipc(remote_rank, remote_buffer_id,
+                                          item)) {
       return false;
     }
   }

--- a/experimental/ukernel/src/transport/communicator.cc
+++ b/experimental/ukernel/src/transport/communicator.cc
@@ -393,16 +393,17 @@ Communicator::~Communicator() {
   }
 
   for (auto const& [buffer_id, item] : mr_manager_.list_local_mrs()) {
-    uint64_t const buffer_id = item.mr.id;
+    uint64_t const registered_id = buffer_id;
     if (uccl_adapter_ && uccl_adapter_->is_initialized()) {
       std::lock_guard<std::mutex> lk(uccl_reg_mu_);
-      if (uccl_registered_mrs_.find(buffer_id) != uccl_registered_mrs_.end()) {
-        uccl_adapter_->deregister_memory(buffer_id);
-        uccl_registered_mrs_.erase(buffer_id);
+      if (uccl_registered_mrs_.find(registered_id) !=
+          uccl_registered_mrs_.end()) {
+        uccl_adapter_->deregister_memory(registered_id);
+        uccl_registered_mrs_.erase(registered_id);
       }
-      uccl_direct_reg_failed_mrs_.erase(buffer_id);
+      uccl_direct_reg_failed_mrs_.erase(registered_id);
     }
-    (void)mr_manager_.delete_mr(buffer_id);
+    (void)mr_manager_.delete_mr(static_cast<uint32_t>(buffer_id));
   }
 
   std::vector<uint32_t> local_ipc_buffer_ids;
@@ -1221,16 +1222,16 @@ unsigned Communicator::isend(int rank, LocalSlice src,
     BounceBufferInfo info;
     info.ptr = bounce_owner->ptr;
     if (needs_uccl_registration) {
-      // Request-scoped bounce MR id. The MR is deleted in request cleanup.
+      // Request-scoped bounce buffer_id. The MR is deleted in request cleanup.
       uint32_t temp_buffer_id =
           next_ephemeral_buffer_id_.fetch_add(1, std::memory_order_relaxed);
       if (temp_buffer_id == 0) {
         temp_buffer_id =
             next_ephemeral_buffer_id_.fetch_add(1, std::memory_order_relaxed);
       }
-      auto mr = mr_manager_.create_local_mr(temp_buffer_id, bounce_owner->ptr,
-                                            bytes);
-      info.buffer_id = mr.mr.id;
+      (void)mr_manager_.create_local_mr(temp_buffer_id, bounce_owner->ptr,
+                                        bytes);
+      info.buffer_id = temp_buffer_id;
     }
     if (bounce_owner->shareable) {
       info.shm_name = shm_manager.get_local_shm(bounce_owner->shm_id).shm_name;
@@ -1330,16 +1331,16 @@ unsigned Communicator::irecv(int rank, LocalSlice dst) {
     BounceBufferInfo info;
     info.ptr = slot->bounce.ptr;
     if (needs_uccl_registration) {
-      // Request-scoped bounce MR id. The MR is deleted in request cleanup.
+      // Request-scoped bounce buffer_id. The MR is deleted in request cleanup.
       uint32_t temp_buffer_id =
           next_ephemeral_buffer_id_.fetch_add(1, std::memory_order_relaxed);
       if (temp_buffer_id == 0) {
         temp_buffer_id =
             next_ephemeral_buffer_id_.fetch_add(1, std::memory_order_relaxed);
       }
-      auto mr =
-          mr_manager_.create_local_mr(temp_buffer_id, slot->bounce.ptr, bytes);
-      info.buffer_id = mr.mr.id;
+      (void)mr_manager_.create_local_mr(temp_buffer_id, slot->bounce.ptr,
+                                        bytes);
+      info.buffer_id = temp_buffer_id;
     }
     if (slot->bounce.shareable) {
       info.shm_name = shm_manager.get_local_shm(slot->bounce.shm_id).shm_name;
@@ -1530,7 +1531,7 @@ bool Communicator::reg_mr(uint32_t buffer_id, void* local_buf, size_t len,
                           bool publish) {
   if (buffer_id == 0 || local_buf == nullptr || len == 0) return false;
   MR mr = mr_manager_.create_local_mr(buffer_id, local_buf, len).mr;
-  if (mr.id == 0) return false;
+  if (mr.address == 0 || mr.length == 0) return false;
 
   {
     std::lock_guard<std::mutex> lk(resource_mu_);
@@ -1559,7 +1560,7 @@ bool Communicator::dereg_mr(uint32_t buffer_id) {
       found = true;
     }
   }
-  uint32_t const registered_id = static_cast<uint32_t>(local_mr.id);
+  uint32_t const registered_id = buffer_id;
 
   if (registered_id != 0 && uccl_adapter_ && uccl_adapter_->is_initialized()) {
     std::lock_guard<std::mutex> lk(uccl_reg_mu_);
@@ -1591,7 +1592,10 @@ bool Communicator::wait_mr(int owner_rank, uint32_t buffer_id, int timeout_ms) {
   bool found = false;
   MR mr{};
   for (auto const& entry : payload.entries) {
-    if (entry.buffer_id != buffer_id || entry.mr.id == 0) continue;
+    if (entry.buffer_id != buffer_id || entry.mr.address == 0 ||
+        entry.mr.length == 0) {
+      continue;
+    }
     mr = entry.mr;
     found = true;
     break;
@@ -1599,6 +1603,7 @@ bool Communicator::wait_mr(int owner_rank, uint32_t buffer_id, int timeout_ms) {
   if (!found) return false;
 
   MRItem item{};
+  item.buffer_id = buffer_id;
   item.mr = mr;
   item.is_local = false;
   item.rank = owner_rank;

--- a/experimental/ukernel/src/transport/communicator.cc
+++ b/experimental/ukernel/src/transport/communicator.cc
@@ -1,8 +1,8 @@
 #include "communicator.h"
 #include "adapter/ipc_adapter.h"
+#include "adapter/uccl_adapter.h"
 #include "adapter/tcp_adapter.h"
 #include "adapter/transport_adapter.h"
-#include "adapter/uccl_adapter.h"
 #include "util/utils.h"
 #include <arpa/inet.h>
 #include <infiniband/verbs.h>
@@ -29,9 +29,7 @@ namespace Transport {
 
 namespace {
 
-constexpr int kBootstrapPollDelayMs = 100;
 constexpr int kDefaultBootstrapTimeoutMs = 30000;
-constexpr int kDefaultMrTimeoutMs = 30000;
 
 std::string get_local_ip() {
   if (char const* env_ip = std::getenv("UHM_LOCAL_IP")) {
@@ -56,15 +54,6 @@ std::string get_local_ip() {
   char buf[INET_ADDRSTRLEN];
   ::inet_ntop(AF_INET, &local.sin_addr, buf, sizeof(buf));
   return buf;
-}
-
-void notify_eventfd_nonblocking(int fd) {
-  if (fd < 0) return;
-  uint64_t one = 1;
-  ssize_t rc = 0;
-  do {
-    rc = ::write(fd, &one, sizeof(one));
-  } while (rc < 0 && errno == EINTR);
 }
 
 bool has_env_value(char const* name) {
@@ -100,8 +89,7 @@ std::string find_ifname_for_local_ip(std::string const& ip) {
   return ifname;
 }
 
-void maybe_configure_uccl_socket_ifname(std::string const& remote_hint_ip,
-                                        std::string const& local_hint_ip) {
+void maybe_configure_uccl_socket_ifname(std::string const& local_hint_ip) {
   if (has_env_value("UCCL_SOCKET_IFNAME") ||
       has_env_value("NCCL_SOCKET_IFNAME")) {
     return;
@@ -115,18 +103,6 @@ void maybe_configure_uccl_socket_ifname(std::string const& remote_hint_ip,
             << std::endl;
 }
 
-std::string get_uccl_remote_hint_ip(
-    std::shared_ptr<CommunicatorConfig> const& config,
-    CommunicatorMeta const& peer_meta) {
-  if (config && !is_unspecified_ip(config->exchanger_ip)) {
-    return config->exchanger_ip;
-  }
-  if (!is_unspecified_ip(peer_meta.ip)) {
-    return peer_meta.ip;
-  }
-  return {};
-}
-
 int get_timeout_ms(char const* env_name, int default_ms) {
   char const* value = std::getenv(env_name);
   if (value == nullptr || value[0] == '\0') return default_ms;
@@ -137,33 +113,8 @@ int get_timeout_ms(char const* env_name, int default_ms) {
   }
 }
 
-int timeout_to_retries(int timeout_ms, int delay_ms) {
-  if (timeout_ms < 0) return -1;
-  if (delay_ms <= 0) return timeout_ms > 0 ? timeout_ms : 1;
-  return std::max(1, (timeout_ms + delay_ms - 1) / delay_ms);
-}
-
 int bootstrap_timeout_ms() {
   return get_timeout_ms("UHM_BOOTSTRAP_TIMEOUT_MS", kDefaultBootstrapTimeoutMs);
-}
-
-int mr_timeout_ms() {
-  return get_timeout_ms("UHM_MR_TIMEOUT_MS", kDefaultMrTimeoutMs);
-}
-
-Exchanger::WaitOptions make_wait_options(int timeout_ms, int delay_ms) {
-  return Exchanger::WaitOptions{timeout_to_retries(timeout_ms, delay_ms),
-                                delay_ms};
-}
-
-Exchanger::WaitOptions make_wait_options_until(
-    std::chrono::steady_clock::time_point deadline, int delay_ms) {
-  auto const now = std::chrono::steady_clock::now();
-  if (deadline <= now) return Exchanger::WaitOptions{0, delay_ms};
-  auto const remaining_ms = static_cast<int>(
-      std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now)
-          .count());
-  return make_wait_options(remaining_ms, delay_ms);
 }
 
 std::string uccl_p2p_key(int src_rank, int dst_rank) {
@@ -176,28 +127,39 @@ std::string tcp_p2p_key(int src_rank, int dst_rank) {
          std::to_string(dst_rank);
 }
 
-std::string ipc_buffer_key(int src_rank, int dst_rank, uint32_t ipc_id) {
-  return "ipcbuf:" + std::to_string(src_rank) + "->" +
-         std::to_string(dst_rank) + ":ipc:" + std::to_string(ipc_id);
+std::string ipc_global_buffer_key(int owner_rank, uint32_t buffer_id) {
+  return "ipc:rank:" + std::to_string(owner_rank) + ":buf:" +
+         std::to_string(buffer_id);
 }
 
-std::string ipc_buffer_versioned_key(int src_rank, int dst_rank,
-                                     uint32_t ipc_id,
-                                     uint64_t binding_version) {
-  return ipc_buffer_key(src_rank, dst_rank, ipc_id) + ":v" +
-         std::to_string(binding_version);
+std::string mr_global_buffer_key(int owner_rank, uint32_t buffer_id) {
+  return "mr:rank:" + std::to_string(owner_rank) + ":buf:" +
+         std::to_string(buffer_id);
 }
 
-IPCItem ipc_item_from_info(IpcBufferInfo const& info, uint32_t ipc_id) {
-  IPCItem state{};
-  state.handle = info.handle;
-  state.binding_version = info.binding_version;
-  state.base_offset = static_cast<uintptr_t>(info.base_offset);
-  state.bytes = static_cast<size_t>(info.bytes);
-  state.device_idx = info.device_idx;
-  state.valid = info.valid;
-  state.ipc_id = ipc_id;
-  return state;
+std::string oob_scoped_key(std::string const& ns, std::string const& key) {
+  if (ns.empty()) return key;
+  return ns + "/" + key;
+}
+
+template <typename Info>
+bool oob_put(Exchanger& ex, std::string const& ns, std::string const& key,
+             Info const& value) {
+  return ex.put(oob_scoped_key(ns, key), value);
+}
+
+template <typename Info>
+bool oob_get(Exchanger& ex, std::string const& ns, std::string const& key,
+             Info& out, int timeout_ms = 0) {
+  std::string const full_key = oob_scoped_key(ns, key);
+  if (timeout_ms == 0) return ex.get(full_key, out);
+  constexpr int kPollDelayMs = 10;
+  int const max_retries =
+      timeout_ms < 0
+          ? -1
+          : std::max(1, (timeout_ms + kPollDelayMs - 1) / kPollDelayMs);
+  return ex.wait(full_key, out,
+                 Exchanger::WaitOptions(max_retries, kPollDelayMs));
 }
 
 void validate_dst_hint_for_transport(PeerTransportKind kind,
@@ -205,39 +167,17 @@ void validate_dst_hint_for_transport(PeerTransportKind kind,
                                      size_t src_bytes) {
   if (!dst_hint.has_value()) return;
   auto const& hint = *dst_hint;
-  if (hint.mem_id == 0) {
-    throw std::invalid_argument("dst_hint.mem_id must be non-zero");
+  if (hint.buffer_id == 0) {
+    throw std::invalid_argument("dst_hint.buffer_id must be non-zero");
   }
-  // IPC/TCP use common (`mem_id`, `offset`) hint and ignore `write`.
-  if (kind == PeerTransportKind::Uccl && hint.has_write_hint() &&
+  // IPC/TCP use common (`buffer_id`, `offset`) hint and ignore `write`.
+  // UCCL validates write-capacity hints when provided.
+  if (kind == PeerTransportKind::Uccl &&
+      hint.has_write_hint() &&
       hint.write.capacity != 0 && hint.write.capacity < src_bytes) {
     throw std::invalid_argument(
         "dst_hint.write.capacity is smaller than send size");
   }
-}
-
-template <typename Info>
-bool publish_local_then_wait_remote(Exchanger& exchanger,
-                                    std::string const& local_key,
-                                    Info const& local_info,
-                                    std::string const& remote_key,
-                                    Info& remote_info, int timeout_ms) {
-  if (!exchanger.put(local_key, local_info)) return false;
-  return exchanger.wait(remote_key, remote_info,
-                        make_wait_options(timeout_ms, kBootstrapPollDelayMs));
-}
-
-template <typename Info>
-bool wait_remote_then_publish_local(Exchanger& exchanger,
-                                    std::string const& remote_key,
-                                    Info& remote_info,
-                                    std::string const& local_key,
-                                    Info const& local_info, int timeout_ms) {
-  if (!exchanger.wait(remote_key, remote_info,
-                      make_wait_options(timeout_ms, kBootstrapPollDelayMs))) {
-    return false;
-  }
-  return exchanger.put(local_key, local_info);
 }
 
 bool detect_local_rdma_capable() {
@@ -252,6 +192,19 @@ bool detect_local_rdma_capable() {
   return count > 0;
 }
 
+void signal_eventfd_if_needed(int event_fd) {
+  if (event_fd < 0) return;
+  uint64_t one = 1;
+  while (true) {
+    ssize_t n = ::write(event_fd, &one, sizeof(one));
+    if (n == static_cast<ssize_t>(sizeof(one))) return;
+    if (n < 0 && errno == EINTR) continue;
+    // EAGAIN means counter is saturated; wakeup is already pending.
+    if (n < 0 && errno == EAGAIN) return;
+    return;
+  }
+}
+
 }  // namespace
 
 Communicator::Communicator(int gpu_id, int rank, int world_size,
@@ -261,6 +214,12 @@ Communicator::Communicator(int gpu_id, int rank, int world_size,
       world_size_(world_size),
       peer_states_(static_cast<size_t>(world_size)),
       config_(config) {
+  if (!config_) {
+    config_ = std::make_shared<CommunicatorConfig>(CommunicatorConfig::from_env());
+  }
+  if (config_->oob_namespace.empty()) {
+    config_->oob_namespace = "default";
+  }
   request_slots_ = std::make_unique<TrackedRequest[]>(kRequestSlotCount);
   active_ring_ = std::make_unique<std::atomic<unsigned>[]>(kActiveRingSize);
   for (uint32_t i = 0; i < kActiveRingSize; ++i) {
@@ -272,7 +231,8 @@ Communicator::Communicator(int gpu_id, int rank, int world_size,
   }
   ipc_adapter_ = std::make_shared<IpcAdapter>(
       this, generate_host_id() + "_p" + std::to_string(config_->exchanger_port),
-      config_->local_id >= 0 ? config_->local_id : global_rank_);
+      config_->local_id >= 0 ? config_->local_id : global_rank_,
+      local_gpu_idx_);
   GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
   GPU_RT_CHECK(
       gpuStreamCreateWithFlags(&host_copy_stream_, gpuStreamNonBlocking));
@@ -280,15 +240,16 @@ Communicator::Communicator(int gpu_id, int rank, int world_size,
   bool is_server = (global_rank_ == 0);
   if (!is_server && config_->exchanger_ip == "0.0.0.0")
     config_->exchanger_ip = "127.0.0.1";
-  std::cout << "[INFO] Using socket-based bootstrap exchanger as "
+  std::cout << "[INFO] Using hierarchical bootstrap exchanger as "
             << (is_server ? "server" : "client") << " " << config_->exchanger_ip
             << std::endl;
   exchanger_client_ = std::make_shared<HierarchicalExchanger>(
       (global_rank_ == 0), config_->exchanger_ip, config_->exchanger_port,
       /*timeout_ms=*/3000, /*max_line_bytes=*/1 * 1024 * 1024,
-      config_->local_id);
+      /*local_id=*/config_->local_id);
   if (!exchanger_client_->valid()) {
-    throw std::runtime_error("failed to initialize hierarchical exchanger");
+    fprintf(stderr, "[ERROR] Failed to connect to Exchanger\n");
+    return;
   }
 
   shm_manager_.emplace();
@@ -303,6 +264,43 @@ Communicator::Communicator(int gpu_id, int rank, int world_size,
   exchange_peer_metas();
   std::cout << "[INFO] Communicator " << global_rank_
             << " initialized: peer meta exchange success" << std::endl;
+}
+
+void Communicator::set_oob_namespace(std::string ns) {
+  if (ns.empty()) ns = "default";
+  std::lock_guard<std::mutex> lk(config_mu_);
+  config_->oob_namespace = std::move(ns);
+}
+
+std::string Communicator::oob_namespace() const {
+  std::lock_guard<std::mutex> lk(config_mu_);
+  if (config_->oob_namespace.empty()) return "default";
+  return config_->oob_namespace;
+}
+
+bool Communicator::barrier(std::string const& barrier_namespace,
+                           int timeout_ms) {
+  if (!exchanger_client_ || !exchanger_client_->valid()) return false;
+  std::string ns = barrier_namespace.empty() ? "default" : barrier_namespace;
+  uint64_t const seq = barrier_seq_.fetch_add(1, std::memory_order_relaxed);
+  std::string const barrier_prefix =
+      oob_namespace() + "/barrier/" + ns + "/seq/" + std::to_string(seq);
+  std::string const arrive_key =
+      barrier_prefix + "/rank/" + std::to_string(global_rank_);
+  if (!exchanger_client_->put(arrive_key, int32_t{1})) return false;
+
+  constexpr int kPollDelayMs = 10;
+  int const max_retries =
+      timeout_ms < 0
+          ? -1
+          : std::max(1, (timeout_ms + kPollDelayMs - 1) / kPollDelayMs);
+  Exchanger::WaitOptions const wait_opt(max_retries, kPollDelayMs);
+  int32_t arrived = 0;
+  for (int rank = 0; rank < world_size_; ++rank) {
+    std::string const key = barrier_prefix + "/rank/" + std::to_string(rank);
+    if (!exchanger_client_->wait(key, arrived, wait_opt)) return false;
+  }
+  return true;
 }
 
 void Communicator::exchange_peer_metas() {
@@ -320,8 +318,9 @@ void Communicator::exchange_peer_metas() {
   }
 
   std::string meta_key = "meta:" + std::to_string(global_rank_);
-  if (!exchanger_client_->put(meta_key, local)) {
-    fprintf(stderr, "[ERROR] Failed to publish local CommunicatorMeta \n");
+  if (!oob_put(*exchanger_client_, oob_namespace(), meta_key, local)) {
+    throw std::runtime_error(
+        "failed to publish local communicator meta to exchanger");
   }
 
   CommunicatorMeta remote;
@@ -329,9 +328,8 @@ void Communicator::exchange_peer_metas() {
   for (int i = 0; i < world_size_; i++) {
     if (i == global_rank_) continue;
     std::string key = "meta:" + std::to_string(i);
-    if (exchanger_client_->wait(
-            key, remote,
-            make_wait_options(bootstrap_timeout_ms(), kBootstrapPollDelayMs))) {
+    if (oob_get(*exchanger_client_, oob_namespace(), key, remote,
+                bootstrap_timeout_ms())) {
       std::lock_guard<std::mutex> lk(peer_mu_);
       auto& peer = peer_states_.at(static_cast<size_t>(i));
       peer.meta = remote;
@@ -357,7 +355,7 @@ Communicator::~Communicator() {
   if (progress_started_.load()) {
     progress_running_.store(false);
     progress_cv_.notify_all();
-    notify_eventfd_nonblocking(completion_event_fd_);
+    signal_eventfd_if_needed(completion_event_fd_);
     if (progress_thread_.joinable()) {
       progress_thread_.join();
     }
@@ -394,9 +392,29 @@ Communicator::~Communicator() {
     host_copy_stream_ = nullptr;
   }
 
-  for (auto const& [buf, item] : mr_manager_.list_local_mrs()) {
-    (void)item;
-    dereg_mr(buf);
+  for (auto const& [buffer_id, item] : mr_manager_.list_local_mrs()) {
+    uint64_t const buffer_id = item.mr.id;
+    if (uccl_adapter_ && uccl_adapter_->is_initialized()) {
+      std::lock_guard<std::mutex> lk(uccl_reg_mu_);
+      if (uccl_registered_mrs_.find(buffer_id) != uccl_registered_mrs_.end()) {
+        uccl_adapter_->deregister_memory(buffer_id);
+        uccl_registered_mrs_.erase(buffer_id);
+      }
+      uccl_direct_reg_failed_mrs_.erase(buffer_id);
+    }
+    (void)mr_manager_.delete_mr(buffer_id);
+  }
+
+  std::vector<uint32_t> local_ipc_buffer_ids;
+  {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    local_ipc_buffer_ids.reserve(local_buffer_to_ipc_.size());
+    for (auto const& kv : local_buffer_to_ipc_) {
+      local_ipc_buffer_ids.push_back(kv.first);
+    }
+  }
+  for (uint32_t buffer_id : local_ipc_buffer_ids) {
+    (void)dereg_ipc(buffer_id);
   }
 
   for (int i = 0; i < world_size_; ++i) {
@@ -404,7 +422,7 @@ Communicator::~Communicator() {
     ipc_manager_.delete_ipc(i);
   }
 
-  // Destroy bounce pool before uccl_adapter_ to avoid dangling references
+  // Destroy bounce pool before transport adapters to avoid dangling references
   // in the deregister callback during pool teardown.
   shm_manager_.reset();
   uccl_adapter_.reset();
@@ -564,42 +582,55 @@ bool Communicator::dequeue_active_request(unsigned* out_req_id) {
 
 void Communicator::notify_request_completion() {
   completion_seq_.fetch_add(1, std::memory_order_release);
-  notify_eventfd_nonblocking(completion_event_fd_);
+  signal_eventfd_if_needed(completion_event_fd_);
 }
 
 UcclTransportAdapter& Communicator::ensure_uccl_adapter(
-    CommunicatorMeta const& local_meta, CommunicatorMeta const& peer_meta) {
+    CommunicatorMeta const& local_meta) {
   if (!uccl_adapter_) {
-    maybe_configure_uccl_socket_ifname(
-        get_uccl_remote_hint_ip(config_, peer_meta), local_meta.ip);
+    maybe_configure_uccl_socket_ifname(local_meta.ip);
     UcclTransportConfig uccl_cfg;
     uccl_adapter_ = std::make_unique<UcclTransportAdapter>(
         local_gpu_idx_, world_size_, std::move(uccl_cfg));
-
-    mr_manager_.bind_backend(
-        [this](uint32_t mr_id, void* ptr, size_t len) -> bool {
-          if (!uccl_adapter_ || !uccl_adapter_->is_initialized()) return false;
-          bool ok = uccl_adapter_->register_memory(mr_id, ptr, len);
-          std::lock_guard<std::mutex> lk(uccl_reg_mu_);
-          if (ok) {
-            uccl_direct_reg_failed_mrs_.erase(mr_id);
-            uccl_registered_mrs_.insert(mr_id);
-          } else {
-            uccl_direct_reg_failed_mrs_.insert(mr_id);
-          }
-          return ok;
-        },
-        [this](uint32_t mr_id) {
-          if (uccl_adapter_ && uccl_adapter_->is_initialized()) {
-            uccl_adapter_->deregister_memory(mr_id);
-          }
-          std::lock_guard<std::mutex> lk(uccl_reg_mu_);
-          uccl_direct_reg_failed_mrs_.erase(mr_id);
-          uccl_registered_mrs_.erase(mr_id);
-        });
-    mr_manager_.sync_local_backend();
   }
   return *uccl_adapter_;
+}
+
+bool Communicator::exchange_uccl_peer_info(
+    int rank, UcclTransportAdapter& uccl_adapter,
+    UCCLP2PInfo* out_remote_p2p_info) {
+  if (out_remote_p2p_info == nullptr) return false;
+
+  int dev_idx = uccl_adapter.get_best_dev_idx(local_gpu_idx_);
+  if (dev_idx < 0) {
+    std::cerr << "[ERROR] Communicator " << global_rank_
+              << " UCCL get_best_dev_idx failed for local gpu "
+              << local_gpu_idx_ << std::endl;
+    return false;
+  }
+  uint16_t local_port = uccl_adapter.get_p2p_listen_port(dev_idx);
+  if (local_port == 0) {
+    std::cerr << "[ERROR] Communicator " << global_rank_
+              << " UCCL local listen port is invalid for dev " << dev_idx
+              << std::endl;
+    return false;
+  }
+  std::string local_ip_addr = uccl_adapter.get_p2p_listen_ip(dev_idx);
+  if (local_ip_addr.empty()) {
+    std::cerr << "[ERROR] Communicator " << global_rank_
+              << " UCCL local listen ip is empty for dev " << dev_idx
+              << std::endl;
+    return false;
+  }
+
+  UCCLP2PInfo local_p2p_info(local_ip_addr, local_port, dev_idx, local_gpu_idx_);
+  std::string p2p_key = uccl_p2p_key(global_rank_, rank);
+  std::string peer_p2p_key = uccl_p2p_key(rank, global_rank_);
+
+  return oob_put(*exchanger_client_, oob_namespace(), p2p_key,
+                 local_p2p_info) &&
+         oob_get(*exchanger_client_, oob_namespace(), peer_p2p_key,
+                 *out_remote_p2p_info, bootstrap_timeout_ms());
 }
 
 TcpTransportAdapter& Communicator::ensure_tcp_adapter(
@@ -647,12 +678,13 @@ bool Communicator::try_fallback_tcp_connect(
                             tcp_adapter.get_listen_port());
   std::string p2p_key = tcp_p2p_key(global_rank_, rank);
   std::string peer_p2p_key = tcp_p2p_key(rank, global_rank_);
-  if (!exchanger_client_->put(p2p_key, local_p2p_info)) return false;
+  if (!oob_put(*exchanger_client_, oob_namespace(), p2p_key,
+               local_p2p_info))
+    return false;
 
   TcpP2PInfo remote_p2p_info;
-  if (!exchanger_client_->wait(
-          peer_p2p_key, remote_p2p_info,
-          make_wait_options(bootstrap_timeout_ms(), kBootstrapPollDelayMs))) {
+  if (!oob_get(*exchanger_client_, oob_namespace(), peer_p2p_key,
+               remote_p2p_info, bootstrap_timeout_ms())) {
     return false;
   }
 
@@ -673,9 +705,7 @@ bool Communicator::try_fallback_tcp_connect(
 }
 
 bool Communicator::try_fallback_tcp_accept(
-    int rank, CommunicatorMeta const& local_meta,
-    CommunicatorMeta const& remote_meta) {
-  (void)remote_meta;
+    int rank, CommunicatorMeta const& local_meta) {
   if (config_->preferred_transport != PreferredTransport::Auto) return false;
   auto& tcp_adapter = ensure_tcp_adapter(local_meta);
   if (tcp_adapter.has_peer(rank)) {
@@ -685,17 +715,16 @@ bool Communicator::try_fallback_tcp_accept(
 
   std::string p2p_key = tcp_p2p_key(global_rank_, rank);
   std::string peer_p2p_key = tcp_p2p_key(rank, global_rank_);
-
-  TcpP2PInfo remote_p2p_info;
-  if (!exchanger_client_->wait(
-          peer_p2p_key, remote_p2p_info,
-          make_wait_options(bootstrap_timeout_ms(), kBootstrapPollDelayMs))) {
-    return false;
-  }
-
   TcpP2PInfo local_p2p_info(tcp_adapter.get_listen_ip(),
                             tcp_adapter.get_listen_port());
-  if (!exchanger_client_->put(p2p_key, local_p2p_info)) return false;
+  if (!oob_put(*exchanger_client_, oob_namespace(), p2p_key, local_p2p_info))
+    return false;
+
+  TcpP2PInfo remote_p2p_info;
+  if (!oob_get(*exchanger_client_, oob_namespace(), peer_p2p_key,
+               remote_p2p_info, bootstrap_timeout_ms())) {
+    return false;
+  }
 
   PeerConnectSpec spec{};
   spec.peer_rank = rank;
@@ -733,50 +762,23 @@ bool Communicator::connect(int rank) {
   }
 
   if (resolved.kind == PeerTransportKind::Uccl) {
-    auto& uccl_adapter =
-        ensure_uccl_adapter(resolved.local_meta, resolved.remote_meta);
+    auto& uccl_adapter = ensure_uccl_adapter(resolved.local_meta);
     if (!uccl_adapter.has_peer(rank)) {
-      int dev_idx = uccl_adapter.get_best_dev_idx(local_gpu_idx_);
-      if (dev_idx < 0) {
-        std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " UCCL get_best_dev_idx failed for local gpu "
-                  << local_gpu_idx_ << std::endl;
+      int local_dev_idx = uccl_adapter.get_best_dev_idx(local_gpu_idx_);
+      if (local_dev_idx < 0) {
         return try_fallback_tcp_connect(rank, resolved.local_meta);
       }
-      uint16_t local_port = uccl_adapter.get_p2p_listen_port(dev_idx);
-      if (local_port == 0) {
-        std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " UCCL local listen port is invalid for dev " << dev_idx
-                  << std::endl;
-        return try_fallback_tcp_connect(rank, resolved.local_meta);
-      }
-      std::string local_ip_addr = uccl_adapter.get_p2p_listen_ip(dev_idx);
-      if (local_ip_addr.empty()) {
-        std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " UCCL local listen ip is empty for dev " << dev_idx
-                  << std::endl;
-        return try_fallback_tcp_connect(rank, resolved.local_meta);
-      }
-      UCCLP2PInfo local_p2p_info(local_ip_addr, local_port, dev_idx,
-                                 local_gpu_idx_);
-      std::string p2p_key = uccl_p2p_key(global_rank_, rank);
-      std::string peer_p2p_key = uccl_p2p_key(rank, global_rank_);
       UCCLP2PInfo remote_p2p_info;
-      if (!publish_local_then_wait_remote(
-              *exchanger_client_, p2p_key, local_p2p_info, peer_p2p_key,
-              remote_p2p_info, bootstrap_timeout_ms())) {
-        return false;
+      if (!exchange_uccl_peer_info(rank, uccl_adapter, &remote_p2p_info)) {
+        return try_fallback_tcp_connect(rank, resolved.local_meta);
       }
-      // connect() path: connect first, then establish reverse flow.
       PeerConnectSpec spec{};
       spec.peer_rank = rank;
       spec.type = PeerConnectType::Connect;
       spec.detail = UcclPeerConnectSpec{
-          remote_p2p_info.ip, remote_p2p_info.port,    dev_idx,
+          remote_p2p_info.ip, remote_p2p_info.port,    local_dev_idx,
           local_gpu_idx_,     remote_p2p_info.dev_idx, remote_p2p_info.gpu_idx};
-      if (!uccl_adapter.has_peer(rank) && !uccl_adapter.ensure_peer(spec)) {
-        std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " UCCL connect_to failed to rank " << rank << std::endl;
+      if (!uccl_adapter.ensure_peer(spec)) {
         return try_fallback_tcp_connect(rank, resolved.local_meta);
       }
     }
@@ -808,9 +810,10 @@ bool Communicator::connect(int rank) {
       std::string p2p_key = tcp_p2p_key(global_rank_, rank);
       std::string peer_p2p_key = tcp_p2p_key(rank, global_rank_);
       TcpP2PInfo remote_p2p_info;
-      if (!publish_local_then_wait_remote(
-              *exchanger_client_, p2p_key, local_p2p_info, peer_p2p_key,
-              remote_p2p_info, bootstrap_timeout_ms())) {
+      if (!oob_put(*exchanger_client_, oob_namespace(), p2p_key,
+                   local_p2p_info) ||
+          !oob_get(*exchanger_client_, oob_namespace(), peer_p2p_key,
+                   remote_p2p_info, bootstrap_timeout_ms())) {
         return false;
       }
       PeerConnectSpec spec{};
@@ -850,55 +853,24 @@ bool Communicator::accept(int rank) {
   }
 
   if (resolved.kind == PeerTransportKind::Uccl) {
-    auto& uccl_adapter =
-        ensure_uccl_adapter(resolved.local_meta, resolved.remote_meta);
+    auto& uccl_adapter = ensure_uccl_adapter(resolved.local_meta);
     if (!uccl_adapter.has_peer(rank)) {
-      int dev_idx = uccl_adapter.get_best_dev_idx(local_gpu_idx_);
-      if (dev_idx < 0) {
-        std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " UCCL get_best_dev_idx failed for local gpu "
-                  << local_gpu_idx_ << std::endl;
-        return try_fallback_tcp_accept(rank, resolved.local_meta,
-                                       resolved.remote_meta);
+      int local_dev_idx = uccl_adapter.get_best_dev_idx(local_gpu_idx_);
+      if (local_dev_idx < 0) {
+        return try_fallback_tcp_accept(rank, resolved.local_meta);
       }
-      uint16_t local_port = uccl_adapter.get_p2p_listen_port(dev_idx);
-      if (local_port == 0) {
-        std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " UCCL local listen port is invalid for dev " << dev_idx
-                  << std::endl;
-        return try_fallback_tcp_accept(rank, resolved.local_meta,
-                                       resolved.remote_meta);
-      }
-      std::string local_ip_addr = uccl_adapter.get_p2p_listen_ip(dev_idx);
-      if (local_ip_addr.empty()) {
-        std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " UCCL local listen ip is empty for dev " << dev_idx
-                  << std::endl;
-        return try_fallback_tcp_accept(rank, resolved.local_meta,
-                                       resolved.remote_meta);
-      }
-      UCCLP2PInfo local_p2p_info(local_ip_addr, local_port, dev_idx,
-                                 local_gpu_idx_);
-      std::string p2p_key = uccl_p2p_key(global_rank_, rank);
-      std::string peer_p2p_key = uccl_p2p_key(rank, global_rank_);
       UCCLP2PInfo remote_p2p_info;
-      if (!wait_remote_then_publish_local(
-              *exchanger_client_, peer_p2p_key, remote_p2p_info, p2p_key,
-              local_p2p_info, bootstrap_timeout_ms())) {
-        return false;
+      if (!exchange_uccl_peer_info(rank, uccl_adapter, &remote_p2p_info)) {
+        return try_fallback_tcp_accept(rank, resolved.local_meta);
       }
-      // accept() path: accept first, then establish reverse flow.
       PeerConnectSpec spec{};
       spec.peer_rank = rank;
       spec.type = PeerConnectType::Accept;
       spec.detail = UcclPeerConnectSpec{
-          remote_p2p_info.ip, remote_p2p_info.port,    dev_idx,
+          remote_p2p_info.ip, remote_p2p_info.port,    local_dev_idx,
           local_gpu_idx_,     remote_p2p_info.dev_idx, remote_p2p_info.gpu_idx};
-      if (!uccl_adapter.has_peer(rank) && !uccl_adapter.ensure_peer(spec)) {
-        std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " UCCL accept_from failed from rank " << rank << std::endl;
-        return try_fallback_tcp_accept(rank, resolved.local_meta,
-                                       resolved.remote_meta);
+      if (!uccl_adapter.ensure_peer(spec)) {
+        return try_fallback_tcp_accept(rank, resolved.local_meta);
       }
     }
     mark_peer_path_ready(rank, PeerTransportKind::Uccl);
@@ -914,7 +886,6 @@ bool Communicator::accept(int rank) {
     if (!ipc_adapter_->ensure_peer(spec)) {
       std::cerr << "[ERROR] Communicator " << global_rank_
                 << " IPC accept_from failed from rank " << rank << std::endl;
-      ipc_adapter_->close_peer(rank);
       return false;
     }
     mark_peer_path_ready(rank, PeerTransportKind::Ipc);
@@ -929,9 +900,10 @@ bool Communicator::accept(int rank) {
       TcpP2PInfo remote_p2p_info;
       TcpP2PInfo local_p2p_info(tcp_adapter.get_listen_ip(),
                                 tcp_adapter.get_listen_port());
-      if (!wait_remote_then_publish_local(
-              *exchanger_client_, peer_p2p_key, remote_p2p_info, p2p_key,
-              local_p2p_info, bootstrap_timeout_ms())) {
+      if (!oob_put(*exchanger_client_, oob_namespace(), p2p_key,
+                   local_p2p_info) ||
+          !oob_get(*exchanger_client_, oob_namespace(), peer_p2p_key,
+                   remote_p2p_info, bootstrap_timeout_ms())) {
         return false;
       }
       PeerConnectSpec spec{};
@@ -1011,34 +983,32 @@ bool Communicator::same_host(int rank) const {
 
 void Communicator::register_existing_local_mrs_with_uccl() {
   if (!uccl_adapter_ || !uccl_adapter_->is_initialized()) return;
-  mr_manager_.sync_local_backend();
+  for (auto const& [buffer_id, item] : mr_manager_.list_local_mrs()) {
+    void* ptr = reinterpret_cast<void*>(item.mr.address);
+    size_t len = static_cast<size_t>(item.mr.length);
+    (void)ensure_uccl_memory_registered(buffer_id, ptr, len);
+  }
 }
 
-bool Communicator::ensure_uccl_memory_registered(uint64_t mr_id, void* ptr,
+bool Communicator::ensure_uccl_memory_registered(uint32_t buffer_id, void* ptr,
                                                  size_t len) {
   if (uccl_adapter_ && uccl_adapter_->is_initialized()) {
-    if (uccl_adapter_->is_memory_registered(mr_id)) return true;
+    if (uccl_adapter_->is_memory_registered(buffer_id)) return true;
 
     void* base_ptr = ptr;
     size_t mr_len = len;
     bool is_direct_local_mr = false;
 
-    // Normal device tensor/staging MRs are tracked in MemoryRegistry by id.
-    // Host bounce buffers use synthetic ids that are not, so fall back to the
-    // explicit ptr/len provided by the caller in that case.
-    if (mr_id <= std::numeric_limits<uint32_t>::max()) {
-      try {
-        MR mr = get_local_mr(static_cast<uint32_t>(mr_id));
-        base_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(mr.address));
-        mr_len = static_cast<size_t>(mr.length);
-        is_direct_local_mr = true;
-      } catch (std::exception const&) {
-      }
+    auto item = mr_manager_.get_mr(static_cast<uint32_t>(buffer_id));
+    if (item.valid) {
+      base_ptr = reinterpret_cast<void*>(static_cast<uintptr_t>(item.mr.address));
+      mr_len = static_cast<size_t>(item.mr.length);
+      is_direct_local_mr = true;
     }
 
     if (is_direct_local_mr) {
       std::lock_guard<std::mutex> lk(uccl_reg_mu_);
-      if (uccl_direct_reg_failed_mrs_.find(mr_id) !=
+      if (uccl_direct_reg_failed_mrs_.find(buffer_id) !=
           uccl_direct_reg_failed_mrs_.end()) {
         return false;
       }
@@ -1047,29 +1017,29 @@ bool Communicator::ensure_uccl_memory_registered(uint64_t mr_id, void* ptr,
     if (base_ptr == nullptr || mr_len == 0) {
       std::cerr << "[ERROR] Communicator " << global_rank_
                 << " has invalid base pointer or length for UCCL registration, "
-                << "mr_id=" << mr_id << std::endl;
+                << "buffer_id=" << buffer_id << std::endl;
       return false;
     }
 
-    bool ok = uccl_adapter_->register_memory(mr_id, base_ptr, mr_len);
+    bool ok = uccl_adapter_->register_memory(buffer_id, base_ptr, mr_len);
     if (!ok) {
       if (is_direct_local_mr) {
         std::lock_guard<std::mutex> lk(uccl_reg_mu_);
-        uccl_direct_reg_failed_mrs_.insert(mr_id);
+        uccl_direct_reg_failed_mrs_.insert(buffer_id);
         std::cerr << "[WARN] Communicator " << global_rank_
-                  << " failed to register local GPU MR " << mr_id
+                  << " failed to register local GPU MR " << buffer_id
                   << " with UCCL, base=" << base_ptr << " len=" << mr_len
                   << "; future requests will fallback to host bounce"
                   << std::endl;
       } else {
         std::cerr << "[ERROR] Communicator " << global_rank_
-                  << " failed to register host bounce MR " << mr_id
+                  << " failed to register host bounce MR " << buffer_id
                   << " with UCCL, base=" << base_ptr << " len=" << mr_len
                   << std::endl;
       }
     } else {
       std::lock_guard<std::mutex> lk(uccl_reg_mu_);
-      uccl_registered_mrs_.insert(mr_id);
+      uccl_registered_mrs_.insert(buffer_id);
     }
     return ok;
   }
@@ -1155,13 +1125,13 @@ SHMManager& Communicator::require_shm_manager(char const* caller) {
 
 unsigned Communicator::isend(int rank, LocalSlice src,
                              std::optional<RemoteSlice> dst_hint) {
-  if (src.mem_id == 0 || src.bytes == 0) {
+  if (src.buffer_id == 0 || src.bytes == 0) {
     throw std::invalid_argument("isend requires non-empty local slice");
   }
   if (!has_peer_path(rank) && !connect(rank)) {
     throw std::runtime_error("transport peer path is not established");
   }
-  MR local_mr = get_local_mr(src.mem_id);
+  MR local_mr = get_mr(src.buffer_id);
   if (src.offset > static_cast<size_t>(local_mr.length) ||
       src.bytes > static_cast<size_t>(local_mr.length) - src.offset) {
     throw std::invalid_argument("isend local slice out of range");
@@ -1172,7 +1142,37 @@ unsigned Communicator::isend(int rank, LocalSlice src,
   if (!adapter) {
     throw std::runtime_error("failed to get adapter for peer");
   }
-  validate_dst_hint_for_transport(peer_kind, dst_hint, src.bytes);
+  std::optional<RemoteSlice> effective_dst_hint = dst_hint;
+  // Auto-enrich one-sided write hint from exchanged remote MR metadata when the
+  // caller only provides {remote buffer_id, offset}. This keeps Python/CCL APIs
+  // simple while still enabling UCCL fast paths.
+  if (peer_kind == PeerTransportKind::Uccl &&
+      effective_dst_hint.has_value() && !effective_dst_hint->has_write_hint() &&
+      effective_dst_hint->buffer_id != 0) {
+    try {
+      MR remote_mr = get_mr(rank, effective_dst_hint->buffer_id);
+      if (remote_mr.address != 0 && remote_mr.key != 0) {
+        RemoteSlice enriched = *effective_dst_hint;
+        uint64_t addr = remote_mr.address;
+        if (enriched.offset <= std::numeric_limits<uint64_t>::max() - addr) {
+          addr += static_cast<uint64_t>(enriched.offset);
+        }
+        uint64_t remaining = 0;
+        if (remote_mr.length > enriched.offset) {
+          remaining = remote_mr.length - static_cast<uint64_t>(enriched.offset);
+        }
+        enriched.write.addr = addr;
+        enriched.write.key = remote_mr.key;
+        enriched.write.capacity = static_cast<uint32_t>(
+            std::min<uint64_t>(remaining, std::numeric_limits<uint32_t>::max()));
+        effective_dst_hint = enriched;
+      }
+    } catch (std::exception const&) {
+      // Remote MR may be unavailable for this buffer_id; keep the original hint
+      // and let adapter fallback logic handle it.
+    }
+  }
+  validate_dst_hint_for_transport(peer_kind, effective_dst_hint, src.bytes);
 
   void* local_ptr = reinterpret_cast<void*>(
       static_cast<uintptr_t>(local_mr.address) + src.offset);
@@ -1182,8 +1182,8 @@ unsigned Communicator::isend(int rank, LocalSlice src,
   bool needs_bounce =
       (peer_kind == PeerTransportKind::Tcp) ||
       (peer_kind == PeerTransportKind::Ipc) ||
-      (peer_kind == PeerTransportKind::Uccl &&
-       !ensure_uccl_memory_registered(src.mem_id, local_ptr, src.bytes));
+      ((peer_kind == PeerTransportKind::Uccl &&
+        !ensure_uccl_memory_registered(src.buffer_id, local_ptr, src.bytes)));
   unsigned rid = 0;
   TrackedRequest* slot = allocate_request_slot(&rid);
   if (slot == nullptr) return 0;
@@ -1222,8 +1222,15 @@ unsigned Communicator::isend(int rank, LocalSlice src,
     info.ptr = bounce_owner->ptr;
     if (needs_uccl_registration) {
       // Request-scoped bounce MR id. The MR is deleted in request cleanup.
-      auto mr = mr_manager_.create_local_mr(bounce_owner->ptr, bytes);
-      info.mr_id = mr.mr.id;
+      uint32_t temp_buffer_id =
+          next_ephemeral_buffer_id_.fetch_add(1, std::memory_order_relaxed);
+      if (temp_buffer_id == 0) {
+        temp_buffer_id =
+            next_ephemeral_buffer_id_.fetch_add(1, std::memory_order_relaxed);
+      }
+      auto mr = mr_manager_.create_local_mr(temp_buffer_id, bounce_owner->ptr,
+                                            bytes);
+      info.buffer_id = mr.mr.id;
     }
     if (bounce_owner->shareable) {
       info.shm_name = shm_manager.get_local_shm(bounce_owner->shm_id).shm_name;
@@ -1231,8 +1238,9 @@ unsigned Communicator::isend(int rank, LocalSlice src,
     return info;
   };
 
-  unsigned result = adapter->send_async(rank, local_ptr, src.bytes, src.mem_id,
-                                        dst_hint, bounce_provider);
+  unsigned result =
+      adapter->send_async(rank, local_ptr, src.bytes, src.buffer_id,
+                          effective_dst_hint, bounce_provider);
   if (result == 0) {
     slot->state.store(TrackedRequest::SlotState::Releasing,
                       std::memory_order_release);
@@ -1251,13 +1259,13 @@ unsigned Communicator::isend(int rank, LocalSlice src,
 }
 
 unsigned Communicator::irecv(int rank, LocalSlice dst) {
-  if (dst.mem_id == 0 || dst.bytes == 0) {
+  if (dst.buffer_id == 0 || dst.bytes == 0) {
     throw std::invalid_argument("irecv requires non-empty local slice");
   }
   if (!has_peer_path(rank) && !connect(rank)) {
     throw std::runtime_error("transport peer path is not established");
   }
-  MR local_mr = get_local_mr(dst.mem_id);
+  MR local_mr = get_mr(dst.buffer_id);
   if (dst.offset > static_cast<size_t>(local_mr.length) ||
       dst.bytes > static_cast<size_t>(local_mr.length) - dst.offset) {
     throw std::invalid_argument("irecv local slice out of range");
@@ -1282,48 +1290,22 @@ unsigned Communicator::irecv(int rank, LocalSlice dst) {
 
   auto needs_bounce =
       (peer_kind == PeerTransportKind::Tcp) ||
-      (peer_kind == PeerTransportKind::Uccl &&
-       !ensure_uccl_memory_registered(dst.mem_id, local_ptr, dst.bytes));
+      ((peer_kind == PeerTransportKind::Uccl &&
+        !ensure_uccl_memory_registered(dst.buffer_id, local_ptr, dst.bytes)));
 
-  // IPC fast path metadata: let sender resolve remote pointer by dst.mem_id
+  // IPC fast path metadata: let sender resolve remote pointer by dst.buffer_id
   // and skip per-request ipc_cache handshake when possible.
   if (peer_kind == PeerTransportKind::Ipc) {
     // Publish MR base mapping (not slice pointer) so sender-side
-    // resolve_ipc_buffer_pointer(remote_offset) applies offset exactly once.
+    // get_ipc(remote_id) + remote_offset applies offset exactly once.
     void* ipc_base_ptr =
         reinterpret_cast<void*>(static_cast<uintptr_t>(local_mr.address));
     size_t ipc_bytes = static_cast<size_t>(local_mr.length);
-    uintptr_t ipc_base_addr = reinterpret_cast<uintptr_t>(ipc_base_ptr);
-    bool should_publish = true;
-    uint64_t publish_binding_version = 0;
-    {
-      std::lock_guard<std::mutex> lk(ipc_gen_mu_);
-      auto& published = local_ipc_published_buffers_[rank][dst.mem_id];
-      if (published.valid && published.base_addr == ipc_base_addr &&
-          published.bytes == ipc_bytes) {
-        should_publish = false;
-        publish_binding_version = published.binding_version;
-      } else {
-        publish_binding_version =
-            ++local_ipc_binding_versions_[rank][dst.mem_id];
-      }
-    }
-    if (should_publish) {
-      if (!notify_ipc_buffer(rank, dst.mem_id, ipc_base_ptr, ipc_bytes,
-                             publish_binding_version)) {
-        std::cerr << "[WARN] Communicator " << global_rank_
-                  << " failed to publish IPC buffer metadata for rank " << rank
-                  << ", ipc_id=" << dst.mem_id
-                  << "; sender may fallback to ipc_cache handshake"
-                  << std::endl;
-      } else {
-        std::lock_guard<std::mutex> lk(ipc_gen_mu_);
-        auto& published = local_ipc_published_buffers_[rank][dst.mem_id];
-        published.base_addr = ipc_base_addr;
-        published.bytes = ipc_bytes;
-        published.binding_version = publish_binding_version;
-        published.valid = true;
-      }
+    if (!reg_ipc(dst.buffer_id, ipc_base_ptr, ipc_bytes, true)) {
+      std::cerr << "[WARN] Communicator " << global_rank_
+                << " failed to publish IPC buffer metadata for rank " << rank
+                << ", buffer_id=" << dst.buffer_id
+                << "; sender may fallback to ipc_cache handshake" << std::endl;
     }
   }
 
@@ -1349,8 +1331,15 @@ unsigned Communicator::irecv(int rank, LocalSlice dst) {
     info.ptr = slot->bounce.ptr;
     if (needs_uccl_registration) {
       // Request-scoped bounce MR id. The MR is deleted in request cleanup.
-      auto mr = mr_manager_.create_local_mr(slot->bounce.ptr, bytes);
-      info.mr_id = mr.mr.id;
+      uint32_t temp_buffer_id =
+          next_ephemeral_buffer_id_.fetch_add(1, std::memory_order_relaxed);
+      if (temp_buffer_id == 0) {
+        temp_buffer_id =
+            next_ephemeral_buffer_id_.fetch_add(1, std::memory_order_relaxed);
+      }
+      auto mr =
+          mr_manager_.create_local_mr(temp_buffer_id, slot->bounce.ptr, bytes);
+      info.buffer_id = mr.mr.id;
     }
     if (slot->bounce.shareable) {
       info.shm_name = shm_manager.get_local_shm(slot->bounce.shm_id).shm_name;
@@ -1358,8 +1347,9 @@ unsigned Communicator::irecv(int rank, LocalSlice dst) {
     return info;
   };
 
-  unsigned result = adapter->recv_async(rank, local_ptr, dst.bytes, dst.mem_id,
-                                        bounce_provider);
+  unsigned result =
+      adapter->recv_async(rank, local_ptr, dst.bytes, dst.buffer_id,
+                          bounce_provider);
   if (result == 0) {
     slot->state.store(TrackedRequest::SlotState::Releasing,
                       std::memory_order_release);
@@ -1391,6 +1381,7 @@ bool Communicator::poll_request_completion(unsigned id, bool blocking) {
   bool failed = false;
   unsigned adapter_id = slot->adapter_request_id;
   if (slot->kind == PeerTransportKind::Uccl) {
+    if (!uccl_adapter_) return false;
     done = blocking ? uccl_adapter_->wait_completion(adapter_id)
                     : uccl_adapter_->poll_completion(adapter_id);
     failed = done && uccl_adapter_->request_failed(adapter_id);
@@ -1532,377 +1523,281 @@ void Communicator::release(unsigned const req) {
 }
 
 bool Communicator::wait_finish(unsigned const req) {
-  if (req == 0) return false;
-  if (progress_started_.load(std::memory_order_acquire)) {
-    while (true) {
-      TrackedRequest* slot = resolve_request_slot(req);
-      if (slot == nullptr) return true;
-      if (slot->kind != PeerTransportKind::Ipc) break;
-      auto state = slot->state.load(std::memory_order_acquire);
-      if (state == TrackedRequest::SlotState::InFlight) {
-        std::this_thread::yield();
-        continue;
-      }
-      if (state == TrackedRequest::SlotState::Completed ||
-          state == TrackedRequest::SlotState::Failed) {
-        TrackedRequest snapshot{};
-        if (try_release_request_slot(req, &snapshot)) {
-          bool failed = (state == TrackedRequest::SlotState::Failed);
-          cleanup_tracked_request(snapshot);
-          return !failed;
-        }
-        // CAS lost: another releaser (e.g. destructor cleanup) claimed the
-        // slot. The slot is transitioning to Free — retry until nullptr.
-        std::this_thread::yield();
-        continue;
-      }
-      // Releasing is a transient state between Completed/Failed and Free.
-      // Yield and retry so the slot can finish transitioning.
-      std::this_thread::yield();
-    }
-  }
   return wait_finish(std::vector<unsigned>{req});
 }
 
-MR Communicator::reg_mr(void* local_buf, size_t len) {
-  return mr_manager_.create_local_mr(local_buf, len).mr;
+bool Communicator::reg_mr(uint32_t buffer_id, void* local_buf, size_t len,
+                          bool publish) {
+  if (buffer_id == 0 || local_buf == nullptr || len == 0) return false;
+  MR mr = mr_manager_.create_local_mr(buffer_id, local_buf, len).mr;
+  if (mr.id == 0) return false;
+
+  {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    local_buffer_to_mr_[buffer_id] = mr;
+  }
+
+  if (!publish || !exchanger_client_ || !exchanger_client_->valid()) {
+    return true;
+  }
+
+  NamedMRInfos payload{};
+  payload.entries.push_back(NamedMR{buffer_id, mr});
+  return oob_put(*exchanger_client_, oob_namespace(),
+                 mr_global_buffer_key(global_rank_, buffer_id), payload);
 }
 
-bool Communicator::dereg_mr(void* local_buf) {
-  (void)mr_manager_.delete_mr(local_buf);
+bool Communicator::dereg_mr(uint32_t buffer_id) {
+  MR local_mr{};
+  bool found = false;
+  {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    auto it = local_buffer_to_mr_.find(buffer_id);
+    if (it != local_buffer_to_mr_.end()) {
+      local_mr = it->second;
+      local_buffer_to_mr_.erase(it);
+      found = true;
+    }
+  }
+  uint32_t const registered_id = static_cast<uint32_t>(local_mr.id);
+
+  if (registered_id != 0 && uccl_adapter_ && uccl_adapter_->is_initialized()) {
+    std::lock_guard<std::mutex> lk(uccl_reg_mu_);
+    if (uccl_registered_mrs_.erase(registered_id) > 0) {
+      uccl_adapter_->deregister_memory(registered_id);
+    }
+    uccl_direct_reg_failed_mrs_.erase(registered_id);
+  }
+  if (found) (void)mr_manager_.delete_mr(buffer_id);
   return true;
 }
 
-bool Communicator::notify_named_mrs(int remote_rank, uint64_t generation,
-                                    NamedMRInfos const& infos) {
+bool Communicator::wait_mr(int owner_rank, uint32_t buffer_id, int timeout_ms) {
+  if (buffer_id == 0) return false;
+  if (owner_rank == global_rank_) {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    return local_buffer_to_mr_.find(buffer_id) != local_buffer_to_mr_.end();
+  }
   if (!exchanger_client_ || !exchanger_client_->valid()) return false;
 
-  std::string key = "named-mr:" + std::to_string(global_rank_) + "->" +
-                    std::to_string(remote_rank) + ":" +
-                    std::to_string(generation);
-  std::lock_guard<std::mutex> lk(mr_exchange_mu_);
-  NamedMRInfos payload = infos;
-  payload.generation = generation;
-
-  // for (auto const& entry : payload.entries) {
-  //   std::cout << "[notify named MR to rank " << remote_rank
-  //             << "] generation=" << generation
-  //             << " buffer_id=" << entry.buffer_id
-  //             << " addr=" << entry.mr.address
-  //             << " length=" << entry.mr.length
-  //             << " key=" << entry.mr.key << std::endl;
-  // }
-
-  return exchanger_client_->put(key, payload);
-}
-
-bool Communicator::wait_named_mrs(int remote_rank, uint64_t generation,
-                                  NamedMRInfos& infos) {
-  if (!exchanger_client_ || !exchanger_client_->valid()) {
-    throw std::runtime_error("Exchanger client is not valid");
-  }
-
-  std::string key = "named-mr:" + std::to_string(remote_rank) + "->" +
-                    std::to_string(global_rank_) + ":" +
-                    std::to_string(generation);
-  int timeout_ms = mr_timeout_ms();
-  if (!exchanger_client_->wait(key, infos, make_wait_options(timeout_ms, 1))) {
-    std::cerr << "[WARN] Timeout waiting for named MR table from rank "
-              << remote_rank << std::endl;
+  NamedMRInfos payload{};
+  if (!oob_get(*exchanger_client_, oob_namespace(),
+               mr_global_buffer_key(owner_rank, buffer_id), payload,
+               timeout_ms)) {
     return false;
   }
-  if (infos.generation != generation) {
-    std::cerr << "[WARN] Named MR generation mismatch from rank " << remote_rank
-              << ": expected=" << generation << " got=" << infos.generation
-              << std::endl;
-    return false;
-  }
+  if (payload.entries.empty()) return false;
 
-  std::vector<MRItem> remote_mrs;
-  remote_mrs.reserve(infos.entries.size());
-  for (auto const& entry : infos.entries) {
-    MRItem item{};
-    item.mr = entry.mr;
-    item.is_local = false;
-    item.rank = remote_rank;
-    item.valid = true;
-    remote_mrs.push_back(item);
-    // std::cout << "[recv named MR from rank " << remote_rank
-    //           << "] generation=" << generation
-    //           << " buffer_id=" << entry.buffer_id
-    //           << " addr=" << entry.mr.address
-    //           << " length=" << entry.mr.length
-    //           << " key=" << entry.mr.key << std::endl;
+  bool found = false;
+  MR mr{};
+  for (auto const& entry : payload.entries) {
+    if (entry.buffer_id != buffer_id || entry.mr.id == 0) continue;
+    mr = entry.mr;
+    found = true;
+    break;
   }
-  mr_manager_.register_remote_mrs(remote_rank, remote_mrs);
+  if (!found) return false;
+
+  MRItem item{};
+  item.mr = mr;
+  item.is_local = false;
+  item.rank = owner_rank;
+  item.valid = true;
+  mr_manager_.register_remote_mr(owner_rank, item);
+
+  {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    remote_buffer_to_mr_[owner_rank][buffer_id] = mr;
+  }
   return true;
 }
 
-MR Communicator::get_local_mr(void* local_buf) {
-  auto item = mr_manager_.get_mr(local_buf);
-  if (!item.valid) throw std::runtime_error("Local MR not found for buffer");
-  return item.mr;
-}
-
-MR Communicator::get_local_mr(uint32_t mr_id) {
-  auto item = mr_manager_.get_mr(mr_id);
-  if (!item.valid) throw std::runtime_error("Local MR not found for id");
-  return item.mr;
-}
-
-MR Communicator::get_remote_mr(int remote_rank, uint32_t mr_id) {
-  auto item = mr_manager_.get_mr(remote_rank, mr_id);
-  if (!item.valid) throw std::runtime_error("Remote MR not found for id");
-  return item.mr;
-}
-
-bool Communicator::notify_ipc_buffer(int remote_rank, uint32_t ipc_id,
-                                     void* local_buf, size_t len,
-                                     uint64_t binding_version) {
-  if (!exchanger_client_ || !exchanger_client_->valid()) return false;
-
-  IpcBufferInfo info{};
-  info.ipc_id = ipc_id;
-  if (binding_version == 0) {
-    std::lock_guard<std::mutex> lk(ipc_gen_mu_);
-    binding_version = ++local_ipc_binding_versions_[remote_rank][ipc_id];
+MR Communicator::get_mr(uint32_t buffer_id) const {
+  std::lock_guard<std::mutex> lk(resource_mu_);
+  auto it = local_buffer_to_mr_.find(buffer_id);
+  if (it == local_buffer_to_mr_.end()) {
+    throw std::runtime_error("local MR not found for buffer_id");
   }
-  info.binding_version = binding_version;
-  info.valid = false;
+  return it->second;
+}
+
+MR Communicator::get_mr(int owner_rank, uint32_t buffer_id) const {
+  if (owner_rank == global_rank_) return get_mr(buffer_id);
+  std::lock_guard<std::mutex> lk(resource_mu_);
+  auto rank_it = remote_buffer_to_mr_.find(owner_rank);
+  if (rank_it == remote_buffer_to_mr_.end()) {
+    throw std::runtime_error("remote MR rank cache not found");
+  }
+  auto id_it = rank_it->second.find(buffer_id);
+  if (id_it == rank_it->second.end()) {
+    throw std::runtime_error("remote MR not found for buffer_id");
+  }
+  return id_it->second;
+}
+
+bool Communicator::reg_ipc(uint32_t buffer_id, void* local_buf, size_t len,
+                           bool publish) {
+  if (buffer_id == 0) return false;
+
+  IPCItem local{};
   if (local_buf != nullptr && len != 0) {
-    auto exported = export_local_ipc_buffer(local_buf, len);
-    if (!exported.valid) return false;
-
-    info.handle = exported.handle;
-    info.base_offset =
-        reinterpret_cast<uintptr_t>(local_buf) - exported.base_addr;
-    info.bytes = len;
-    info.device_idx = exported.device_idx;
-    info.valid = true;
+    int original_device = -1;
+    GPU_RT_CHECK(gpuGetDevice(&original_device));
+    auto restore = UKernel::Transport::finally(
+        [&]() { GPU_RT_CHECK(gpuSetDevice(original_device)); });
+    GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
+    local = ipc_manager_.create_local_ipc(local_buf, len, local_gpu_idx_);
+    if (!local.valid) return false;
+  } else {
+    local.valid = false;
   }
 
-  auto const latest_key = ipc_buffer_key(global_rank_, remote_rank, ipc_id);
-  if (!exchanger_client_->put(latest_key, info)) return false;
-  auto const versioned_key = ipc_buffer_versioned_key(global_rank_, remote_rank,
-                                                      ipc_id, binding_version);
-  return exchanger_client_->put(versioned_key, info);
-}
+  {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    local_buffer_to_ipc_[buffer_id] = local;
+  }
 
-IPCItem Communicator::export_local_ipc_buffer(void* local_buf, size_t len) {
-  if (local_buf == nullptr || len == 0) return {};
+  if (!publish || !exchanger_client_ || !exchanger_client_->valid()) {
+    return true;
+  }
 
-  int original_device = -1;
-  GPU_RT_CHECK(gpuGetDevice(&original_device));
-  auto restore = UKernel::Transport::finally(
-      [&]() { GPU_RT_CHECK(gpuSetDevice(original_device)); });
-  GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
-  return ipc_manager_.create_local_ipc(local_buf, len, local_gpu_idx_);
-}
-
-bool Communicator::wait_ipc_buffer(int remote_rank, uint32_t ipc_id,
-                                   uint64_t expected_binding_version) {
-  if (!exchanger_client_ || !exchanger_client_->valid()) return false;
   IpcBufferInfo info{};
-  auto const latest_key = ipc_buffer_key(remote_rank, global_rank_, ipc_id);
-  auto const deadline = std::chrono::steady_clock::now() +
-                        std::chrono::milliseconds(bootstrap_timeout_ms());
-  if (expected_binding_version != 0) {
-    auto const versioned_key = ipc_buffer_versioned_key(
-        remote_rank, global_rank_, ipc_id, expected_binding_version);
-    // Prefer deterministic versioned key to avoid stale latest-key reads.
-    if (exchanger_client_->wait(
-            versioned_key, info,
-            make_wait_options_until(deadline, kBootstrapPollDelayMs))) {
-      return register_remote_ipc_info(remote_rank, ipc_id, info,
-                                      /*eager_open_direct_ptr=*/true);
-    }
-  }
-  while (true) {
-    if (!exchanger_client_->wait(
-            latest_key, info,
-            make_wait_options_until(deadline, kBootstrapPollDelayMs))) {
-      return false;
-    }
-    if (expected_binding_version == 0 ||
-        info.binding_version == expected_binding_version) {
-      break;
-    }
-    if (std::chrono::steady_clock::now() >= deadline) {
-      return false;
-    }
-    std::this_thread::sleep_for(
-        std::chrono::milliseconds(kBootstrapPollDelayMs));
-  }
-
-  bool const eager_open_direct_ptr = (expected_binding_version != 0);
-  return register_remote_ipc_info(remote_rank, ipc_id, info,
-                                  eager_open_direct_ptr);
+  info.handle = local.handle;
+  info.base_offset = static_cast<uint64_t>(local.base_offset);
+  info.bytes = static_cast<uint64_t>(local.bytes);
+  info.device_idx = local.device_idx;
+  info.valid = local.valid;
+  return oob_put(*exchanger_client_, oob_namespace(),
+                 ipc_global_buffer_key(global_rank_, buffer_id), info);
 }
 
-bool Communicator::fetch_ipc_buffer(int remote_rank, uint32_t ipc_id,
-                                    uint64_t expected_binding_version) {
-  if (!exchanger_client_ || !exchanger_client_->valid()) return false;
-  IpcBufferInfo info{};
-  if (expected_binding_version != 0) {
-    auto const versioned_key = ipc_buffer_versioned_key(
-        remote_rank, global_rank_, ipc_id, expected_binding_version);
-    if (exchanger_client_->get(versioned_key, info)) {
-      if (info.valid && info.binding_version != expected_binding_version) {
-        invalidate_remote_ipc_buffer(remote_rank, ipc_id);
-        return false;
-      }
-      return register_remote_ipc_info(remote_rank, ipc_id, info,
-                                      /*eager_open_direct_ptr=*/true);
+bool Communicator::dereg_ipc(uint32_t buffer_id) {
+  IPCItem local{};
+  bool found = false;
+  {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    auto it = local_buffer_to_ipc_.find(buffer_id);
+    if (it != local_buffer_to_ipc_.end()) {
+      local = it->second;
+      local_buffer_to_ipc_.erase(it);
+      found = true;
     }
   }
-  if (!exchanger_client_->get(ipc_buffer_key(remote_rank, global_rank_, ipc_id),
-                              info)) {
-    return false;
-  }
-  if (info.valid && expected_binding_version != 0 &&
-      info.binding_version != expected_binding_version) {
-    invalidate_remote_ipc_buffer(remote_rank, ipc_id);
-    return false;
-  }
-  bool const eager_open_direct_ptr = (expected_binding_version != 0);
-  return register_remote_ipc_info(remote_rank, ipc_id, info,
-                                  eager_open_direct_ptr);
-}
-
-bool Communicator::register_remote_ipc_info(int remote_rank, uint32_t ipc_id,
-                                            IpcBufferInfo const& info,
-                                            bool eager_open_direct_ptr) {
-  IPCItem state = ipc_item_from_info(info, ipc_id);
-  bool const ok = ipc_manager_.register_remote_ipc(remote_rank, state);
-  if (ok && eager_open_direct_ptr) {
-    try_open_remote_ipc_buffer(remote_rank, state);
-  }
-  return ok;
-}
-
-void Communicator::try_open_remote_ipc_buffer(int remote_rank,
-                                              IPCItem const& state) {
-  if (!state.valid || state.direct_ptr != nullptr) return;
-
-  int original_device = -1;
-  GPU_RT_CHECK(gpuGetDevice(&original_device));
-  auto restore = UKernel::Transport::finally(
-      [&]() { GPU_RT_CHECK(gpuSetDevice(original_device)); });
-  GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
-
-  bool can_use_direct_peer = (state.device_idx == local_gpu_idx_);
-  if (!can_use_direct_peer && state.device_idx >= 0) {
-    int can_access_peer = 0;
-    GPU_RT_CHECK(gpuDeviceCanAccessPeer(&can_access_peer, local_gpu_idx_,
-                                        state.device_idx));
-    can_use_direct_peer = (can_access_peer != 0);
-  }
-  if (!can_use_direct_peer) return;
-
-  void* direct_ptr = nullptr;
-  gpuError_t open_err = gpuIpcOpenMemHandle(&direct_ptr, state.handle,
-                                            gpuIpcMemLazyEnablePeerAccess);
-  if (open_err != gpuSuccess || direct_ptr == nullptr) {
-    (void)gpuGetLastError();
-    return;
-  }
-
-  IPCItem opened = state;
-  opened.direct_ptr = direct_ptr;
-  opened.ipc_id = state.ipc_id;
-  (void)ipc_manager_.register_remote_ipc(remote_rank, opened);
-}
-
-bool Communicator::has_fresh_remote_ipc_buffer(
-    int remote_rank, uint32_t ipc_id, uint64_t expected_binding_version) const {
-  auto state = ipc_manager_.get_ipc(remote_rank, ipc_id);
-  if (!state.valid) return false;
-  if (expected_binding_version != 0 &&
-      state.binding_version != expected_binding_version) {
-    return false;
+  if (found && local.base_addr != 0) {
+    (void)ipc_manager_.delete_ipc(reinterpret_cast<void*>(local.base_addr));
   }
   return true;
 }
 
-void Communicator::invalidate_remote_ipc_buffer(int remote_rank,
-                                                uint32_t ipc_id) {
-  ipc_manager_.delete_ipc(remote_rank, ipc_id);
+bool Communicator::wait_ipc(int owner_rank, uint32_t buffer_id, int timeout_ms) {
+  if (buffer_id == 0) return false;
+  if (owner_rank == global_rank_) {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    return local_buffer_to_ipc_.find(buffer_id) != local_buffer_to_ipc_.end();
+  }
+  if (!exchanger_client_ || !exchanger_client_->valid()) return false;
+
+  IpcBufferInfo info{};
+  if (!oob_get(*exchanger_client_, oob_namespace(),
+               ipc_global_buffer_key(owner_rank, buffer_id), info,
+               timeout_ms)) {
+    return false;
+  }
+
+  IPCItem state{};
+  state.handle = info.handle;
+  state.base_offset = static_cast<uintptr_t>(info.base_offset);
+  state.bytes = static_cast<size_t>(info.bytes);
+  state.device_idx = info.device_idx;
+  state.valid = info.valid;
+  return ipc_manager_.register_remote_ipc(owner_rank, buffer_id, state);
 }
 
-bool Communicator::resolve_ipc_buffer_pointer(int remote_rank, uint32_t ipc_id,
-                                              size_t offset, size_t bytes,
-                                              void** out_ptr,
-                                              int* out_device_idx) {
-  if (out_ptr == nullptr) return false;
-
-  auto state = ipc_manager_.get_ipc(remote_rank, ipc_id);
-  if (!state.valid) return false;
-  if (offset > state.bytes || bytes > state.bytes - offset) return false;
-
-  int original_device = -1;
-  GPU_RT_CHECK(gpuGetDevice(&original_device));
-  auto restore = UKernel::Transport::finally(
-      [&]() { GPU_RT_CHECK(gpuSetDevice(original_device)); });
-  GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
-
-  bool can_use_direct_peer = (state.device_idx == local_gpu_idx_);
-  if (!can_use_direct_peer && state.device_idx >= 0) {
-    int can_access_peer = 0;
-    GPU_RT_CHECK(gpuDeviceCanAccessPeer(&can_access_peer, local_gpu_idx_,
-                                        state.device_idx));
-    can_use_direct_peer = (can_access_peer != 0);
+IPCItem Communicator::get_ipc(uint32_t buffer_id) {
+  std::lock_guard<std::mutex> lk(resource_mu_);
+  auto it = local_buffer_to_ipc_.find(buffer_id);
+  if (it == local_buffer_to_ipc_.end()) {
+    throw std::runtime_error("local IPC not found for buffer_id");
   }
-  if (!can_use_direct_peer) return false;
+  return it->second;
+}
 
-  if (state.direct_ptr == nullptr) {
-    gpuError_t open_err = gpuIpcOpenMemHandle(&state.direct_ptr, state.handle,
+IPCItem Communicator::get_ipc(int owner_rank, uint32_t buffer_id) {
+  if (owner_rank == global_rank_) return get_ipc(buffer_id);
+  IPCItem item = ipc_manager_.get_ipc(owner_rank, buffer_id);
+  if (!item.valid) {
+    throw std::runtime_error("remote IPC not found for buffer_id");
+  }
+  if (item.direct_ptr == nullptr) {
+    int original_device = -1;
+    GPU_RT_CHECK(gpuGetDevice(&original_device));
+    auto restore = UKernel::Transport::finally(
+        [&]() { GPU_RT_CHECK(gpuSetDevice(original_device)); });
+    GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
+
+    gpuError_t open_err = gpuIpcOpenMemHandle(&item.direct_ptr, item.handle,
                                               gpuIpcMemLazyEnablePeerAccess);
     if (open_err != gpuSuccess) {
-      // Treat IPC open failure as recoverable here so upper layers can
-      // fallback to host-bounce relay instead of aborting.
-      (void)gpuGetLastError();
+      throw std::runtime_error("failed to open remote IPC mem handle");
+    }
+    ipc_manager_.register_remote_ipc(owner_rank, buffer_id, item);
+  }
+  return item;
+}
+
+bool Communicator::try_resolve_remote_ipc_pointer(int remote_rank,
+                                                  uint32_t remote_buffer_id,
+                                                  size_t offset, size_t bytes,
+                                                  void** out_ptr,
+                                                  int* out_device_idx) {
+  if (out_ptr == nullptr || remote_buffer_id == 0) return false;
+  *out_ptr = nullptr;
+
+  IPCItem item{};
+  if (remote_rank == global_rank_) {
+    std::lock_guard<std::mutex> lk(resource_mu_);
+    auto it = local_buffer_to_ipc_.find(remote_buffer_id);
+    if (it != local_buffer_to_ipc_.end()) {
+      item = it->second;
+    }
+  } else {
+    item = ipc_manager_.get_ipc(remote_rank, remote_buffer_id);
+  }
+  if (!item.valid) return false;
+
+  if (remote_rank == global_rank_) {
+    if (item.base_addr == 0) return false;
+    if (offset > item.bytes || bytes > item.bytes - offset) return false;
+    uintptr_t const resolved = item.base_addr + item.base_offset + offset;
+    *out_ptr = reinterpret_cast<void*>(resolved);
+    if (out_device_idx != nullptr) {
+      *out_device_idx = item.device_idx;
+    }
+    return true;
+  }
+
+  if (item.direct_ptr == nullptr) {
+    int original_device = -1;
+    if (gpuGetDevice(&original_device) != gpuSuccess) return false;
+    if (gpuSetDevice(local_gpu_idx_) != gpuSuccess) return false;
+    gpuError_t open_err = gpuIpcOpenMemHandle(&item.direct_ptr, item.handle,
+                                              gpuIpcMemLazyEnablePeerAccess);
+    gpuError_t restore_err = gpuSetDevice(original_device);
+    if (restore_err != gpuSuccess) return false;
+    if (open_err != gpuSuccess || item.direct_ptr == nullptr) return false;
+    if (!ipc_manager_.register_remote_ipc(remote_rank, remote_buffer_id, item)) {
       return false;
     }
-    state.ipc_id = ipc_id;
-    ipc_manager_.register_remote_ipc(remote_rank, state);
   }
 
-  *out_ptr =
-      reinterpret_cast<void*>(reinterpret_cast<uintptr_t>(state.direct_ptr) +
-                              state.base_offset + offset);
+  if (offset > item.bytes || bytes > item.bytes - offset) return false;
+  uintptr_t const base = reinterpret_cast<uintptr_t>(item.direct_ptr);
+  uintptr_t const resolved = base + item.base_offset + offset;
+  *out_ptr = reinterpret_cast<void*>(resolved);
   if (out_device_idx != nullptr) {
-    *out_device_idx = state.device_idx;
+    *out_device_idx = item.device_idx;
   }
   return true;
-}
-
-bool Communicator::register_remote_ipc_cache(int remote_rank,
-                                             gpuIpcMemHandle_t handle,
-                                             IPCItem const& ipc) {
-  IPCItem item = ipc;
-  item.handle = handle;
-  return ipc_manager_.register_remote_ipc(remote_rank, item);
-}
-
-IPCItem Communicator::get_remote_ipc_cache(int remote_rank,
-                                           gpuIpcMemHandle_t handle) {
-  return ipc_manager_.get_ipc(remote_rank, handle);
-}
-
-bool Communicator::ipc_has_fresh_remote_ipc_buffer(
-    int remote_rank, uint32_t ipc_id, uint64_t expected_binding_version) const {
-  return has_fresh_remote_ipc_buffer(remote_rank, ipc_id,
-                                     expected_binding_version);
-}
-
-bool Communicator::ipc_fetch_remote_ipc_buffer(
-    int remote_rank, uint32_t ipc_id, uint64_t expected_binding_version) {
-  return fetch_ipc_buffer(remote_rank, ipc_id, expected_binding_version);
-}
-
-void Communicator::ipc_invalidate_remote_ipc_buffer(int remote_rank,
-                                                    uint32_t ipc_id) {
-  invalidate_remote_ipc_buffer(remote_rank, ipc_id);
 }
 
 void* Communicator::get_or_open_bounce_shm(std::string const& shm_name) {

--- a/experimental/ukernel/src/transport/communicator.h
+++ b/experimental/ukernel/src/transport/communicator.h
@@ -6,6 +6,7 @@
 #include "memory/shm_manager.h"
 #include "oob/oob.h"
 #include "request.h"
+#include <atomic>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -54,43 +55,34 @@ class Communicator {
   // Identity.
   int rank() const { return global_rank_; }
   int world_size() const { return world_size_; }
+  // Runtime-selectable OOB namespace for communication-group isolation.
+  void set_oob_namespace(std::string ns);
+  std::string oob_namespace() const;
+  // OOB global barrier across ranks in this communicator.
+  bool barrier(std::string const& barrier_namespace = "default",
+               int timeout_ms = -1);
 
   // Completion notification hook.
   std::shared_ptr<void> register_completion_notifier(
       std::function<void(unsigned, std::chrono::steady_clock::time_point)> cb);
 
-  // MR metadata exchange.
-  MR reg_mr(void* local_buf, size_t len);
-  bool dereg_mr(void* local_buf);
-  bool notify_named_mrs(int remote_rank, uint64_t generation,
-                        NamedMRInfos const& infos);
-  bool wait_named_mrs(int remote_rank, uint64_t generation,
-                      NamedMRInfos& infos);
-  MR get_local_mr(void* local_buf);
-  MR get_local_mr(uint32_t mr_id);
-  MR get_remote_mr(int remote_rank, uint32_t mr_id);
+  // Async resource API (buffer_id keyed).
+  bool reg_mr(uint32_t buffer_id, void* local_buf, size_t len,
+              bool publish = true);
+  bool dereg_mr(uint32_t buffer_id);
+  bool wait_mr(int owner_rank, uint32_t buffer_id, int timeout_ms = -1);
+  MR get_mr(uint32_t buffer_id) const;
+  MR get_mr(int owner_rank, uint32_t buffer_id) const;
 
-  // IPC metadata exchange.
-  bool notify_ipc_buffer(int remote_rank, uint32_t ipc_id, void* local_buf,
-                         size_t len, uint64_t binding_version = 0);
-  bool wait_ipc_buffer(int remote_rank, uint32_t ipc_id,
-                       uint64_t expected_binding_version = 0);
-  bool resolve_ipc_buffer_pointer(int remote_rank, uint32_t ipc_id,
-                                  size_t offset, size_t bytes, void** out_ptr,
-                                  int* out_device_idx);
-  IPCItem export_local_ipc_buffer(void* local_buf, size_t len);
-
-  bool register_remote_ipc_cache(int remote_rank, gpuIpcMemHandle_t handle,
-                                 IPCItem const& ipc);
-  IPCItem get_remote_ipc_cache(int remote_rank, gpuIpcMemHandle_t handle);
-
-  // Adapter-facing IPC metadata helpers.
-  int local_gpu_idx() const { return local_gpu_idx_; }
-  bool ipc_has_fresh_remote_ipc_buffer(int remote_rank, uint32_t ipc_id,
-                                       uint64_t expected_binding_version) const;
-  bool ipc_fetch_remote_ipc_buffer(int remote_rank, uint32_t ipc_id,
-                                   uint64_t expected_binding_version = 0);
-  void ipc_invalidate_remote_ipc_buffer(int remote_rank, uint32_t ipc_id);
+  bool reg_ipc(uint32_t buffer_id, void* local_buf, size_t len,
+               bool publish = true);
+  bool dereg_ipc(uint32_t buffer_id);
+  bool wait_ipc(int owner_rank, uint32_t buffer_id, int timeout_ms = -1);
+  IPCItem get_ipc(uint32_t buffer_id);
+  IPCItem get_ipc(int owner_rank, uint32_t buffer_id);
+  bool try_resolve_remote_ipc_pointer(int remote_rank, uint32_t remote_buffer_id,
+                                      size_t offset, size_t bytes, void** out_ptr,
+                                      int* out_device_idx);
 
   // SHM bounce.
   void* get_or_open_bounce_shm(std::string const& shm_name);
@@ -136,12 +128,22 @@ class Communicator {
     std::shared_ptr<SHMItem> bounce_owner;
   };
 
-  UcclTransportAdapter& ensure_uccl_adapter(CommunicatorMeta const& local_meta,
-                                            CommunicatorMeta const& peer_meta);
+  // Adapter bootstrap / selection.
+  UcclTransportAdapter& ensure_uccl_adapter(CommunicatorMeta const& local_meta);
+  bool exchange_uccl_peer_info(int rank, UcclTransportAdapter& uccl_adapter,
+                               UCCLP2PInfo* out_remote_p2p_info);
   TcpTransportAdapter& ensure_tcp_adapter(CommunicatorMeta const& local_meta);
+
+  // Peer-state lifecycle.
   PeerTransportKind get_peer_transport_kind(int rank) const;
   bool has_peer_path(int rank) const;
   void mark_peer_path_ready(int rank, PeerTransportKind kind);
+  void exchange_peer_metas();
+  ResolvedPeer resolve_peer(int rank) const;
+  bool try_fallback_tcp_connect(int rank, CommunicatorMeta const& local_meta);
+  bool try_fallback_tcp_accept(int rank, CommunicatorMeta const& local_meta);
+
+  // Request tracking / progress.
   bool poll_request_completion(unsigned id, bool blocking);
   TrackedRequest* allocate_request_slot(unsigned* out_req_id);
   TrackedRequest* resolve_request_slot(unsigned req_id) const;
@@ -152,25 +154,16 @@ class Communicator {
   static uint32_t request_slot_index(unsigned req_id);
   static uint32_t request_generation(unsigned req_id);
   void notify_request_completion();
+
+  // UCCL MR lifecycle.
   void register_existing_local_mrs_with_uccl();
-  bool ensure_uccl_memory_registered(uint64_t mr_id, void* ptr, size_t len);
-  bool fetch_ipc_buffer(int remote_rank, uint32_t ipc_id,
-                        uint64_t expected_binding_version = 0);
-  bool has_fresh_remote_ipc_buffer(int remote_rank, uint32_t ipc_id,
-                                   uint64_t expected_binding_version) const;
-  void invalidate_remote_ipc_buffer(int remote_rank, uint32_t ipc_id);
-  bool register_remote_ipc_info(int remote_rank, uint32_t ipc_id,
-                                IpcBufferInfo const& info,
-                                bool eager_open_direct_ptr);
-  void try_open_remote_ipc_buffer(int remote_rank, IPCItem const& state);
+  bool ensure_uccl_memory_registered(uint32_t buffer_id, void* ptr, size_t len);
+
+  // Request cleanup helpers.
   void cleanup_tracked_request(TrackedRequest& tracked);
   bool complete_host_bounce_recv(TrackedRequest& tracked, bool blocking);
   SHMManager& require_shm_manager(char const* caller);
-  void exchange_peer_metas();
-  ResolvedPeer resolve_peer(int rank) const;
-  bool try_fallback_tcp_connect(int rank, CommunicatorMeta const& local_meta);
-  bool try_fallback_tcp_accept(int rank, CommunicatorMeta const& local_meta,
-                               CommunicatorMeta const& remote_meta);
+
   // Background progress loop: advances completion state for all in-flight
   // requests and emits user completion callbacks for requests that finish.
   void progress_loop();
@@ -195,7 +188,9 @@ class Communicator {
   mutable std::mutex peer_mu_;
   std::vector<PeerState> peer_states_;
   std::shared_ptr<CommunicatorConfig> config_;
+  mutable std::mutex config_mu_;
   std::shared_ptr<Exchanger> exchanger_client_;
+  std::atomic<uint64_t> barrier_seq_{0};
 
   // Adapter dispatch.
   TransportAdapter* get_adapter(PeerTransportKind kind);
@@ -214,7 +209,11 @@ class Communicator {
   std::atomic<uint32_t> active_tail_{0};
   int completion_event_fd_ = -1;
   std::atomic<uint64_t> completion_seq_{0};
-  mutable std::mutex mr_exchange_mu_;
+  mutable std::mutex resource_mu_;
+  std::unordered_map<uint32_t, MR> local_buffer_to_mr_;
+  std::unordered_map<int, std::unordered_map<uint32_t, MR>>
+      remote_buffer_to_mr_;
+  std::unordered_map<uint32_t, IPCItem> local_buffer_to_ipc_;
 
   // Despite the historical name, this thread now serves as the communicator's
   // background progress engine. register_completion_notifier() only attaches
@@ -230,24 +229,12 @@ class Communicator {
   };
   std::vector<std::weak_ptr<NotifyTarget>> notify_targets_;
 
-  struct PublishedIpcBuffer {
-    uintptr_t base_addr = 0;
-    size_t bytes = 0;
-    uint64_t binding_version = 0;
-    bool valid = false;
-  };
-
-  // UCCL registration cache.
+  // UCCL registration caches.
   mutable std::mutex uccl_reg_mu_;
   std::unordered_set<uint64_t> uccl_direct_reg_failed_mrs_;
   std::unordered_set<uint64_t> uccl_registered_mrs_;
+  std::atomic<uint32_t> next_ephemeral_buffer_id_{0x80000000u};
 
-  // IPC binding versions.
-  mutable std::mutex ipc_gen_mu_;
-  std::unordered_map<int, std::unordered_map<uint32_t, uint64_t>>
-      local_ipc_binding_versions_;
-  std::unordered_map<int, std::unordered_map<uint32_t, PublishedIpcBuffer>>
-      local_ipc_published_buffers_;
 };
 
 }  // namespace Transport

--- a/experimental/ukernel/src/transport/communicator.h
+++ b/experimental/ukernel/src/transport/communicator.h
@@ -80,8 +80,9 @@ class Communicator {
   bool wait_ipc(int owner_rank, uint32_t buffer_id, int timeout_ms = -1);
   IPCItem get_ipc(uint32_t buffer_id);
   IPCItem get_ipc(int owner_rank, uint32_t buffer_id);
-  bool try_resolve_remote_ipc_pointer(int remote_rank, uint32_t remote_buffer_id,
-                                      size_t offset, size_t bytes, void** out_ptr,
+  bool try_resolve_remote_ipc_pointer(int remote_rank,
+                                      uint32_t remote_buffer_id, size_t offset,
+                                      size_t bytes, void** out_ptr,
                                       int* out_device_idx);
 
   // SHM bounce.
@@ -234,7 +235,6 @@ class Communicator {
   std::unordered_set<uint64_t> uccl_direct_reg_failed_mrs_;
   std::unordered_set<uint64_t> uccl_registered_mrs_;
   std::atomic<uint32_t> next_ephemeral_buffer_id_{0x80000000u};
-
 };
 
 }  // namespace Transport

--- a/experimental/ukernel/src/transport/memory/ipc_manager.cc
+++ b/experimental/ukernel/src/transport/memory/ipc_manager.cc
@@ -35,13 +35,12 @@ void IPCManager::close_local_import_if_open(IPCItem& item) {
   }
 }
 
-bool IPCManager::register_remote_ipc(int rank, IPCItem const& ipc) {
+bool IPCManager::register_remote_ipc(int rank, uint32_t buffer_id,
+                                     IPCItem const& ipc) {
   std::lock_guard<std::mutex> lk(remote_mu_);
   IPCItem item = ipc;
   item.is_local = false;
-  if (item.ipc_id != 0) {
-    rank_ipc_id_cache_[rank][item.ipc_id] = item;
-  }
+  if (buffer_id != 0) rank_buffer_id_cache_[rank][buffer_id] = item;
   if (has_handle(item.handle)) {
     rank_handle_cache_[rank][make_ipc_handle_key(item.handle)] = item;
   }
@@ -108,11 +107,11 @@ IPCItem IPCManager::get_ipc(int rank, gpuIpcMemHandle_t handle) const {
   return it->second;
 }
 
-IPCItem IPCManager::get_ipc(int rank, uint32_t ipc_id) const {
+IPCItem IPCManager::get_ipc(int rank, uint32_t buffer_id) const {
   std::lock_guard<std::mutex> lk(remote_mu_);
-  auto rank_it = rank_ipc_id_cache_.find(rank);
-  if (rank_it == rank_ipc_id_cache_.end()) return {};
-  auto it = rank_it->second.find(ipc_id);
+  auto rank_it = rank_buffer_id_cache_.find(rank);
+  if (rank_it == rank_buffer_id_cache_.end()) return {};
+  auto it = rank_it->second.find(buffer_id);
   if (it == rank_it->second.end()) return {};
   return it->second;
 }
@@ -145,20 +144,25 @@ bool IPCManager::delete_ipc(int rank, gpuIpcMemHandle_t handle) {
   IPCItem item = it->second;
   close_local_import_if_open(item);
   rank_it->second.erase(it);
-  if (item.ipc_id != 0) {
-    auto id_rank_it = rank_ipc_id_cache_.find(rank);
-    if (id_rank_it != rank_ipc_id_cache_.end()) {
-      id_rank_it->second.erase(item.ipc_id);
+  auto id_rank_it = rank_buffer_id_cache_.find(rank);
+  if (id_rank_it != rank_buffer_id_cache_.end()) {
+    for (auto id_it = id_rank_it->second.begin();
+         id_it != id_rank_it->second.end();) {
+      if (make_ipc_handle_key(id_it->second.handle) == key) {
+        id_it = id_rank_it->second.erase(id_it);
+      } else {
+        ++id_it;
+      }
     }
   }
   return true;
 }
 
-bool IPCManager::delete_ipc(int rank, uint32_t ipc_id) {
+bool IPCManager::delete_ipc(int rank, uint32_t buffer_id) {
   std::lock_guard<std::mutex> lk(remote_mu_);
-  auto rank_it = rank_ipc_id_cache_.find(rank);
-  if (rank_it == rank_ipc_id_cache_.end()) return false;
-  auto it = rank_it->second.find(ipc_id);
+  auto rank_it = rank_buffer_id_cache_.find(rank);
+  if (rank_it == rank_buffer_id_cache_.end()) return false;
+  auto it = rank_it->second.find(buffer_id);
   if (it == rank_it->second.end()) return false;
 
   IPCItem item = it->second;
@@ -204,9 +208,9 @@ void IPCManager::delete_ipc(int rank) {
   };
 
   close_from_map(rank_handle_cache_);
-  close_from_map(rank_ipc_id_cache_);
+  close_from_map(rank_buffer_id_cache_);
   rank_handle_cache_.erase(rank);
-  rank_ipc_id_cache_.erase(rank);
+  rank_buffer_id_cache_.erase(rank);
 }
 
 }  // namespace Transport

--- a/experimental/ukernel/src/transport/memory/ipc_manager.h
+++ b/experimental/ukernel/src/transport/memory/ipc_manager.h
@@ -19,29 +19,26 @@ struct IPCItem {
   size_t bytes = 0;
   size_t allocation_size = 0;
   int device_idx = -1;
-  uint64_t binding_version = 0;
-  uint32_t ipc_id = 0;
   bool is_local = false;
   bool valid = false;
 };
 
 class IPCManager {
  public:
-  // Register remote IPC metadata/cache item (supports both handle-keyed and
-  // ipc_id-keyed records by filling `handle` and/or `ipc_id`).
-  bool register_remote_ipc(int rank, IPCItem const& ipc);
+  // Register remote IPC metadata/cache item under an optional buffer_id key.
+  bool register_remote_ipc(int rank, uint32_t buffer_id, IPCItem const& ipc);
 
   // Create or reuse local GPU IPC export item for a local pointer.
   IPCItem create_local_ipc(void* ptr, size_t len, int device_idx);
 
   // Unified lookup API.
   IPCItem get_ipc(int rank, gpuIpcMemHandle_t handle) const;
-  IPCItem get_ipc(int rank, uint32_t ipc_id) const;
+  IPCItem get_ipc(int rank, uint32_t buffer_id) const;
   IPCItem get_ipc(void* local_ptr) const;
 
   // Unified delete API.
   bool delete_ipc(int rank, gpuIpcMemHandle_t handle);
-  bool delete_ipc(int rank, uint32_t ipc_id);
+  bool delete_ipc(int rank, uint32_t buffer_id);
   bool delete_ipc(void* local_ptr);
   void delete_ipc(int rank);
 
@@ -77,7 +74,7 @@ class IPCManager {
                      std::unordered_map<IpcHandleKey, IPCItem, IpcHandleHash>>
       rank_handle_cache_;
   std::unordered_map<int, std::unordered_map<uint32_t, IPCItem>>
-      rank_ipc_id_cache_;
+      rank_buffer_id_cache_;
 
   mutable std::mutex local_mu_;
   std::unordered_map<uintptr_t, IPCItem> local_ipc_cache_;

--- a/experimental/ukernel/src/transport/memory/mr_manager.cc
+++ b/experimental/ukernel/src/transport/memory/mr_manager.cc
@@ -18,7 +18,7 @@ MRItem MRManager::create_local_mr(uint32_t buffer_id, void* ptr, size_t len) {
   }
 
   MRItem created{};
-  created.mr.id = buffer_id;
+  created.buffer_id = buffer_id;
   created.mr.address = reinterpret_cast<uint64_t>(ptr);
   created.mr.length = static_cast<uint64_t>(len);
   created.mr.lkey = 0;
@@ -33,12 +33,12 @@ MRItem MRManager::create_local_mr(uint32_t buffer_id, void* ptr, size_t len) {
 }
 
 bool MRManager::register_remote_mr(int rank, MRItem const& item) {
-  if (!item.valid || item.mr.id == 0) return false;
+  if (!item.valid || item.buffer_id == 0) return false;
   std::lock_guard<std::mutex> lk(remote_mu_);
   MRItem v = item;
   v.is_local = false;
   v.rank = rank;
-  remote_by_rank_[rank][v.mr.id] = v;
+  remote_by_rank_[rank][v.buffer_id] = v;
   return true;
 }
 
@@ -47,11 +47,11 @@ void MRManager::register_remote_mrs(int rank,
   std::lock_guard<std::mutex> lk(remote_mu_);
   auto& dst = remote_by_rank_[rank];
   for (auto const& item : items) {
-    if (!item.valid || item.mr.id == 0) continue;
+    if (!item.valid || item.buffer_id == 0) continue;
     MRItem v = item;
     v.is_local = false;
     v.rank = rank;
-    dst[v.mr.id] = v;
+    dst[v.buffer_id] = v;
   }
 }
 
@@ -135,7 +135,7 @@ bool MRManager::delete_mr(int remote_rank, uint32_t remote_buffer_id) {
   return rank_it->second.erase(remote_buffer_id) > 0;
 }
 
-void MRManager::delete_mr(int remote_rank) {
+void MRManager::delete_remote_mrs(int remote_rank) {
   std::lock_guard<std::mutex> lk(remote_mu_);
   remote_by_rank_.erase(remote_rank);
 }

--- a/experimental/ukernel/src/transport/memory/mr_manager.cc
+++ b/experimental/ukernel/src/transport/memory/mr_manager.cc
@@ -3,65 +3,37 @@
 namespace UKernel {
 namespace Transport {
 
-void MRManager::bind_backend(RegisterFn register_fn,
-                             DeregisterFn deregister_fn) {
-  std::lock_guard<std::mutex> lk(local_mu_);
-  register_fn_ = std::move(register_fn);
-  deregister_fn_ = std::move(deregister_fn);
-}
-
-void MRManager::sync_local_backend() {
-  std::lock_guard<std::mutex> lk(local_mu_);
-  if (!register_fn_) return;
-  for (auto& [ptr, item] : local_by_ptr_) {
-    (void)ptr;
-    if (!item.valid || item.backend_registered) continue;
-    item.backend_registered = register_fn_(
-        item.mr.id,
-        reinterpret_cast<void*>(static_cast<uintptr_t>(item.mr.address)),
-        static_cast<size_t>(item.mr.length));
-  }
-}
-
-MRItem MRManager::create_local_mr(void* ptr, size_t len) {
-  if (ptr == nullptr || len == 0) return {};
+MRItem MRManager::create_local_mr(uint32_t buffer_id, void* ptr, size_t len) {
+  if (buffer_id == 0 || ptr == nullptr || len == 0) return {};
   std::lock_guard<std::mutex> lk(local_mu_);
 
-  auto existing_it = local_by_ptr_.find(ptr);
-  if (existing_it != local_by_ptr_.end()) {
-    MRItem const& existing = existing_it->second;
-    if (static_cast<size_t>(existing.mr.length) == len) {
-      if (!existing.backend_registered && register_fn_) {
-        existing_it->second.backend_registered =
-            register_fn_(existing.mr.id, ptr, len);
-      }
-      return existing_it->second;
+  auto it = local_by_buffer_id_.find(buffer_id);
+  if (it != local_by_buffer_id_.end()) {
+    MRItem& existing = it->second;
+    if (existing.mr.address == reinterpret_cast<uint64_t>(ptr) &&
+        static_cast<size_t>(existing.mr.length) == len) {
+      return existing;
     }
-    if (existing.backend_registered && deregister_fn_) {
-      deregister_fn_(existing.mr.id);
-    }
-    local_ptr_by_id_.erase(existing.mr.id);
-    local_by_ptr_.erase(existing_it);
+    local_buffer_id_by_ptr_.erase(static_cast<uintptr_t>(existing.mr.address));
   }
 
   MRItem created{};
-  created.mr.id = next_mr_id_++;
+  created.mr.id = buffer_id;
   created.mr.address = reinterpret_cast<uint64_t>(ptr);
   created.mr.length = static_cast<uint64_t>(len);
   created.mr.lkey = 0;
+  created.mr.key = 0;
   created.is_local = true;
   created.rank = -1;
-  created.backend_registered =
-      register_fn_ ? register_fn_(created.mr.id, ptr, len) : false;
   created.valid = true;
 
-  local_by_ptr_[ptr] = created;
-  local_ptr_by_id_[created.mr.id] = ptr;
+  local_by_buffer_id_[buffer_id] = created;
+  local_buffer_id_by_ptr_[reinterpret_cast<uintptr_t>(ptr)] = buffer_id;
   return created;
 }
 
 bool MRManager::register_remote_mr(int rank, MRItem const& item) {
-  if (!item.valid) return false;
+  if (!item.valid || item.mr.id == 0) return false;
   std::lock_guard<std::mutex> lk(remote_mu_);
   MRItem v = item;
   v.is_local = false;
@@ -75,7 +47,7 @@ void MRManager::register_remote_mrs(int rank,
   std::lock_guard<std::mutex> lk(remote_mu_);
   auto& dst = remote_by_rank_[rank];
   for (auto const& item : items) {
-    if (!item.valid) continue;
+    if (!item.valid || item.mr.id == 0) continue;
     MRItem v = item;
     v.is_local = false;
     v.rank = rank;
@@ -84,13 +56,18 @@ void MRManager::register_remote_mrs(int rank,
 }
 
 MRItem MRManager::get_mr(void* local_ptr) const {
+  if (local_ptr == nullptr) return {};
   std::lock_guard<std::mutex> lk(local_mu_);
-  auto exact = local_by_ptr_.find(local_ptr);
-  if (exact != local_by_ptr_.end()) return exact->second;
 
   uintptr_t query = reinterpret_cast<uintptr_t>(local_ptr);
-  for (auto const& [ptr, item] : local_by_ptr_) {
-    (void)ptr;
+  auto exact_it = local_buffer_id_by_ptr_.find(query);
+  if (exact_it != local_buffer_id_by_ptr_.end()) {
+    auto item_it = local_by_buffer_id_.find(exact_it->second);
+    if (item_it != local_by_buffer_id_.end()) return item_it->second;
+  }
+
+  for (auto const& [buffer_id, item] : local_by_buffer_id_) {
+    (void)buffer_id;
     uintptr_t begin = static_cast<uintptr_t>(item.mr.address);
     uintptr_t end = begin + static_cast<uintptr_t>(item.mr.length);
     if (query >= begin && query < end) return item;
@@ -98,41 +75,64 @@ MRItem MRManager::get_mr(void* local_ptr) const {
   return {};
 }
 
-MRItem MRManager::get_mr(uint32_t local_mr_id) const {
+MRItem MRManager::get_mr(uint32_t local_buffer_id) const {
+  if (local_buffer_id == 0) return {};
   std::lock_guard<std::mutex> lk(local_mu_);
-  auto ptr_it = local_ptr_by_id_.find(local_mr_id);
-  if (ptr_it == local_ptr_by_id_.end()) return {};
-  auto item_it = local_by_ptr_.find(ptr_it->second);
-  if (item_it == local_by_ptr_.end()) return {};
-  return item_it->second;
+  auto it = local_by_buffer_id_.find(local_buffer_id);
+  if (it == local_by_buffer_id_.end()) return {};
+  return it->second;
 }
 
-MRItem MRManager::get_mr(int remote_rank, uint32_t remote_mr_id) const {
+MRItem MRManager::get_mr(int remote_rank, uint32_t remote_buffer_id) const {
+  if (remote_buffer_id == 0) return {};
   std::lock_guard<std::mutex> lk(remote_mu_);
   auto rank_it = remote_by_rank_.find(remote_rank);
   if (rank_it == remote_by_rank_.end()) return {};
-  auto it = rank_it->second.find(remote_mr_id);
+  auto it = rank_it->second.find(remote_buffer_id);
   if (it == rank_it->second.end()) return {};
   return it->second;
 }
 
 bool MRManager::delete_mr(void* local_ptr) {
+  if (local_ptr == nullptr) return false;
   std::lock_guard<std::mutex> lk(local_mu_);
-  auto it = local_by_ptr_.find(local_ptr);
-  if (it == local_by_ptr_.end()) return false;
-  if (it->second.backend_registered && deregister_fn_) {
-    deregister_fn_(it->second.mr.id);
+
+  uintptr_t query = reinterpret_cast<uintptr_t>(local_ptr);
+  auto exact_it = local_buffer_id_by_ptr_.find(query);
+  if (exact_it != local_buffer_id_by_ptr_.end()) {
+    uint32_t buffer_id = exact_it->second;
+    local_buffer_id_by_ptr_.erase(exact_it);
+    return local_by_buffer_id_.erase(buffer_id) > 0;
   }
-  local_ptr_by_id_.erase(it->second.mr.id);
-  local_by_ptr_.erase(it);
+
+  for (auto it = local_by_buffer_id_.begin(); it != local_by_buffer_id_.end();
+       ++it) {
+    uintptr_t begin = static_cast<uintptr_t>(it->second.mr.address);
+    uintptr_t end = begin + static_cast<uintptr_t>(it->second.mr.length);
+    if (query < begin || query >= end) continue;
+    local_buffer_id_by_ptr_.erase(begin);
+    local_by_buffer_id_.erase(it);
+    return true;
+  }
+  return false;
+}
+
+bool MRManager::delete_mr(uint32_t local_buffer_id) {
+  if (local_buffer_id == 0) return false;
+  std::lock_guard<std::mutex> lk(local_mu_);
+  auto it = local_by_buffer_id_.find(local_buffer_id);
+  if (it == local_by_buffer_id_.end()) return false;
+  local_buffer_id_by_ptr_.erase(static_cast<uintptr_t>(it->second.mr.address));
+  local_by_buffer_id_.erase(it);
   return true;
 }
 
-bool MRManager::delete_mr(int remote_rank, uint32_t remote_mr_id) {
+bool MRManager::delete_mr(int remote_rank, uint32_t remote_buffer_id) {
+  if (remote_buffer_id == 0) return false;
   std::lock_guard<std::mutex> lk(remote_mu_);
   auto rank_it = remote_by_rank_.find(remote_rank);
   if (rank_it == remote_by_rank_.end()) return false;
-  return rank_it->second.erase(remote_mr_id) > 0;
+  return rank_it->second.erase(remote_buffer_id) > 0;
 }
 
 void MRManager::delete_mr(int remote_rank) {
@@ -140,11 +140,11 @@ void MRManager::delete_mr(int remote_rank) {
   remote_by_rank_.erase(remote_rank);
 }
 
-std::vector<std::pair<void*, MRItem>> MRManager::list_local_mrs() const {
+std::vector<std::pair<uint32_t, MRItem>> MRManager::list_local_mrs() const {
   std::lock_guard<std::mutex> lk(local_mu_);
-  std::vector<std::pair<void*, MRItem>> out;
-  out.reserve(local_by_ptr_.size());
-  for (auto const& kv : local_by_ptr_) {
+  std::vector<std::pair<uint32_t, MRItem>> out;
+  out.reserve(local_by_buffer_id_.size());
+  for (auto const& kv : local_by_buffer_id_) {
     out.push_back(kv);
   }
   return out;

--- a/experimental/ukernel/src/transport/memory/mr_manager.h
+++ b/experimental/ukernel/src/transport/memory/mr_manager.h
@@ -12,6 +12,7 @@ namespace UKernel {
 namespace Transport {
 
 struct MRItem {
+  uint32_t buffer_id = 0;
   MR mr{};
   bool is_local = false;
   int rank = -1;
@@ -31,7 +32,7 @@ class MRManager {
   bool delete_mr(void* local_ptr);
   bool delete_mr(uint32_t local_buffer_id);
   bool delete_mr(int remote_rank, uint32_t remote_buffer_id);
-  void delete_mr(int remote_rank);
+  void delete_remote_mrs(int remote_rank);
 
   std::vector<std::pair<uint32_t, MRItem>> list_local_mrs() const;
 

--- a/experimental/ukernel/src/transport/memory/mr_manager.h
+++ b/experimental/ukernel/src/transport/memory/mr_manager.h
@@ -3,7 +3,6 @@
 #include "../oob/oob.h"
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <mutex>
 #include <unordered_map>
 #include <utility>
@@ -16,39 +15,30 @@ struct MRItem {
   MR mr{};
   bool is_local = false;
   int rank = -1;
-  bool backend_registered = false;
   bool valid = false;
 };
 
 class MRManager {
  public:
-  using RegisterFn = std::function<bool(uint32_t, void*, size_t)>;
-  using DeregisterFn = std::function<void(uint32_t)>;
-
-  void bind_backend(RegisterFn register_fn, DeregisterFn deregister_fn);
-  void sync_local_backend();
-
-  MRItem create_local_mr(void* ptr, size_t len);
+  MRItem create_local_mr(uint32_t buffer_id, void* ptr, size_t len);
   bool register_remote_mr(int rank, MRItem const& item);
   void register_remote_mrs(int rank, std::vector<MRItem> const& items);
 
   MRItem get_mr(void* local_ptr) const;
-  MRItem get_mr(uint32_t local_mr_id) const;
-  MRItem get_mr(int remote_rank, uint32_t remote_mr_id) const;
+  MRItem get_mr(uint32_t local_buffer_id) const;
+  MRItem get_mr(int remote_rank, uint32_t remote_buffer_id) const;
 
   bool delete_mr(void* local_ptr);
-  bool delete_mr(int remote_rank, uint32_t remote_mr_id);
+  bool delete_mr(uint32_t local_buffer_id);
+  bool delete_mr(int remote_rank, uint32_t remote_buffer_id);
   void delete_mr(int remote_rank);
 
-  std::vector<std::pair<void*, MRItem>> list_local_mrs() const;
+  std::vector<std::pair<uint32_t, MRItem>> list_local_mrs() const;
 
  private:
   mutable std::mutex local_mu_;
-  std::unordered_map<void*, MRItem> local_by_ptr_;
-  std::unordered_map<uint32_t, void*> local_ptr_by_id_;
-  uint32_t next_mr_id_ = 1;
-  RegisterFn register_fn_;
-  DeregisterFn deregister_fn_;
+  std::unordered_map<uint32_t, MRItem> local_by_buffer_id_;
+  std::unordered_map<uintptr_t, uint32_t> local_buffer_id_by_ptr_;
 
   mutable std::mutex remote_mu_;
   std::unordered_map<int, std::unordered_map<uint32_t, MRItem>> remote_by_rank_;

--- a/experimental/ukernel/src/transport/oob/oob.h
+++ b/experimental/ukernel/src/transport/oob/oob.h
@@ -62,7 +62,6 @@ struct CommunicatorMeta {
 };
 
 struct MR {
-  uint32_t id = 0;
   uint64_t address = 0;
   uint64_t length = 0;
   uint32_t lkey = 0;
@@ -132,9 +131,8 @@ struct IpcBufferInfo {
 UK_OOB_DEFINE_VISIT_FIELDS(CommunicatorMeta, f("host_id", v.host_id);
                            f("ip", v.ip); f("local_id", v.local_id);
                            f("rdma_capable", v.rdma_capable);)
-UK_OOB_DEFINE_VISIT_FIELDS(MR, f("id", v.id); f("address", v.address);
-                           f("length", v.length); f("lkey", v.lkey);
-                           f("key", v.key);)
+UK_OOB_DEFINE_VISIT_FIELDS(MR, f("address", v.address); f("length", v.length);
+                           f("lkey", v.lkey); f("key", v.key);)
 UK_OOB_DEFINE_VISIT_FIELDS(NamedMR, f("buffer_id", v.buffer_id); f("mr", v.mr);)
 UK_OOB_DEFINE_VISIT_FIELDS(NamedMRInfos, f("generation", v.generation);
                            f("entries", v.entries);)

--- a/experimental/ukernel/src/transport/oob/oob.h
+++ b/experimental/ukernel/src/transport/oob/oob.h
@@ -110,8 +110,6 @@ struct TcpP2PInfo {
 };
 
 struct IpcBufferInfo {
-  uint32_t ipc_id = 0;
-  uint64_t binding_version = 0;
   gpuIpcMemHandle_t handle{};
   uint64_t base_offset = 0;
   uint64_t bytes = 0;
@@ -143,9 +141,7 @@ UK_OOB_DEFINE_VISIT_FIELDS(NamedMRInfos, f("generation", v.generation);
 UK_OOB_DEFINE_VISIT_FIELDS(UCCLP2PInfo, f("ip", v.ip); f("port", v.port);
                            f("dev_idx", v.dev_idx); f("gpu_idx", v.gpu_idx);)
 UK_OOB_DEFINE_VISIT_FIELDS(TcpP2PInfo, f("ip", v.ip); f("port", v.port);)
-UK_OOB_DEFINE_VISIT_FIELDS(IpcBufferInfo, f("ipc_id", v.ipc_id);
-                           f("binding_version", v.binding_version);
-                           f("handle", v.handle);
+UK_OOB_DEFINE_VISIT_FIELDS(IpcBufferInfo, f("handle", v.handle);
                            f("base_offset", v.base_offset); f("bytes", v.bytes);
                            f("device_idx", v.device_idx); f("valid", v.valid);)
 
@@ -391,7 +387,6 @@ class ShmExchanger : public Exchanger {
     static uint64_t hash_key(std::string_view key);
   };
   static constexpr uint32_t kShmMagic = 0x554B4F42;  // "UKOB"
-  static constexpr uint32_t kShmVersion = 6;
   static constexpr uint32_t kMaxSlots = 1024;
   static constexpr uint32_t kMaxKeyBytes = 256;
   static constexpr uint32_t kMaxValueBytes = 8192;
@@ -411,7 +406,6 @@ class ShmExchanger : public Exchanger {
 
   struct KvShmHeader {
     uint32_t magic = 0;
-    uint32_t version = 0;
     uint64_t write_seq = 0;
     uint32_t owner_pid = 0;
     uint32_t init_done = 0;

--- a/experimental/ukernel/src/transport/oob/oob_socket.cc
+++ b/experimental/ukernel/src/transport/oob/oob_socket.cc
@@ -442,11 +442,9 @@ bool ShmExchanger::init_shared_store() {
   shm_ = reinterpret_cast<KvShmHeader*>(mapped);
 
   bool need_init = created || shm_->magic != kShmMagic ||
-                   shm_->version != kShmVersion ||
                    shm_->slot_capacity != kMaxSlots;
   if (need_init) {
     shm_->magic = kShmMagic;
-    shm_->version = kShmVersion;
     shm_->slot_capacity = kMaxSlots;
     shm_->write_seq = 0;
     shm_->owner_pid = 0;

--- a/experimental/ukernel/src/transport/oob/oob_socket.cc
+++ b/experimental/ukernel/src/transport/oob/oob_socket.cc
@@ -441,8 +441,8 @@ bool ShmExchanger::init_shared_store() {
   }
   shm_ = reinterpret_cast<KvShmHeader*>(mapped);
 
-  bool need_init = created || shm_->magic != kShmMagic ||
-                   shm_->slot_capacity != kMaxSlots;
+  bool need_init =
+      created || shm_->magic != kShmMagic || shm_->slot_capacity != kMaxSlots;
   if (need_init) {
     shm_->magic = kShmMagic;
     shm_->slot_capacity = kMaxSlots;

--- a/experimental/ukernel/src/transport/request.h
+++ b/experimental/ukernel/src/transport/request.h
@@ -7,7 +7,7 @@ namespace UKernel {
 namespace Transport {
 
 struct LocalSlice {
-  uint32_t mem_id = 0;
+  uint32_t buffer_id = 0;
   size_t offset = 0;
   size_t bytes = 0;
 };
@@ -27,17 +27,13 @@ struct RemoteWriteHint {
 
 struct RemoteSlice {
   // Cross-transport destination hint contract:
-  // 1) Common semantic: destination is [remote MR `mem_id`] + `offset`.
-  // 2) IPC/TCP/UCCL all support this common hint (`mem_id`, `offset`).
+  // 1) Common semantic: destination is [remote MR `buffer_id`] + `offset`.
+  // 2) IPC/TCP/UCCL all support this common hint (`buffer_id`, `offset`).
   // 3) UCCL may additionally use `write` for one-sided write fast path.
   //    IPC/TCP ignore `write`.
-  // 4) `binding_version` is IPC metadata epoch/version. Non-zero means sender
-  //    must match the same published IPC buffer version before direct access.
-  //    Zero means "version unspecified" and should fall back to safe handshake.
-  uint32_t mem_id = 0;
+  uint32_t buffer_id = 0;
   size_t offset = 0;
   RemoteWriteHint write{};
-  uint64_t binding_version = 0;
 
   bool has_write_hint() const { return write.usable(); }
 };

--- a/experimental/ukernel/src/transport/test/integration/test_transport_communicator.cc
+++ b/experimental/ukernel/src/transport/test/integration/test_transport_communicator.cc
@@ -15,9 +15,6 @@
 using CommunicatorConfig = UKernel::Transport::CommunicatorConfig;
 using Communicator = UKernel::Transport::Communicator;
 using LocalSlice = UKernel::Transport::LocalSlice;
-using MR = UKernel::Transport::MR;
-using NamedMR = UKernel::Transport::NamedMR;
-using NamedMRInfos = UKernel::Transport::NamedMRInfos;
 using RemoteSlice = UKernel::Transport::RemoteSlice;
 
 static constexpr int kWorldSize = 2;
@@ -34,7 +31,8 @@ using UKernel::Transport::TestUtil::require;
 using UKernel::Transport::TestUtil::run_case;
 
 constexpr size_t kMessageBytes = 4 * 1024;
-constexpr uint64_t kNamedMrGeneration = 1;
+constexpr uint32_t kClientSendBufferId = 1001;
+constexpr uint32_t kServerRecvBufferId = 2001;
 
 void fill_pattern(std::vector<uint8_t>& buf, uint8_t seed) {
   for (size_t i = 0; i < buf.size(); ++i) {
@@ -91,23 +89,21 @@ int run_exchange_client(std::string const& exchanger_ip, int exchanger_port,
   GPU_RT_CHECK(gpuMemcpy(sendbuf_d, send_host.data(), send_host.size(),
                          gpuMemcpyHostToDevice));
 
-  MR send_mr = comm->reg_mr(sendbuf_d, kMessageBytes);
-  NamedMRInfos remote_recv_infos{};
-  if (comm->peer_transport_kind(kServerRank) ==
-      UKernel::Transport::PeerTransportKind::Uccl) {
-    require(comm->wait_named_mrs(kServerRank, kNamedMrGeneration,
-                                 remote_recv_infos),
-            "client wait_named_mrs failed");
+  require(comm->reg_mr(kClientSendBufferId, sendbuf_d, kMessageBytes, false),
+          "client reg_mr failed");
+  uint32_t remote_recv_mr_id = 0;
+  auto peer_kind = comm->peer_transport_kind(kServerRank);
+  if (peer_kind == UKernel::Transport::PeerTransportKind::Uccl) {
+    require(comm->wait_mr(kServerRank, kServerRecvBufferId),
+            "client wait_mr failed");
+    remote_recv_mr_id = comm->get_mr(kServerRank, kServerRecvBufferId).id;
   }
-  uint32_t remote_recv_mr_id = remote_recv_infos.entries.empty()
-                                   ? 0
-                                   : remote_recv_infos.entries.front().mr.id;
   std::optional<RemoteSlice> dst_hint = std::nullopt;
   if (remote_recv_mr_id != 0) {
     dst_hint = RemoteSlice{remote_recv_mr_id, 0};
   }
   unsigned send_req = comm->isend(
-      kServerRank, LocalSlice{send_mr.id, 0, kMessageBytes}, dst_hint);
+      kServerRank, LocalSlice{kClientSendBufferId, 0, kMessageBytes}, dst_hint);
   require(send_req != 0, "client isend failed");
   require(comm->wait_finish(send_req), "client wait_finish(send) failed");
 
@@ -128,18 +124,13 @@ int run_exchange_server(std::string const& exchanger_ip, int exchanger_port,
   auto free_buf = UKernel::Transport::finally([&] { gpuFree(recvbuf_d); });
   GPU_RT_CHECK(gpuMemset(recvbuf_d, 0, kMessageBytes));
 
-  MR recv_mr = comm->reg_mr(recvbuf_d, kMessageBytes);
-  if (comm->peer_transport_kind(kClientRank) ==
-      UKernel::Transport::PeerTransportKind::Uccl) {
-    NamedMRInfos infos{};
-    infos.generation = kNamedMrGeneration;
-    infos.entries.push_back(NamedMR{0, recv_mr});
-    require(comm->notify_named_mrs(kClientRank, kNamedMrGeneration, infos),
-            "server notify_named_mrs failed");
-  }
+  require(comm->reg_mr(kServerRecvBufferId, recvbuf_d, kMessageBytes, true),
+          "server reg_mr failed");
+  auto peer_kind = comm->peer_transport_kind(kClientRank);
+  (void)peer_kind;
 
   unsigned recv_req =
-      comm->irecv(kClientRank, LocalSlice{recv_mr.id, 0, kMessageBytes});
+      comm->irecv(kClientRank, LocalSlice{kServerRecvBufferId, 0, kMessageBytes});
   require(recv_req != 0, "server irecv failed");
   require(comm->wait_finish(recv_req), "server wait_finish(recv) failed");
 
@@ -168,21 +159,20 @@ int run_ipc_buffer_metadata_client(
   auto free_buf = UKernel::Transport::finally([&] { gpuFree(buf); });
 
   constexpr uint32_t kValidIpcId = 4242;
-  require(comm->notify_ipc_buffer(kServerRank, kValidIpcId, buf, 4096),
-          "notify_ipc_buffer should succeed");
+  require(comm->reg_ipc(kValidIpcId, buf, 4096, true), "reg_ipc should succeed");
 
   constexpr uint32_t kInvalidIpcId = 9999;
-  require(comm->notify_ipc_buffer(kServerRank, kInvalidIpcId, nullptr, 0),
+  require(comm->reg_ipc(kInvalidIpcId, nullptr, 0, true),
           "invalid ipc metadata publish should still succeed");
 
   constexpr uint32_t kAckIpcId = 7777;
-  require(comm->wait_ipc_buffer(kServerRank, kAckIpcId),
-          "client wait_ipc_buffer(ack) should succeed");
+  require(comm->wait_ipc(kServerRank, kAckIpcId),
+          "client wait_ipc(ack) should succeed");
   // Publish a completion marker so the server keeps the exchanger process
   // alive until the client has observed the ack.
   constexpr uint32_t kClientDoneIpcId = 8888;
-  require(comm->notify_ipc_buffer(kServerRank, kClientDoneIpcId, nullptr, 0),
-          "client notify_ipc_buffer(done) should succeed");
+  require(comm->reg_ipc(kClientDoneIpcId, nullptr, 0, true),
+          "client reg_ipc(done) should succeed");
 
   std::cout << "[CLIENT][ipc-buffer-meta] OK" << std::endl;
   return 0;
@@ -198,37 +188,35 @@ int run_ipc_buffer_metadata_server(
   require(comm->same_host(kClientRank),
           "ipc-buffer-meta requires same-host peers");
 
-  void* resolved = nullptr;
-  int device_idx = -1;
-
   constexpr uint32_t kValidIpcId = 4242;
-  require(comm->wait_ipc_buffer(kClientRank, kValidIpcId),
-          "wait_ipc_buffer should succeed");
-  require(comm->resolve_ipc_buffer_pointer(kClientRank, kValidIpcId, 128, 256,
-                                           &resolved, &device_idx),
-          "resolve_ipc_buffer_pointer should succeed");
-  require(resolved != nullptr, "resolved remote pointer should not be null");
-  require(device_idx == kClientGpu,
-          "resolved remote pointer should preserve device index");
-  require(!comm->resolve_ipc_buffer_pointer(kClientRank, kValidIpcId, 4096, 1,
-                                            &resolved, &device_idx),
-          "out-of-range ipc pointer resolution should fail");
+  require(comm->wait_ipc(kClientRank, kValidIpcId), "wait_ipc should succeed");
+  auto ipc = comm->get_ipc(kClientRank, kValidIpcId);
+  require(ipc.direct_ptr != nullptr,
+          "get_ipc should resolve a non-null direct_ptr for valid IPC");
+  require(ipc.device_idx == kClientGpu,
+          "get_ipc should preserve remote device index");
+  bool out_of_range_ok = (4096 > ipc.bytes || 1 > (ipc.bytes - 4096));
+  require(out_of_range_ok, "out-of-range span check should fail");
 
   constexpr uint32_t kInvalidIpcId = 9999;
-  require(comm->wait_ipc_buffer(kClientRank, kInvalidIpcId),
+  require(comm->wait_ipc(kClientRank, kInvalidIpcId),
           "invalid ipc metadata fetch should succeed");
-  require(!comm->resolve_ipc_buffer_pointer(kClientRank, kInvalidIpcId, 0, 1,
-                                            &resolved, &device_idx),
-          "invalid ipc metadata should not resolve to a pointer");
+  bool invalid_failed = false;
+  try {
+    (void)comm->get_ipc(kClientRank, kInvalidIpcId);
+  } catch (...) {
+    invalid_failed = true;
+  }
+  require(invalid_failed, "invalid ipc metadata should not resolve to IPC");
 
   constexpr uint32_t kAckIpcId = 7777;
-  require(comm->notify_ipc_buffer(kClientRank, kAckIpcId, nullptr, 0),
-          "server notify_ipc_buffer(ack) should succeed");
+  require(comm->reg_ipc(kAckIpcId, nullptr, 0, true),
+          "server reg_ipc(ack) should succeed");
   // Wait for client completion marker to avoid tearing down the in-process
   // exchanger before the client has consumed the ack.
   constexpr uint32_t kClientDoneIpcId = 8888;
-  require(comm->wait_ipc_buffer(kClientRank, kClientDoneIpcId),
-          "server wait_ipc_buffer(done) should succeed");
+  require(comm->wait_ipc(kClientRank, kClientDoneIpcId),
+          "server wait_ipc(done) should succeed");
 
   std::cout << "[SERVER][ipc-buffer-meta] OK" << std::endl;
   return 0;
@@ -248,18 +236,20 @@ void test_transport_communicator_local() {
     GPU_RT_CHECK(gpuMalloc(&buf, 4096));
     auto free_buf = UKernel::Transport::finally([&] { gpuFree(buf); });
 
-    MR mr0 = comm->reg_mr(buf, 4096);
-    MR mr1 = comm->reg_mr(buf, 4096);
+    constexpr uint32_t kLocalBufferId = 1;
+    require(comm->reg_mr(kLocalBufferId, buf, 4096, false), "reg_mr#0 failed");
+    MR mr0 = comm->get_mr(kLocalBufferId);
+    require(comm->reg_mr(kLocalBufferId, buf, 4096, false), "reg_mr#1 failed");
+    MR mr1 = comm->get_mr(kLocalBufferId);
     require(mr0.id == mr1.id,
             "reg_mr should be idempotent for the same buffer");
-    require(comm->get_local_mr(static_cast<char*>(buf) + 128).id == mr0.id,
-            "communicator local MR range lookup failed");
     require(
-        comm->get_local_mr(mr0.id).address == reinterpret_cast<uint64_t>(buf),
-        "communicator local MR lookup by id failed");
+        comm->get_mr(kLocalBufferId).address == reinterpret_cast<uint64_t>(buf),
+        "communicator local MR lookup by buffer_id failed");
 
-    require(comm->dereg_mr(buf), "dereg_mr failed");
-    MR mr2 = comm->reg_mr(buf, 4096);
+    require(comm->dereg_mr(kLocalBufferId), "dereg_mr failed");
+    require(comm->reg_mr(kLocalBufferId, buf, 4096, false), "reg_mr#2 failed");
+    MR mr2 = comm->get_mr(kLocalBufferId);
     require(mr2.id != mr0.id,
             "re-registering after dereg_mr should allocate a new MR id");
   });

--- a/experimental/ukernel/src/transport/test/integration/test_transport_communicator.cc
+++ b/experimental/ukernel/src/transport/test/integration/test_transport_communicator.cc
@@ -131,8 +131,8 @@ int run_exchange_server(std::string const& exchanger_ip, int exchanger_port,
   auto peer_kind = comm->peer_transport_kind(kClientRank);
   (void)peer_kind;
 
-  unsigned recv_req =
-      comm->irecv(kClientRank, LocalSlice{kServerRecvBufferId, 0, kMessageBytes});
+  unsigned recv_req = comm->irecv(
+      kClientRank, LocalSlice{kServerRecvBufferId, 0, kMessageBytes});
   require(recv_req != 0, "server irecv failed");
   require(comm->wait_finish(recv_req), "server wait_finish(recv) failed");
 
@@ -161,7 +161,8 @@ int run_ipc_buffer_metadata_client(
   auto free_buf = UKernel::Transport::finally([&] { gpuFree(buf); });
 
   constexpr uint32_t kValidIpcId = 4242;
-  require(comm->reg_ipc(kValidIpcId, buf, 4096, true), "reg_ipc should succeed");
+  require(comm->reg_ipc(kValidIpcId, buf, 4096, true),
+          "reg_ipc should succeed");
 
   constexpr uint32_t kInvalidIpcId = 9999;
   require(comm->reg_ipc(kInvalidIpcId, nullptr, 0, true),

--- a/experimental/ukernel/src/transport/test/integration/test_transport_communicator.cc
+++ b/experimental/ukernel/src/transport/test/integration/test_transport_communicator.cc
@@ -14,6 +14,7 @@
 
 using CommunicatorConfig = UKernel::Transport::CommunicatorConfig;
 using Communicator = UKernel::Transport::Communicator;
+using MR = UKernel::Transport::MR;
 using LocalSlice = UKernel::Transport::LocalSlice;
 using RemoteSlice = UKernel::Transport::RemoteSlice;
 
@@ -91,16 +92,17 @@ int run_exchange_client(std::string const& exchanger_ip, int exchanger_port,
 
   require(comm->reg_mr(kClientSendBufferId, sendbuf_d, kMessageBytes, false),
           "client reg_mr failed");
-  uint32_t remote_recv_mr_id = 0;
+  uint32_t remote_recv_buffer_id = 0;
   auto peer_kind = comm->peer_transport_kind(kServerRank);
   if (peer_kind == UKernel::Transport::PeerTransportKind::Uccl) {
     require(comm->wait_mr(kServerRank, kServerRecvBufferId),
             "client wait_mr failed");
-    remote_recv_mr_id = comm->get_mr(kServerRank, kServerRecvBufferId).id;
+    (void)comm->get_mr(kServerRank, kServerRecvBufferId);
+    remote_recv_buffer_id = kServerRecvBufferId;
   }
   std::optional<RemoteSlice> dst_hint = std::nullopt;
-  if (remote_recv_mr_id != 0) {
-    dst_hint = RemoteSlice{remote_recv_mr_id, 0};
+  if (remote_recv_buffer_id != 0) {
+    dst_hint = RemoteSlice{remote_recv_buffer_id, 0};
   }
   unsigned send_req = comm->isend(
       kServerRank, LocalSlice{kClientSendBufferId, 0, kMessageBytes}, dst_hint);
@@ -241,7 +243,7 @@ void test_transport_communicator_local() {
     MR mr0 = comm->get_mr(kLocalBufferId);
     require(comm->reg_mr(kLocalBufferId, buf, 4096, false), "reg_mr#1 failed");
     MR mr1 = comm->get_mr(kLocalBufferId);
-    require(mr0.id == mr1.id,
+    require(mr0.address == mr1.address && mr0.length == mr1.length,
             "reg_mr should be idempotent for the same buffer");
     require(
         comm->get_mr(kLocalBufferId).address == reinterpret_cast<uint64_t>(buf),
@@ -250,8 +252,8 @@ void test_transport_communicator_local() {
     require(comm->dereg_mr(kLocalBufferId), "dereg_mr failed");
     require(comm->reg_mr(kLocalBufferId, buf, 4096, false), "reg_mr#2 failed");
     MR mr2 = comm->get_mr(kLocalBufferId);
-    require(mr2.id != mr0.id,
-            "re-registering after dereg_mr should allocate a new MR id");
+    require(mr2.address == mr0.address && mr2.length == mr0.length,
+            "re-registering after dereg_mr should preserve MR metadata");
   });
 }
 

--- a/experimental/ukernel/src/transport/test/unit/test_transport_core.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_core.cc
@@ -48,35 +48,40 @@ void test_memory_manager() {
   MR mr_a_again = tracked_a_again.mr;
   MR mr_b = tracked_b.mr;
 
-  require(mr_a.id == mr_a_again.id, "local MR id should be stable");
-  require(mr_a.id != mr_b.id, "different buffers should produce different ids");
-  require(mrm.get_mr(buf_a.data()).mr.id == mr_a.id,
+  require(tracked_a.buffer_id == tracked_a_again.buffer_id,
+          "local buffer_id should be stable");
+  require(tracked_a.buffer_id != tracked_b.buffer_id,
+          "different buffers should produce different buffer_ids");
+  require(mrm.get_mr(buf_a.data()).buffer_id == tracked_a.buffer_id,
           "exact local MR lookup failed");
-  require(mrm.get_mr(buf_a.data() + 128).mr.id == mr_a.id,
+  require(mrm.get_mr(buf_a.data() + 128).buffer_id == tracked_a.buffer_id,
           "range-based local MR lookup failed");
-  require(mrm.get_mr(mr_b.id).mr.address ==
+  require(mrm.get_mr(/*buffer_id=*/tracked_b.buffer_id).mr.address ==
               reinterpret_cast<uint64_t>(buf_b.data()),
-          "MR lookup by id failed");
+          "MR lookup by buffer_id failed");
 
-  MR remote0{7, 0x1000ULL, 128, 0, 77};
-  MR remote1{8, 0x2000ULL, 256, 0, 88};
-  MR remote2{9, 0x3000ULL, 512, 0, 99};
+  MR remote0{0x1000ULL, 128, 0, 77};
+  MR remote1{0x2000ULL, 256, 0, 88};
+  MR remote2{0x3000ULL, 512, 0, 99};
   MRItem ri0{};
+  ri0.buffer_id = 7;
   ri0.mr = remote0;
   ri0.valid = true;
   MRItem ri1{};
+  ri1.buffer_id = 8;
   ri1.mr = remote1;
   ri1.valid = true;
   MRItem ri2{};
+  ri2.buffer_id = 9;
   ri2.mr = remote2;
   ri2.valid = true;
   mrm.register_remote_mrs(/*remote_rank=*/3, {ri0, ri1});
   mrm.register_remote_mrs(/*remote_rank=*/3, {ri0, ri1, ri2});
-  require(mrm.get_mr(3, remote0.id).mr.address == remote0.address,
+  require(mrm.get_mr(3, ri0.buffer_id).mr.address == remote0.address,
           "cached remote MR lookup for first entry failed");
-  require(mrm.get_mr(3, remote1.id).mr.address == remote1.address,
+  require(mrm.get_mr(3, ri1.buffer_id).mr.address == remote1.address,
           "cached remote MR lookup for second entry failed");
-  require(mrm.get_mr(3, remote2.id).mr.address == remote2.address,
+  require(mrm.get_mr(3, ri2.buffer_id).mr.address == remote2.address,
           "cached remote MR lookup failed");
 
   gpuIpcMemHandle_t handle{};
@@ -104,9 +109,9 @@ void test_memory_manager() {
 
   auto resized = mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(),
                                      buf_a.size() / 2);
-  require(resized.mr.id == mr_a.id,
-          "same buffer_id should keep stable MR id after resize");
-  require(mrm.get_mr(buf_a.data()).mr.id == resized.mr.id,
+  require(resized.buffer_id == tracked_a.buffer_id,
+          "same buffer_id should keep stable id after resize");
+  require(mrm.get_mr(buf_a.data()).buffer_id == resized.buffer_id,
           "resized exact lookup should resolve to new MR");
   require(!mrm.get_mr(buf_a.data() + buf_a.size() / 2 + 1).valid,
           "lookup beyond resized range should fail");

--- a/experimental/ukernel/src/transport/test/unit/test_transport_core.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_core.cc
@@ -37,28 +37,19 @@ void test_memory_manager() {
   UKernel::Transport::IPCManager ipcm;
   std::vector<uint8_t> buf_a(512, 0x11);
   std::vector<uint8_t> buf_b(1024, 0x22);
-  std::vector<uint32_t> reg_ids;
-  std::vector<uint32_t> dereg_ids;
 
-  mrm.bind_backend(
-      [&](uint32_t mr_id, void* ptr, size_t len) {
-        require(ptr != nullptr && len > 0, "backend register args invalid");
-        reg_ids.push_back(mr_id);
-        return true;
-      },
-      [&](uint32_t mr_id) { dereg_ids.push_back(mr_id); });
-
-  auto tracked_a = mrm.create_local_mr(buf_a.data(), buf_a.size());
-  auto tracked_a_again = mrm.create_local_mr(buf_a.data(), buf_a.size());
-  auto tracked_b = mrm.create_local_mr(buf_b.data(), buf_b.size());
+  auto tracked_a = mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(),
+                                       buf_a.size());
+  auto tracked_a_again = mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(),
+                                             buf_a.size());
+  auto tracked_b = mrm.create_local_mr(/*buffer_id=*/12, buf_b.data(),
+                                       buf_b.size());
   MR mr_a = tracked_a.mr;
   MR mr_a_again = tracked_a_again.mr;
   MR mr_b = tracked_b.mr;
 
   require(mr_a.id == mr_a_again.id, "local MR id should be stable");
   require(mr_a.id != mr_b.id, "different buffers should produce different ids");
-  require(reg_ids.size() == 2,
-          "backend register should run once per unique local buffer");
   require(mrm.get_mr(buf_a.data()).mr.id == mr_a.id,
           "exact local MR lookup failed");
   require(mrm.get_mr(buf_a.data() + 128).mr.id == mr_a.id,
@@ -99,7 +90,7 @@ void test_memory_manager() {
   cache.base_offset = 64;
   cache.bytes = 2048;
   cache.device_idx = 5;
-  require(ipcm.register_remote_ipc(4, cache),
+  require(ipcm.register_remote_ipc(4, /*buffer_id=*/0, cache),
           "failed to register remote IPC cache");
   IPCItem cached = ipcm.get_ipc(4, handle);
   require(cached.direct_ptr == cache.direct_ptr &&
@@ -108,60 +99,27 @@ void test_memory_manager() {
               cached.device_idx == cache.device_idx,
           "remote IPC cache round-trip mismatch");
 
-  require(mrm.delete_mr(buf_a.data()), "first local MR delete should succeed");
-  require(dereg_ids.size() == 1 && dereg_ids.back() == mr_a.id,
-          "backend deregister should run when local MR is deleted");
+  require(mrm.delete_mr(/*buffer_id=*/11),
+          "first local MR delete should succeed");
 
-  auto resized = mrm.create_local_mr(buf_a.data(), buf_a.size() / 2);
-  require(resized.mr.id != mr_a.id,
-          "resized registration should allocate a new MR id");
-  require(reg_ids.size() == 3 && reg_ids.back() == resized.mr.id,
-          "resized local MR should trigger backend register for new id");
+  auto resized = mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(),
+                                     buf_a.size() / 2);
+  require(resized.mr.id == mr_a.id,
+          "same buffer_id should keep stable MR id after resize");
   require(mrm.get_mr(buf_a.data()).mr.id == resized.mr.id,
           "resized exact lookup should resolve to new MR");
   require(!mrm.get_mr(buf_a.data() + buf_a.size() / 2 + 1).valid,
           "lookup beyond resized range should fail");
 
-  require(mrm.delete_mr(buf_a.data()),
+  require(mrm.delete_mr(/*buffer_id=*/11),
           "resized local MR delete should succeed");
-  require(dereg_ids.size() == 2 && dereg_ids.back() == resized.mr.id,
-          "resized local MR delete should trigger backend deregister");
   require(!mrm.get_mr(buf_a.data()).valid,
           "released local buffer should not be queryable");
 
-  require(!mrm.delete_mr(buf_a.data()),
+  require(!mrm.delete_mr(/*buffer_id=*/11),
           "released resized buffer should no longer be tracked");
 
-  require(mrm.delete_mr(buf_b.data()), "single-use MR should be deletable");
-  require(dereg_ids.size() == 3 && dereg_ids.back() == mr_b.id,
-          "single-use local MR delete should trigger backend deregister");
-
-  // Verify "create first, bind/sync later" path.
-  MRManager late_bound;
-  std::vector<uint32_t> late_reg_ids;
-  std::vector<uint32_t> late_dereg_ids;
-  std::vector<uint8_t> buf_c(256, 0x33);
-
-  auto tracked_c = late_bound.create_local_mr(buf_c.data(), buf_c.size());
-  require(tracked_c.valid, "late-bound test local MR should be valid");
-
-  late_bound.bind_backend(
-      [&](uint32_t mr_id, void* ptr, size_t len) {
-        require(ptr == buf_c.data() && len == buf_c.size(),
-                "late-bound backend register args mismatch");
-        late_reg_ids.push_back(mr_id);
-        return true;
-      },
-      [&](uint32_t mr_id) { late_dereg_ids.push_back(mr_id); });
-  late_bound.sync_local_backend();
-
-  require(late_reg_ids.size() == 1 && late_reg_ids.back() == tracked_c.mr.id,
-          "sync_local_backend should register pre-existing local MR");
-  require(late_bound.delete_mr(buf_c.data()),
-          "late-bound local MR delete should succeed");
-  require(
-      late_dereg_ids.size() == 1 && late_dereg_ids.back() == tracked_c.mr.id,
-      "late-bound local MR delete should trigger backend deregister");
+  require(mrm.delete_mr(/*buffer_id=*/12), "single-use MR should be deletable");
 }
 
 void test_peer_transport_kind() {

--- a/experimental/ukernel/src/transport/test/unit/test_transport_core.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_core.cc
@@ -38,12 +38,12 @@ void test_memory_manager() {
   std::vector<uint8_t> buf_a(512, 0x11);
   std::vector<uint8_t> buf_b(1024, 0x22);
 
-  auto tracked_a = mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(),
-                                       buf_a.size());
-  auto tracked_a_again = mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(),
-                                             buf_a.size());
-  auto tracked_b = mrm.create_local_mr(/*buffer_id=*/12, buf_b.data(),
-                                       buf_b.size());
+  auto tracked_a =
+      mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(), buf_a.size());
+  auto tracked_a_again =
+      mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(), buf_a.size());
+  auto tracked_b =
+      mrm.create_local_mr(/*buffer_id=*/12, buf_b.data(), buf_b.size());
   MR mr_a = tracked_a.mr;
   MR mr_a_again = tracked_a_again.mr;
   MR mr_b = tracked_b.mr;
@@ -107,8 +107,8 @@ void test_memory_manager() {
   require(mrm.delete_mr(/*buffer_id=*/11),
           "first local MR delete should succeed");
 
-  auto resized = mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(),
-                                     buf_a.size() / 2);
+  auto resized =
+      mrm.create_local_mr(/*buffer_id=*/11, buf_a.data(), buf_a.size() / 2);
   require(resized.buffer_id == tracked_a.buffer_id,
           "same buffer_id should keep stable id after resize");
   require(mrm.get_mr(buf_a.data()).buffer_id == resized.buffer_id,

--- a/experimental/ukernel/src/transport/test/unit/test_transport_oob_exchangeable.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_oob_exchangeable.cc
@@ -34,8 +34,8 @@ void test_exchangeable_round_trip() {
 
   NamedMRInfos infos{};
   infos.generation = 42;
-  infos.entries.push_back(NamedMR{3, MR{1, 0x1000ULL, 256, 0, 11}});
-  infos.entries.push_back(NamedMR{7, MR{2, 0x2000ULL, 512, 0, 22}});
+  infos.entries.push_back(NamedMR{3, MR{0x1000ULL, 256, 0, 11}});
+  infos.entries.push_back(NamedMR{7, MR{0x2000ULL, 512, 0, 22}});
   NamedMRInfos infos_rt;
   require(infos.serialize(encoded), "NamedMRInfos serialize failed");
   require(infos_rt.deserialize(encoded), "NamedMRInfos deserialize failed");

--- a/experimental/ukernel/src/transport/test/unit/test_transport_oob_exchangeable.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_oob_exchangeable.cc
@@ -66,7 +66,6 @@ void test_exchangeable_round_trip() {
           "TcpP2PInfo round-trip mismatch");
 
   IpcBufferInfo ipc{};
-  ipc.ipc_id = 9;
   ipc.base_offset = 128;
   ipc.bytes = 4096;
   ipc.device_idx = 3;
@@ -79,7 +78,6 @@ void test_exchangeable_round_trip() {
   IpcBufferInfo ipc_rt;
   require(ipc.serialize(encoded), "IpcBufferInfo serialize failed");
   require(ipc_rt.deserialize(encoded), "IpcBufferInfo deserialize failed");
-  require(ipc_rt.ipc_id == ipc.ipc_id, "IpcBufferInfo ipc_id mismatch");
   require(ipc_rt.base_offset == ipc.base_offset,
           "IpcBufferInfo base_offset mismatch");
   require(ipc_rt.bytes == ipc.bytes, "IpcBufferInfo bytes mismatch");

--- a/experimental/ukernel/src/transport/test/unit/test_transport_oob_socket.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_oob_socket.cc
@@ -165,8 +165,8 @@ void publisher_socket(int port) {
   require(ex.valid(), "publisher failed to connect to socket exchanger");
 
   NamedMRInfos remote{};
-  remote.entries.push_back(NamedMR{5, MR{1, 0x12345000ULL, 4096, 0, 123}});
-  remote.entries.push_back(NamedMR{8, MR{2, 0x12346000ULL, 8192, 0, 456}});
+  remote.entries.push_back(NamedMR{5, MR{0x12345000ULL, 4096, 0, 123}});
+  remote.entries.push_back(NamedMR{8, MR{0x12346000ULL, 8192, 0, 456}});
 
   std::this_thread::sleep_for(std::chrono::milliseconds(300));
   require(ex.put("named-mr:peer:1:0", remote),
@@ -184,7 +184,7 @@ void test_socket_publish_fetch() {
           "socket listener not ready in time");
 
   NamedMRInfos local{};
-  local.entries.push_back(NamedMR{9, MR{7, 0xABCDEF00ULL, 16384, 0, 789}});
+  local.entries.push_back(NamedMR{9, MR{0xABCDEF00ULL, 16384, 0, 789}});
   require(ex.put("named-mr:peer:0:0", local),
           "failed to publish local MR info");
 
@@ -201,8 +201,8 @@ void test_socket_publish_fetch() {
   require(ex.wait("named-mr:peer:1:0", remote, Exchanger::WaitOptions{50, 100}),
           "timeout waiting for remote MR info");
   require(remote.entries.size() == 2, "remote MR count mismatch");
-  require(remote.entries[0].mr.id == 1 && remote.entries[1].mr.id == 2,
-          "remote MR ids mismatch");
+  require(remote.entries[0].buffer_id == 5 && remote.entries[1].buffer_id == 8,
+          "remote buffer_ids mismatch");
 
   pub_thread.join();
   if (pub_error) std::rethrow_exception(pub_error);
@@ -278,8 +278,8 @@ void test_socket_valid_implies_snapshot_ready() {
 
   NamedMRInfos payload{};
   payload.generation = 7;
-  payload.entries.push_back(NamedMR{3, MR{11, 0x11111000ULL, 2048, 0, 11}});
-  payload.entries.push_back(NamedMR{4, MR{12, 0x22222000ULL, 4096, 0, 12}});
+  payload.entries.push_back(NamedMR{3, MR{0x11111000ULL, 2048, 0, 11}});
+  payload.entries.push_back(NamedMR{4, MR{0x22222000ULL, 4096, 0, 12}});
   require(server.put("snapshot:key", payload),
           "server failed to publish snapshot payload");
 

--- a/experimental/ukernel/src/transport/test/unit/test_transport_tcp_adapter.cc
+++ b/experimental/ukernel/src/transport/test/unit/test_transport_tcp_adapter.cc
@@ -60,12 +60,12 @@ void test_tcp_connect_and_transfer() {
   fill_pattern(sendbuf, 0x33);
 
   unsigned recv_req = server.recv_async(/*peer_rank=*/1, recvbuf.data(),
-                                        recvbuf.size(), /*local_mr_id=*/0,
+                                        recvbuf.size(), /*local_buffer_id=*/0,
                                         /*bounce_provider=*/nullptr);
   require(recv_req != 0, "server recv_async should succeed");
   unsigned send_req =
       client.send_async(/*peer_rank=*/0, sendbuf.data(), sendbuf.size(),
-                        /*local_mr_id=*/0, std::nullopt,
+                        /*local_buffer_id=*/0, std::nullopt,
                         /*bounce_provider=*/nullptr);
   require(send_req != 0, "client send_async should succeed");
 
@@ -84,11 +84,11 @@ void test_tcp_invalid_peer_paths() {
   std::vector<uint8_t> buf(64, 0);
 
   require(adapter.send_async(/*peer_rank=*/1, buf.data(), buf.size(),
-                             /*local_mr_id=*/0, std::nullopt,
+                             /*local_buffer_id=*/0, std::nullopt,
                              /*bounce_provider=*/nullptr) == 0,
           "send_async without peer should fail");
   require(adapter.recv_async(/*peer_rank=*/1, buf.data(), buf.size(),
-                             /*local_mr_id=*/0,
+                             /*local_buffer_id=*/0,
                              /*bounce_provider=*/nullptr) == 0,
           "recv_async without peer should fail");
   require(adapter.poll_completion(/*request_id=*/999),


### PR DESCRIPTION
## Description
This PR completes a hard migration to buffer_id as the single transport resource identity across ukernel transport, CCL, and Python bindings. It removes mixed mr_id/ipc_id semantics, simplifies MR/IPC ownership boundaries, and updates adapter/runtime call paths accordingly.

Key updates include:

- Unified async/data-path contracts to buffer_id in communicator/adapters/Python.
- Removed duplicated MR identity (MR.id) and standardized indexing on buffer_id.
- Refactored MR/IPC manager responsibilities into clean metadata/data-plane stores.
- Hardened IPC pointer resolution and OOB-related runtime paths to use explicit non-throwing checks.
- Fixed Python binding config migration issues (new oob_namespace field ordering).
- Fixed out-of-place all-to-all binding roles so scratch buffer is always distinct from input/output.
- Updated transport/OOB/unit/integration tests and Python smoke paths to match new semantics.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
