### PR TITLE
[EP] chore: isolate warning suppression to uccl_ep only

### DIFF
--- a/ep/Makefile
+++ b/ep/Makefile
@@ -66,7 +66,7 @@ INSTALL_DIR          := $(PYTHON_SITE_PACKAGES)/uccl
 DETECTED_SM := $(shell nvidia-smi --query-gpu=compute_cap --format=csv,noheader | head -n1 | tr -d '.')
 SM ?= $(DETECTED_SM)
 
-CXXFLAGS  := -O3 -std=c++17 -Wall -pthread -fPIC -fvisibility=hidden -Wno-interference-size -Wno-unused-function -D_GLIBCXX_USE_CXX11_ABI=$(TORCH_ABI)
+CXXFLAGS  := -O3 -std=c++17 -Wall -pthread -fPIC -fvisibility=hidden -Wno-interference-size -Wno-unused-function -D_GLIBCXX_USE_CXX11_ABI=$(TORCH_ABI) -DNB_DOMAIN=uccl_ep
 LDFLAGS := -lpthread  -libverbs -lnl-3 -lnl-route-3 -lnuma -Xlinker -rpath -Xlinker $(CUDA_PATH)/lib64
 NVCCFLAGS := -O3 -std=c++17 -Xcompiler "-Wall -pthread -fPIC -fvisibility=hidden" -ccbin /usr/bin/g++ --expt-relaxed-constexpr -D_GLIBCXX_USE_CXX11_ABI=$(TORCH_ABI)
 INCLUDES := -Iinclude -I$(CUDA_PATH)/include -I/usr/include -I../include 

--- a/ep/setup.py
+++ b/ep/setup.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
         "-Wno-attributes",
         "-Wno-unused-result",
         "-Wno-unused-function",
-        "-DNB_DOMAIN=uccl_ep"
+        "-DNB_DOMAIN=uccl_ep",
     ]
     nvcc_flags = ["-O3", "-Xcompiler", "-O3"]
     sources = glob("./src/*.cu") + glob("./src/*.cpp") + glob("./src/*.cc")

--- a/ep/setup.py
+++ b/ep/setup.py
@@ -138,6 +138,7 @@ if __name__ == "__main__":
         "-Wno-attributes",
         "-Wno-unused-result",
         "-Wno-unused-function",
+        "-DNB_DOMAIN=uccl_ep"
     ]
     nvcc_flags = ["-O3", "-Xcompiler", "-O3"]
     sources = glob("./src/*.cu") + glob("./src/*.cpp") + glob("./src/*.cc")


### PR DESCRIPTION
## Description
Addition to #910 to isolate suppression of nanobind warnings to uccl_ep only, as recommended in the nanobind docs:

> Note that is a global flag shared by all nanobind extension libraries in the same ABI domain. When changing global flags, please isolate your extension from others by passing the NB_DOMAIN parameter to the [nanobind_add_module()](https://nanobind.readthedocs.io/en/latest/api_cmake.html#command:nanobind_add_module) CMake command:

I've verified that this is the actual flag added by checking against the output when running CMake with `NB_DOMAIN` configured:

<img width="999" height="60" alt="Screenshot 2026-04-28 at 9 03 56 AM" src="https://github.com/user-attachments/assets/b6af7eae-c9fb-42c1-80bc-141a68498448" />

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [x] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
