### PR TITLE
[P2P] Fix sendv/recvv bugs.

### DIFF
--- a/p2p/benchmarks/benchmark_uccl.py
+++ b/p2p/benchmarks/benchmark_uccl.py
@@ -61,12 +61,12 @@ def _run_server(args, ep, remote_metadata):
     print(f"[Server] Accept from {r_ip} (GPU {r_gpu}) conn_id={conn_id}")
 
     for size in args.sizes:
-        size_per_block = size // args.num_kvblocks
+        size_per_block = size // args.num_iovs
         buf_v = []
         mr_id_v = []
         data_ptr_v = []
         size_v = []
-        for _ in range(args.num_kvblocks):
+        for _ in range(args.num_iovs):
             buf, ptr = _make_buffer(
                 size_per_block, args.device, args.local_gpu_idx, args.pinned
             )
@@ -77,7 +77,7 @@ def _run_server(args, ep, remote_metadata):
             data_ptr_v.append(ptr)
             size_v.append(size_per_block)
 
-        if args.num_kvblocks == 1:
+        if args.num_iovs == 1:
             if args.async_api:
                 ok, transfer_id = ep.recv_async(
                     conn_id, mr_id_v[0], data_ptr_v[0], size_v[0]
@@ -117,7 +117,7 @@ def _run_server(args, ep, remote_metadata):
         else:
             if args.async_api:
                 ok, transfer_id = ep.recvv_async(
-                    conn_id, mr_id_v, data_ptr_v, size_v, args.num_kvblocks
+                    conn_id, mr_id_v, data_ptr_v, size_v, args.num_iovs
                 )
                 assert ok, "[Server] recvv_async error"
                 is_done = False
@@ -125,14 +125,14 @@ def _run_server(args, ep, remote_metadata):
                     ok, is_done = ep.poll_async(transfer_id)
                     assert ok, "[Server] poll_async error"
             else:
-                ep.recvv(conn_id, mr_id_v, data_ptr_v, size_v, args.num_kvblocks)
+                ep.recvv(conn_id, mr_id_v, data_ptr_v, size_v, args.num_iovs)
 
             start = time.perf_counter()
             total_recv = 0
             for _ in range(args.iters):
                 if args.async_api:
                     ok, transfer_id = ep.recvv_async(
-                        conn_id, mr_id_v, data_ptr_v, size_v, args.num_kvblocks
+                        conn_id, mr_id_v, data_ptr_v, size_v, args.num_iovs
                     )
                     assert ok, "[Server] recvv_async error"
                     is_done = False
@@ -140,9 +140,7 @@ def _run_server(args, ep, remote_metadata):
                         ok, is_done = ep.poll_async(transfer_id)
                         assert ok, "[Server] poll_async error"
                 else:
-                    ok = ep.recvv(
-                        conn_id, mr_id_v, data_ptr_v, size_v, args.num_kvblocks
-                    )
+                    ok = ep.recvv(conn_id, mr_id_v, data_ptr_v, size_v, args.num_iovs)
                     assert ok, "[Server] recv error"
                 total_recv += sum(size_v)
             elapsed = time.perf_counter() - start
@@ -163,12 +161,12 @@ def _run_client(args, ep, remote_metadata):
     print(f"[Client] Connected to {ip}:{port} (GPU {r_gpu}) conn_id={conn_id}")
 
     for size in args.sizes:
-        size_per_block = size // args.num_kvblocks
+        size_per_block = size // args.num_iovs
         buf_v = []
         mr_id_v = []
         data_ptr_v = []
         size_v = []
-        for _ in range(args.num_kvblocks):
+        for _ in range(args.num_iovs):
             buf, ptr = _make_buffer(
                 size_per_block, args.device, args.local_gpu_idx, args.pinned
             )
@@ -179,7 +177,7 @@ def _run_client(args, ep, remote_metadata):
             data_ptr_v.append(ptr)
             size_v.append(size_per_block)
 
-        if args.num_kvblocks == 1:
+        if args.num_iovs == 1:
             if args.async_api:
                 ok, transfer_id = ep.send_async(
                     conn_id, mr_id_v[0], data_ptr_v[0], size_v[0]
@@ -216,7 +214,7 @@ def _run_client(args, ep, remote_metadata):
         else:
             if args.async_api:
                 ok, transfer_id = ep.sendv_async(
-                    conn_id, mr_id_v, data_ptr_v, size_v, args.num_kvblocks
+                    conn_id, mr_id_v, data_ptr_v, size_v, args.num_iovs
                 )
                 assert ok, "[Client] sendv_async error"
                 is_done = False
@@ -224,14 +222,14 @@ def _run_client(args, ep, remote_metadata):
                     ok, is_done = ep.poll_async(transfer_id)
                     assert ok, "[Client] poll_async error"
             else:
-                ep.sendv(conn_id, mr_id_v, data_ptr_v, size_v, args.num_kvblocks)
+                ep.sendv(conn_id, mr_id_v, data_ptr_v, size_v, args.num_iovs)
 
             start = time.perf_counter()
             total_sent = 0
             for _ in range(args.iters):
                 if args.async_api:
                     ok, transfer_id = ep.sendv_async(
-                        conn_id, mr_id_v, data_ptr_v, size_v, args.num_kvblocks
+                        conn_id, mr_id_v, data_ptr_v, size_v, args.num_iovs
                     )
                     assert ok, "[Client] sendv_async error"
                     is_done = False
@@ -239,9 +237,7 @@ def _run_client(args, ep, remote_metadata):
                         ok, is_done = ep.poll_async(transfer_id)
                         assert ok, "[Client] poll_async error"
                 else:
-                    ok = ep.sendv(
-                        conn_id, mr_id_v, data_ptr_v, size_v, args.num_kvblocks
-                    )
+                    ok = ep.sendv(conn_id, mr_id_v, data_ptr_v, size_v, args.num_iovs)
                     assert ok, "[Client] send error"
                 total_sent += sum(size_v)
             elapsed = time.perf_counter() - start
@@ -495,11 +491,11 @@ def _run_server_write_ipc(args, ep):
     ok, remote_gpu_idx, conn_id = ep.accept_local()
     assert ok, "[Server] Failed to accept local IPC connection"
 
-    num_kvblocks = args.num_kvblocks
+    num_iovs = args.num_iovs
     for size in args.sizes:
-        size_per_block = size // num_kvblocks
+        size_per_block = size // num_iovs
 
-        if num_kvblocks == 1:
+        if num_iovs == 1:
             buf, ptr = _make_buffer(size_per_block, "gpu", args.local_gpu_idx)
             ok, info_blob = ep.advertise_ipc(conn_id, ptr, size_per_block)
             assert ok, "[Server] advertise_ipc failed"
@@ -507,16 +503,14 @@ def _run_server_write_ipc(args, ep):
         else:
             bufs_ptrs = [
                 _make_buffer(size_per_block, "gpu", args.local_gpu_idx)
-                for _ in range(num_kvblocks)
+                for _ in range(num_iovs)
             ]
             ptrs = [p for _, p in bufs_ptrs]
             ok, info_blobs = ep.advertisev_ipc(
-                conn_id, ptrs, [size_per_block] * num_kvblocks
+                conn_id, ptrs, [size_per_block] * num_iovs
             )
             assert ok, "[Server] advertisev_ipc failed"
-            packed = struct.pack("I", num_kvblocks) + b"".join(
-                bytes(b) for b in info_blobs
-            )
+            packed = struct.pack("I", num_iovs) + b"".join(bytes(b) for b in info_blobs)
             _send_bytes_dist(packed, dst=0)
 
         _recv_bytes_dist(src=0)
@@ -529,11 +523,11 @@ def _run_client_write_ipc(args, ep, remote_gpu_idx):
     ok, conn_id = ep.connect_local(remote_gpu_idx)
     assert ok, "[Client] Failed to connect to local server via IPC"
 
-    num_kvblocks = args.num_kvblocks
+    num_iovs = args.num_iovs
     for size in args.sizes:
-        size_per_block = size // num_kvblocks
+        size_per_block = size // num_iovs
 
-        if num_kvblocks == 1:
+        if num_iovs == 1:
             buf, ptr = _make_buffer(
                 size_per_block, args.device, args.local_gpu_idx, args.pinned
             )
@@ -574,16 +568,16 @@ def _run_client_write_ipc(args, ep, remote_gpu_idx):
                 _make_buffer(
                     size_per_block, args.device, args.local_gpu_idx, args.pinned
                 )
-                for _ in range(num_kvblocks)
+                for _ in range(num_iovs)
             ]
             ptrs = [p for _, p in bufs_ptrs]
             packed = _recv_bytes_dist(src=1)
-            blob_size = (len(packed) - 4) // num_kvblocks
+            blob_size = (len(packed) - 4) // num_iovs
             info_blobs = [
                 packed[4 + i * blob_size : 4 + (i + 1) * blob_size]
-                for i in range(num_kvblocks)
+                for i in range(num_iovs)
             ]
-            size_v = [size_per_block] * num_kvblocks
+            size_v = [size_per_block] * num_iovs
 
             # Warm-up
             if args.async_api:
@@ -612,7 +606,7 @@ def _run_client_write_ipc(args, ep, remote_gpu_idx):
                 else:
                     ok = ep.writev_ipc(conn_id, ptrs, size_v, info_blobs)
                     assert ok, "[Client] writev_ipc error"
-                total += size_per_block * num_kvblocks
+                total += size_per_block * num_iovs
 
         elapsed = time.perf_counter() - start
         gbps = (total * 8) / elapsed / 1e9
@@ -633,11 +627,11 @@ def _run_server_read_ipc(args, ep):
     ok, remote_gpu_idx, conn_id = ep.accept_local()
     assert ok, "[Server] Failed to accept local IPC connection"
 
-    num_kvblocks = args.num_kvblocks
+    num_iovs = args.num_iovs
     for size in args.sizes:
-        size_per_block = size // num_kvblocks
+        size_per_block = size // num_iovs
 
-        if num_kvblocks == 1:
+        if num_iovs == 1:
             buf, ptr = _make_buffer(size_per_block, "gpu", args.local_gpu_idx)
             ok, info_blob = ep.advertise_ipc(conn_id, ptr, size_per_block)
             assert ok, "[Server] advertise_ipc failed"
@@ -645,16 +639,14 @@ def _run_server_read_ipc(args, ep):
         else:
             bufs_ptrs = [
                 _make_buffer(size_per_block, "gpu", args.local_gpu_idx)
-                for _ in range(num_kvblocks)
+                for _ in range(num_iovs)
             ]
             ptrs = [p for _, p in bufs_ptrs]
             ok, info_blobs = ep.advertisev_ipc(
-                conn_id, ptrs, [size_per_block] * num_kvblocks
+                conn_id, ptrs, [size_per_block] * num_iovs
             )
             assert ok, "[Server] advertisev_ipc failed"
-            packed = struct.pack("I", num_kvblocks) + b"".join(
-                bytes(b) for b in info_blobs
-            )
+            packed = struct.pack("I", num_iovs) + b"".join(bytes(b) for b in info_blobs)
             _send_bytes_dist(packed, dst=0)
 
         _recv_bytes_dist(src=0)
@@ -667,11 +659,11 @@ def _run_client_read_ipc(args, ep, remote_gpu_idx):
     ok, conn_id = ep.connect_local(remote_gpu_idx)
     assert ok, "[Client] Failed to connect to local server via IPC"
 
-    num_kvblocks = args.num_kvblocks
+    num_iovs = args.num_iovs
     for size in args.sizes:
-        size_per_block = size // num_kvblocks
+        size_per_block = size // num_iovs
 
-        if num_kvblocks == 1:
+        if num_iovs == 1:
             buf, ptr = _make_buffer(
                 size_per_block, args.device, args.local_gpu_idx, args.pinned
             )
@@ -712,16 +704,16 @@ def _run_client_read_ipc(args, ep, remote_gpu_idx):
                 _make_buffer(
                     size_per_block, args.device, args.local_gpu_idx, args.pinned
                 )
-                for _ in range(num_kvblocks)
+                for _ in range(num_iovs)
             ]
             ptrs = [p for _, p in bufs_ptrs]
             packed = _recv_bytes_dist(src=1)
-            blob_size = (len(packed) - 4) // num_kvblocks
+            blob_size = (len(packed) - 4) // num_iovs
             info_blobs = [
                 packed[4 + i * blob_size : 4 + (i + 1) * blob_size]
-                for i in range(num_kvblocks)
+                for i in range(num_iovs)
             ]
-            size_v = [size_per_block] * num_kvblocks
+            size_v = [size_per_block] * num_iovs
 
             # Warm-up
             if args.async_api:
@@ -750,7 +742,7 @@ def _run_client_read_ipc(args, ep, remote_gpu_idx):
                 else:
                     ok = ep.readv_ipc(conn_id, ptrs, size_v, info_blobs)
                     assert ok, "[Client] readv_ipc error"
-                total += size_per_block * num_kvblocks
+                total += size_per_block * num_iovs
 
         elapsed = time.perf_counter() - start
         gbps = (total * 8) / elapsed / 1e9
@@ -812,14 +804,14 @@ def main():
     p.add_argument(
         "--iters",
         type=int,
-        default=10,
+        default=100,
         help="Iterations per message size (excluding 1 warm-up)",
     )
     p.add_argument(
-        "--num-kvblocks",
+        "--num-iovs",
         type=int,
         default=1,
-        help="Number of key-value blocks to send/recv in a single call",
+        help="Number of iovs to send/recv in a single call",
     )
     p.add_argument(
         "--async-api",
@@ -896,7 +888,7 @@ def main():
         "client" if rank == 0 else "server",
     )
     if not is_ipc_mode:
-        print("Number of key-value blocks per message:", args.num_kvblocks)
+        print("Number of IOVs per message:", args.num_iovs)
     else:
         # Use the rank as the local GPU index for IPC
         print(f"Using rank {rank} as local GPU index for IPC")
@@ -905,13 +897,13 @@ def main():
     print("Message sizes:", ", ".join(_pretty_size(s) for s in args.sizes))
     pinned_str = " (pinned)" if args.pinned else ""
     if is_ipc_mode:
-        kvblocks_str = (
-            f" | Blocks per call: {args.num_kvblocks}"
+        iovs_str = (
+            f" | IOVs per call: {args.num_iovs}"
             if (args.write_ipc or args.read_ipc)
             else ""
         )
         print(
-            f"Sender device: {args.sender_device}{pinned_str} | Receiver device: {args.receiver_device}{pinned_str} | Local GPU idx: {args.local_gpu_idx} | Iterations: {args.iters}{kvblocks_str}"
+            f"Sender device: {args.sender_device}{pinned_str} | Receiver device: {args.receiver_device}{pinned_str} | Local GPU idx: {args.local_gpu_idx} | Iterations: {args.iters}{iovs_str}"
         )
     else:
         print(

--- a/p2p/benchmarks/benchmark_uccl_readwrite.py
+++ b/p2p/benchmarks/benchmark_uccl_readwrite.py
@@ -302,7 +302,7 @@ def main():
             104857600,
         ],
     )
-    p.add_argument("--iters", type=int, default=10)
+    p.add_argument("--iters", type=int, default=100)
     p.add_argument("--async-api", action="store_true")
     p.add_argument(
         "--num-iovs",

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -783,9 +783,8 @@ bool Endpoint::sendv(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
     return false;
   }
 
-  std::vector<ucclRequest> ureq(num_iovs);
-  std::vector<bool> sent(num_iovs, false);
-  std::vector<bool> done(num_iovs, false);
+  ucclRequest ureq[kMaxInflightOps] = {};
+  bool done[kMaxInflightOps] = {false};
   std::vector<P2PMhandle*> mhandles(num_iovs);
 
   // Check if mhandles are all valid
@@ -797,31 +796,32 @@ bool Endpoint::sendv(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
     }
   }
 
-  while (1) {
-    for (size_t i = 0; i < num_iovs; i++) {
-      if (done[i]) continue;
-      if (!sent[i]) {
-        void* cur_data = (void*)data_v[i];
-        size_t cur_size = size_v[i];
+  size_t iov_issued = 0, iov_finished = 0;
 
-        auto mhandle = mhandles[i];
+  while (iov_finished < num_iovs) {
+    while (iov_issued < num_iovs &&
+           iov_issued - iov_finished < kMaxInflightOps) {
+      size_t slot = iov_issued % kMaxInflightOps;
+      void* cur_data = (void*)data_v[iov_issued];
+      size_t cur_size = size_v[iov_issued];
 
-        auto rc =
-            uccl_send_async(ep_, conn, mhandle, cur_data, cur_size, &ureq[i]);
-        if (rc != -1) {
-          sent[i] = true;
-        }
-      }
+      auto rc = uccl_send_async(ep_, conn, mhandles[iov_issued], cur_data,
+                                cur_size, &ureq[slot]);
+      if (rc == -1) break;
+      done[slot] = false;
+      iov_issued++;
+    }
 
-      if (sent[i] && !done[i]) {
-        if (uccl_poll_ureq_once(ep_, &ureq[i])) {
-          done[i] = true;
-        }
+    for (size_t i = iov_finished; i < iov_issued; i++) {
+      size_t slot = i % kMaxInflightOps;
+      if (done[slot]) continue;
+      if (uccl_poll_ureq_once(ep_, &ureq[slot])) {
+        done[slot] = true;
       }
     }
 
-    if (std::all_of(done.begin(), done.end(), [](bool b) { return b; })) {
-      break;
+    while (iov_finished < iov_issued && done[iov_finished % kMaxInflightOps]) {
+      iov_finished++;
     }
 
     auto _ = inside_python ? (check_python_signals(), nullptr) : nullptr;
@@ -868,9 +868,8 @@ bool Endpoint::recvv(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
     return false;
   }
 
-  std::vector<ucclRequest> ureq(num_iovs);
-  std::vector<bool> done(num_iovs, false);
-  std::vector<bool> received(num_iovs, false);
+  ucclRequest ureq[kMaxInflightOps] = {};
+  bool done[kMaxInflightOps] = {false};
   std::vector<P2PMhandle*> mhandles(num_iovs);
 
   // Check if mhandles are all valid
@@ -881,34 +880,32 @@ bool Endpoint::recvv(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
       return false;
     }
   }
-  while (1) {
-    for (size_t i = 0; i < num_iovs; i++) {
-      if (done[i]) continue;
+  size_t iov_issued = 0, iov_finished = 0;
 
-      if (!received[i]) {
-        void* cur_data = data_v[i];
-        size_t cur_size = size_v[i];
+  while (iov_finished < num_iovs) {
+    while (iov_issued < num_iovs &&
+           iov_issued - iov_finished < kMaxInflightOps) {
+      size_t slot = iov_issued % kMaxInflightOps;
+      void* cur_data = data_v[iov_issued];
+      int size_int = static_cast<int>(size_v[iov_issued]);
 
-        auto mhandle = mhandles[i];
+      auto rc = uccl_recv_async(ep_, conn, mhandles[iov_issued], &cur_data,
+                                &size_int, 1, &ureq[slot]);
+      if (rc == -1) break;
+      done[slot] = false;
+      iov_issued++;
+    }
 
-        int size_int = static_cast<int>(cur_size);
-
-        auto rc = uccl_recv_async(ep_, conn, mhandle, &cur_data, &size_int, 1,
-                                  &ureq[i]);
-        if (rc != -1) {
-          received[i] = true;
-        }
-      }
-
-      if (received[i] && !done[i]) {
-        if (uccl_poll_ureq_once(ep_, &ureq[i])) {
-          done[i] = true;
-        }
+    for (size_t i = iov_finished; i < iov_issued; i++) {
+      size_t slot = i % kMaxInflightOps;
+      if (done[slot]) continue;
+      if (uccl_poll_ureq_once(ep_, &ureq[slot])) {
+        done[slot] = true;
       }
     }
 
-    if (std::all_of(done.begin(), done.end(), [](bool b) { return b; })) {
-      break;
+    while (iov_finished < iov_issued && done[iov_finished % kMaxInflightOps]) {
+      iov_finished++;
     }
 
     auto _ = inside_python ? (check_python_signals(), nullptr) : nullptr;
@@ -1036,40 +1033,45 @@ bool Endpoint::readv(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
   }
 
   ucclRequest ureq[kMaxInflightOps] = {};
-  bool done[kMaxInflightOps] = {false};
+  bool active[kMaxInflightOps] = {false};
 
-  size_t iov_issued = 0, iov_finished = 0;
+  size_t next_iov = 0;
+  size_t num_completed = 0;
+  size_t num_inflight = 0;
 
-  while (iov_finished < num_iovs) {
-    // Issue up to kMaxInflightOps IOVs
-    while (iov_issued < num_iovs &&
-           iov_issued - iov_finished < kMaxInflightOps) {
-      P2PMhandle* mhandle = get_mhandle(mr_id_v[iov_issued]);
+  while (num_completed < num_iovs) {
+    while (next_iov < num_iovs && num_inflight < kMaxInflightOps) {
+      size_t slot = 0;
+      while (slot < kMaxInflightOps && active[slot]) {
+        slot++;
+      }
+      UCCL_DCHECK(slot < kMaxInflightOps);
+
+      P2PMhandle* mhandle = get_mhandle(mr_id_v[next_iov]);
       if (unlikely(mhandle == nullptr)) {
-        std::cerr << "[readv] Error: Invalid mr_id " << mr_id_v[iov_issued]
+        std::cerr << "[readv] Error: Invalid mr_id " << mr_id_v[next_iov]
                   << std::endl;
         return false;
       }
 
-      auto rc = uccl_read_async(ep_, conn, mhandle, dst_v[iov_issued],
-                                size_v[iov_issued], slot_item_v[iov_issued],
-                                &ureq[iov_issued % kMaxInflightOps]);
+      auto rc =
+          uccl_read_async(ep_, conn, mhandle, dst_v[next_iov], size_v[next_iov],
+                          slot_item_v[next_iov], &ureq[slot]);
       if (rc == -1) break;
-      done[iov_issued % kMaxInflightOps] = false;
-      iov_issued++;
+      active[slot] = true;
+      next_iov++;
+      num_inflight++;
     }
 
     auto _ = inside_python ? (check_python_signals(), nullptr) : nullptr;
 
-    for (size_t i = iov_finished; i < iov_issued; i++) {
-      if (done[i % kMaxInflightOps]) continue;
-      if (uccl_poll_ureq_once(ep_, &ureq[i % kMaxInflightOps])) {
-        done[i % kMaxInflightOps] = true;
+    for (size_t slot = 0; slot < kMaxInflightOps; slot++) {
+      if (!active[slot]) continue;
+      if (uccl_poll_ureq_once(ep_, &ureq[slot])) {
+        active[slot] = false;
+        num_completed++;
+        num_inflight--;
       }
-    }
-
-    while (iov_finished < iov_issued && done[iov_finished % kMaxInflightOps]) {
-      iov_finished++;
     }
   }
 
@@ -1194,39 +1196,45 @@ bool Endpoint::writev(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
   }
 
   ucclRequest ureq[kMaxInflightOps] = {};
-  bool done[kMaxInflightOps] = {false};
+  bool active[kMaxInflightOps] = {false};
 
-  size_t iov_issued = 0, iov_finished = 0;
+  size_t next_iov = 0;
+  size_t num_completed = 0;
+  size_t num_inflight = 0;
 
-  while (iov_finished < num_iovs) {
-    while (iov_issued < num_iovs &&
-           iov_issued - iov_finished < kMaxInflightOps) {
-      P2PMhandle* mhandle = get_mhandle(mr_id_v[iov_issued]);
+  while (num_completed < num_iovs) {
+    while (next_iov < num_iovs && num_inflight < kMaxInflightOps) {
+      size_t slot = 0;
+      while (slot < kMaxInflightOps && active[slot]) {
+        slot++;
+      }
+      UCCL_DCHECK(slot < kMaxInflightOps);
+
+      P2PMhandle* mhandle = get_mhandle(mr_id_v[next_iov]);
       if (unlikely(mhandle == nullptr)) {
-        std::cerr << "[writev] Error: Invalid mr_id " << mr_id_v[iov_issued]
+        std::cerr << "[writev] Error: Invalid mr_id " << mr_id_v[next_iov]
                   << std::endl;
         return false;
       }
 
-      auto rc = uccl_write_async(ep_, conn, mhandle, src_v[iov_issued],
-                                 size_v[iov_issued], slot_item_v[iov_issued],
-                                 &ureq[iov_issued % kMaxInflightOps]);
+      auto rc = uccl_write_async(ep_, conn, mhandle, src_v[next_iov],
+                                 size_v[next_iov], slot_item_v[next_iov],
+                                 &ureq[slot]);
       if (rc == -1) break;
-      done[iov_issued % kMaxInflightOps] = false;
-      iov_issued++;
+      active[slot] = true;
+      next_iov++;
+      num_inflight++;
     }
 
     auto _ = inside_python ? (check_python_signals(), nullptr) : nullptr;
 
-    for (size_t i = iov_finished; i < iov_issued; i++) {
-      if (done[i % kMaxInflightOps]) continue;
-      if (uccl_poll_ureq_once(ep_, &ureq[i % kMaxInflightOps])) {
-        done[i % kMaxInflightOps] = true;
+    for (size_t slot = 0; slot < kMaxInflightOps; slot++) {
+      if (!active[slot]) continue;
+      if (uccl_poll_ureq_once(ep_, &ureq[slot])) {
+        active[slot] = false;
+        num_completed++;
+        num_inflight--;
       }
-    }
-
-    while (iov_finished < iov_issued && done[iov_finished % kMaxInflightOps]) {
-      iov_finished++;
     }
   }
 

--- a/p2p/rdma/define.h
+++ b/p2p/rdma/define.h
@@ -550,10 +550,10 @@ typedef struct RemoteMemInfo {
 } RemoteMemInfo;
 
 typedef struct RDMARecvRequest {
-  uint32_t from_rank_id;
-  uint32_t to_rank_id;
-  uint32_t channel_id;
-  int64_t wr_id;
+  uint32_t from_rank_id = INVALID_RANK_ID;
+  uint32_t to_rank_id = INVALID_RANK_ID;
+  uint32_t channel_id = 0;
+  int64_t wr_id = -1;
   std::shared_ptr<RegMemBlock> local_mem;
   std::shared_ptr<RegMemBlock> local_compression_mem;
   CompressCtx compress_ctx;
@@ -717,12 +717,12 @@ enum class SendType { Send, Write, Read };
 struct RDMASendRequest {
   std::shared_ptr<RegMemBlock> local_mem;
   std::shared_ptr<RemoteMemInfo> remote_mem;
-  uint32_t from_rank_id;
-  uint32_t to_rank_id;
-  uint32_t channel_id;
+  uint32_t from_rank_id = INVALID_RANK_ID;
+  uint32_t to_rank_id = INVALID_RANK_ID;
+  uint32_t channel_id = 0;
   ImmData imm_data = 0;  // immediate data with chunk_count (high 16 bits) and
                          // index (low 16 bits)
-  int64_t wr_id;
+  int64_t wr_id = -1;
   bool need_signaled;  // Whether to use IBV_SEND_SIGNALED flag
   SendType send_type = SendType::Send;
   CompressCtx compress_ctx;

--- a/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.cc
+++ b/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.cc
@@ -18,12 +18,13 @@
 #define TIMEOUT 14
 #define MAX_RD_ATOMIC 1
 #define MAX_DEST_RD_ATOMIC 1
-#define MAX_CQE 1024
+static constexpr int kMaxCqe = kMaxSendWr + kMaxRecvWr;
+static constexpr uint64_t kRecvWrIdMask = 1ull << 63;
 
 inline void IBChannelImpl::initQP(std::shared_ptr<RdmaContext> ctx,
                                   struct ibv_cq_ex** cq_ex, struct ibv_qp** qp,
                                   ChannelMetaData* local_meta) {
-  *cq_ex = (struct ibv_cq_ex*)ibv_create_cq(ctx->getCtx(), MAX_CQE, nullptr,
+  *cq_ex = (struct ibv_cq_ex*)ibv_create_cq(ctx->getCtx(), kMaxCqe, nullptr,
                                             nullptr, 0);
   assert(*cq_ex);
 
@@ -185,7 +186,12 @@ inline bool IBChannelImpl::pollOnce(struct ibv_cq_ex* cq_ex,
     if (unlikely(status != IBV_WC_SUCCESS)) {
       UCCL_LOG(WARN) << "pollOnce - channel_id: " << channel_id
                      << ", CQE error, wr_id=" << wr_id << ", status=" << status
-                     << " (" << ibv_wc_status_str(status) << ")";
+                     << " (" << ibv_wc_status_str(status) << ")"
+                     << ", opcode=" << wc->opcode
+                     << ", byte_len=" << wc->byte_len << ", vendor_err=0x"
+                     << std::hex << wc->vendor_err << ", qp_num=0x"
+                     << wc->qp_num << ", wc_flags=0x" << wc->wc_flags
+                     << std::dec;
     } else {
       CQMeta cq_data{};
       cq_data.wr_id = wr_id;
@@ -256,6 +262,7 @@ inline void IBChannelImpl::initPreAllocResources() {
   pending_post_recv_ = 0;
   for (int i = 0; i < kMaxRecvWr; i++) {
     pre_alloc_recv_wrs_[i] = {};
+    pre_alloc_recv_wrs_[i].wr_id = kRecvWrIdMask | static_cast<uint64_t>(i);
     pre_alloc_recv_wrs_[i].next =
         (i == kMaxRecvWr - 1) ? nullptr : &pre_alloc_recv_wrs_[i + 1];
   }

--- a/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.h
+++ b/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.h
@@ -6,7 +6,7 @@
 class IBChannelImpl : public RDMADataChannelImpl {
  public:
   IBChannelImpl() = default;
-  ~IBChannelImpl() override = default;
+  ~IBChannelImpl() override { delete[] pre_alloc_recv_wrs_; }
 
   void initQP(std::shared_ptr<RdmaContext> ctx, struct ibv_cq_ex** cq_ex,
               struct ibv_qp** qp, ChannelMetaData* local_meta) override;

--- a/p2p/rdma/rdma_connection.h
+++ b/p2p/rdma/rdma_connection.h
@@ -169,10 +169,10 @@ class SendConnection : public RDMAConnection {
     // getTotalInflightBytes() only reflects requests actually being sent.
     int64_t wr_id = tracker_->sendPacket(0);
     req->wr_id = wr_id;
-    if (unlikely(request_queue_->push(req) < 0)) {
+    while (unlikely(request_queue_->push(req) < 0)) {
       UCCL_LOG(WARN) << "SendConnection: isend request queue is full, wr_id="
                      << wr_id;
-      return -1;
+      std::this_thread::yield();
     }
     return wr_id;
   }

--- a/p2p/rdma/rdma_ctrl_channel.h
+++ b/p2p/rdma/rdma_ctrl_channel.h
@@ -148,7 +148,11 @@ class RecvControlChannel : public RDMADataChannel {
         std::make_shared<RDMASendRequest>(local_mem_ptr_, remote_mem_ptr_,
                                           index);
     send_ptr->channel_id = kControlChannelID;
-    RDMADataChannel::send(send_ptr);
+    send_ptr->wr_id = index;
+    while (RDMADataChannel::send(send_ptr) < 0) {
+      noblockingPoll();
+      std::this_thread::yield();
+    }
     return index;
   }
 

--- a/p2p/rdma/rdma_data_channel.h
+++ b/p2p/rdma/rdma_data_channel.h
@@ -100,6 +100,7 @@ class RDMADataChannel {
     wr.num_sge = 1;
     if (ibv_post_recv(qp_, &wr, &bad_wr)) {
       UCCL_LOG(ERROR) << "ibv_post_recv failed: " << strerror(errno);
+      return -1;
     }
     return wr_id;
   }
@@ -288,8 +289,8 @@ class RDMADataChannel {
   }
 
   void initQP() {
-    impl_->initQP(ctx_, &cq_ex_, &qp_, local_meta_.get());
     impl_->initPreAllocResources();
+    impl_->initQP(ctx_, &cq_ex_, &qp_, local_meta_.get());
   }
 
   // Prepare SGE list for send request

--- a/p2p/rdma/rdma_data_channel_impl.h
+++ b/p2p/rdma/rdma_data_channel_impl.h
@@ -87,8 +87,8 @@ class RDMADataChannelImpl {
   virtual void initPreAllocResources() = 0;
 
  protected:
-  struct ibv_recv_wr* pre_alloc_recv_wrs_;
-  uint32_t pending_post_recv_;
+  struct ibv_recv_wr* pre_alloc_recv_wrs_ = nullptr;
+  uint32_t pending_post_recv_ = 0;
 };
 
 // Forward declarations for implementations


### PR DESCRIPTION
## Description

Fixes #933 

### BUGs:
1. There are sequence leaks when the request queue is full (`sendPacket(0)` increments the sequence number anyway): 
https://github.com/uccl-project/uccl/blob/main/p2p/rdma/rdma_connection.h#L170-L176
2. Same sequence leaks in the control path (send-recv negotiation): https://github.com/uccl-project/uccl/blob/main/p2p/rdma/rdma_ctrl_channel.h#L151

### Improvement:
1. Use independent slot reuse for `readv/writev` to preserve full one-sided depth; the previous implementation can't make the transfer pipeline always full. **The rationale is that elements in vectors are independent for WRITE/READ, and the transfer order doesn't matter.**
2. Limit `sendv/recvv` outstanding operations with an ordered inflight window `kMaxInflightOps` (just like WRITE/READ); **the previous implementation sends all vectors at once.**
3. Initialize IB receive WR resources before QP setup and size CQ for send+recv completions.

### Nits:
1. Rename `--num-kvblocks` in `benchmark_uccl.py` to `--num-iovs`
2. Use 100 as the default iterations for `benchmark_uccl.py` and `benchmark_uccl_readwrite.py`

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [x] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
