### PR TITLE
[EP] Add sleep mode in absence of RDMA requests

### DIFF
--- a/ep/README.md
+++ b/ep/README.md
@@ -137,7 +137,7 @@ Notes:
 | UCCL_IB_SL | Service level in RDMA network | 3/8 (IB/EFA) |
 | UCCL_IB_TC | Traffic class in RDMA network | 104/0 (IB/EFA) |
 | UCCL_EP_ENABLE_AGGRESSIVE_ATOMIC | Use relaxed atomics with manual `s_waitcnt vmcnt(0)` fences instead of acquire/release semantics. Required on AMD CDNA so the combine receiver actually sees the producer's tail-pointer updates over XGMI; without it the kernel deadlocks at scale. | 1 on AMD, 0 on CUDA |
-
+| UCCL_RDMA_ADAPTIVE_SLEEP | Enable adaptive sleeping on proxy threads, by putting the proxy threads into a sleeping state if there have been no new work requests / RDMA completion events after 120s. | null |
 
 ## Results
 

--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -328,6 +328,7 @@ class Buffer:
             hook: the receiving hook function (valid only if `return_recv_hook` is set).
         """
         for proxy in self.proxies:
+            proxy.notify_proxy_thread_adaptive_sleeper()
             proxy.calculate_and_set_dispatch_recv_data_offset(
                 num_tokens=x.shape[0],
                 hidden=x.shape[1],
@@ -502,6 +503,9 @@ class Buffer:
                 "with DeepEP and SGLang SBO callers; enabling the overlap kernel path requires "
                 "changes to internode_ll::combine() that will land in a follow-up PR."
             )
+        for proxy in self.proxies:
+            proxy.notify_proxy_thread_adaptive_sleeper()
+
         (
             src_info,
             layout_range,
@@ -935,6 +939,7 @@ class Buffer:
         # Internode
         if self.runtime.get_num_rdma_ranks() > 1:
             for proxy in self.proxies:
+                print("Notifying proxies...")
                 proxy.notify_proxy_thread_adaptive_sleeper()
 
             return self.internode_dispatch(
@@ -1260,6 +1265,7 @@ class Buffer:
         # Internode
         if self.runtime.get_num_rdma_ranks() > 1:
             for proxy in self.proxies:
+                print("Notifying proxies...")
                 proxy.notify_proxy_thread_adaptive_sleeper()
 
             return self.internode_combine(
@@ -1853,3 +1859,6 @@ class Buffer:
             num_experts,
             compute_stream_ptr,
         )
+
+    def get_proxies(self):
+        return self.proxies

--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -1857,6 +1857,3 @@ class Buffer:
             num_experts,
             compute_stream_ptr,
         )
-
-    def get_proxies(self):
-        return self.proxies

--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -934,6 +934,9 @@ class Buffer:
 
         # Internode
         if self.runtime.get_num_rdma_ranks() > 1:
+            for proxy in self.proxies:
+                proxy.notify_proxy_thread_adaptive_sleeper()
+
             return self.internode_dispatch(
                 x,
                 handle,
@@ -1256,6 +1259,9 @@ class Buffer:
 
         # Internode
         if self.runtime.get_num_rdma_ranks() > 1:
+            for proxy in self.proxies:
+                proxy.notify_proxy_thread_adaptive_sleeper()
+
             return self.internode_combine(
                 x,
                 handle,

--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -939,7 +939,6 @@ class Buffer:
         # Internode
         if self.runtime.get_num_rdma_ranks() > 1:
             for proxy in self.proxies:
-                print("Notifying proxies...")
                 proxy.notify_proxy_thread_adaptive_sleeper()
 
             return self.internode_dispatch(
@@ -1265,7 +1264,6 @@ class Buffer:
         # Internode
         if self.runtime.get_num_rdma_ranks() > 1:
             for proxy in self.proxies:
-                print("Notifying proxies...")
                 proxy.notify_proxy_thread_adaptive_sleeper()
 
             return self.internode_combine(

--- a/ep/bench/test_low_latency.py
+++ b/ep/bench/test_low_latency.py
@@ -384,6 +384,9 @@ def test_main(
                                     )
                                     _record_hash(f"combine_out|{tag}", combined_x)
 
+                                import time
+                                time.sleep(3)
+
     # noinspection PyShadowingNames
     def large_gemm_with_hook(hook):
         mat_0 = torch.randn((8192, 8192), dtype=torch.float)

--- a/ep/bench/test_low_latency.py
+++ b/ep/bench/test_low_latency.py
@@ -384,9 +384,6 @@ def test_main(
                                     )
                                     _record_hash(f"combine_out|{tag}", combined_x)
 
-                                import time
-                                time.sleep(3)
-
     # noinspection PyShadowingNames
     def large_gemm_with_hook(hook):
         mat_0 = torch.randn((8192, 8192), dtype=torch.float)

--- a/ep/include/adaptive_sleeper.hpp
+++ b/ep/include/adaptive_sleeper.hpp
@@ -1,6 +1,7 @@
 #ifndef ADAPTIVE_SLEEPER_HPP
 #define ADAPTIVE_SLEEPER_HPP
 
+#include "common.hpp"
 #include "proxy_ctx.hpp"
 #include "util/debug.h"
 #include <chrono>
@@ -9,109 +10,29 @@
 #include <sys/eventfd.h>
 #include <sys/poll.h>
 
+// to enable Adaptive Sleeper, set UCCL_RDMA_ADAPTIVE_SLEEP=1
 // handles level of sleep on the proxy thread, based on RDMA request volume
 // Adaptive sleeper states:
 // 1. POLL = no delay at all
 // 2. SLEEP = put the CPU to sleep, while letting it poll on GPU initiated
 // events and the completion events queue. This happens when there has been no
-// work for >= kNoActivityDuration
+// work for >= kNoActivityDuration (120 seconds)
 class AdaptiveSleeper {
  public:
   enum SleepState { POLL = 0, SLEEP };
 
-  AdaptiveSleeper()
-      : state_(POLL),
-        last_event_time_(std::chrono::steady_clock::time_point::min()) {
-    work_eventfd_ = eventfd(0, EFD_NONBLOCK);
-  }
+  AdaptiveSleeper();
 
-  ~AdaptiveSleeper() { close(work_eventfd_); }
+  ~AdaptiveSleeper();
 
   // decide whether or not to put the CPU to sleep based on its current
-  void maybe_sleep(ProxyCtx& proxy_ctx) {
-    int ret;
+  void maybe_sleep(ProxyCtx& proxy_ctx);
 
-    if (std::chrono::steady_clock::now() - last_event_time_ >=
-            kNoActivityThreshold &&
-        last_event_time_ != std::chrono::steady_clock::time_point::min()) {
-      UCCL_LOG(INFO, UCCL_EP) << "No activity detected for the last 30 "
-                                 "seconds, putting proxy to sleep";
+  void maybe_wake_proxy_thread();
 
-      state_ = SLEEP;
-
-      // TODO: do I have to clear anything from the completion channel if I
-      // did not ask for anything?
-      // TODO: should I check for all types of notifications (solicited only)?
-      ret = ibv_req_notify_cq(proxy_ctx.cq, 0);
-      UCCL_PCHECK(ret == 0);
-    }
-
-    if (state_ == POLL || proxy_ctx.comp_channel == nullptr) {
-      return;
-    } else if (state_ == SLEEP) {
-      UCCL_LOG(INFO, UCCL_EP) << "Sleeping proxy thread";
-
-      // continuously sleep while there are no new work entries
-      struct pollfd events_to_poll[kNumActivitiesToPoll] = {
-          {.fd = work_eventfd_, .events = POLLIN},
-          {.fd = proxy_ctx.comp_channel->fd, .events = POLLIN},
-      };
-
-      int n = ppoll(events_to_poll, kNumActivitiesToPoll, &kPollSleepDuration,
-                    NULL);
-      UCCL_PCHECK(n != -1);
-
-      if (n > 0) {
-        // handle the necessary acknowledgements for the file descriptors
-        if (events_to_poll[0].revents == POLLIN) {
-          UCCL_LOG(INFO, UCCL_EP)
-              << "Waking up because of dispatch/combine trigger";
-
-          eventfd_t work_value;
-          ret = eventfd_read(work_eventfd_, &work_value);
-          // we check for % since cumulative unread writes will add on each
-          // other
-          UCCL_CHECK(ret == 0 && work_value % kWakeEventConst == 0);
-        }
-
-        if (events_to_poll[1].revents == POLLIN) {
-          UCCL_LOG(INFO, UCCL_EP) << "Waking up because of RDMA event";
-          // TODO: need to dig into what each of these events does
-          void* ctx;
-          ibv_get_cq_event(proxy_ctx.comp_channel, &proxy_ctx.cq, &ctx);
-          // acknowledge the event to clear the notification
-          // TODO: what happens If I dont ack
-          // TODO: what happens if I ack more than I get?
-          ibv_ack_cq_events(proxy_ctx.cq, 1);
-        }
-
-        // TODO: there is some small bug that stops the second pass of bench
-        // kineto from running as quickly as it normally would does not affect
-        // correctness though
-        last_event_time_ = std::chrono::steady_clock::now();
-        state_ = POLL;
-      } else if (n == 0) {
-        UCCL_LOG(INFO, UCCL_EP)
-            << "Proxy thread woke due to poll timeout, sleeping again";
-      }
-    }
-  }
-
-  void maybe_wake_proxy_thread() {
-    int ret = eventfd_write(work_eventfd_, kWakeEventConst);
-    UCCL_CHECK(ret == 0);
-  }
-
-  void init_timer() { last_event_time_ = std::chrono::steady_clock::now(); }
-
-  std::string_view get_sleep_state() {
-    switch (state_) {
-      case (POLL):
-        return "POLL";
-      case (SLEEP):
-        return "SLEEP";
-    }
-  }
+  // this function kickk starts the inactivity timer, and is guarded by the
+  // UCCL_RDMA_ADAPTIVE_SLEEP flag
+  void init_timer();
 
  private:
   static constexpr auto kNoActivityThreshold = std::chrono::seconds(120);

--- a/ep/include/adaptive_sleeper.hpp
+++ b/ep/include/adaptive_sleeper.hpp
@@ -23,7 +23,6 @@ class AdaptiveSleeper {
       : state_(POLL),
         last_event_time_(std::chrono::steady_clock::time_point::min()) {
     work_eventfd_ = eventfd(0, EFD_NONBLOCK);
-    UCCL_LOG(INFO, UCCL_EP) << "Adaptive sleeper initialzed!";
   }
 
   ~AdaptiveSleeper() { close(work_eventfd_); }
@@ -60,11 +59,14 @@ class AdaptiveSleeper {
 
       int n = ppoll(events_to_poll, kNumActivitiesToPoll, &kPollSleepDuration,
                     NULL);
-      if (n > 0) {
-        UCCL_LOG(INFO, UCCL_EP) << "Detected new event, waking proxy thread";
+      UCCL_PCHECK(n != -1);
 
+      if (n > 0) {
         // handle the necessary acknowledgements for the file descriptors
         if (events_to_poll[0].revents == POLLIN) {
+          UCCL_LOG(INFO, UCCL_EP)
+              << "Waking up because of dispatch/combine trigger";
+
           eventfd_t work_value;
           ret = eventfd_read(work_eventfd_, &work_value);
           // we check for % since cumulative unread writes will add on each
@@ -73,6 +75,7 @@ class AdaptiveSleeper {
         }
 
         if (events_to_poll[1].revents == POLLIN) {
+          UCCL_LOG(INFO, UCCL_EP) << "Waking up because of RDMA event";
           // TODO: need to dig into what each of these events does
           void* ctx;
           ibv_get_cq_event(proxy_ctx.comp_channel, &proxy_ctx.cq, &ctx);
@@ -90,8 +93,6 @@ class AdaptiveSleeper {
       } else if (n == 0) {
         UCCL_LOG(INFO, UCCL_EP)
             << "Proxy thread woke due to poll timeout, sleeping again";
-      } else {
-        UCCL_LOG(FATAL) << "Encountered ppoll error";
       }
     }
   }
@@ -113,14 +114,15 @@ class AdaptiveSleeper {
   }
 
  private:
-  //  TODO: change back to 30 seconds after testing
-  static constexpr auto kNoActivityThreshold = std::chrono::seconds(10);
+  static constexpr auto kNoActivityThreshold = std::chrono::seconds(120);
   static constexpr int kNumActivitiesToPoll = 2;
-  static constexpr struct timespec kPollSleepDuration = {.tv_sec = 5};
+  static constexpr struct timespec kPollSleepDuration = {
+      .tv_sec = 5,
+      .tv_nsec = 0,
+  };
   static constexpr int kWakeEventConst = 0x42;
 
   SleepState state_;
-  // used by python API to inform proxy threads of new work entry
   int work_eventfd_;
   std::chrono::steady_clock::time_point last_event_time_;
 };

--- a/ep/include/adaptive_sleeper.hpp
+++ b/ep/include/adaptive_sleeper.hpp
@@ -71,7 +71,9 @@ class AdaptiveSleeper {
           // we check for % since cumulative unread writes will add on each
           // other
           UCCL_CHECK(ret == 0 && work_value % kWakeEventConst == 0);
-        } else if (events_to_poll[1].revents == POLLIN) {
+        } 
+        
+        if (events_to_poll[1].revents == POLLIN) {
           // TODO: need to dig into what each of these events does
           void* ctx;
           ibv_get_cq_event(proxy_ctx.comp_channel, &proxy_ctx.cq, &ctx);

--- a/ep/include/adaptive_sleeper.hpp
+++ b/ep/include/adaptive_sleeper.hpp
@@ -1,13 +1,13 @@
 #ifndef ADAPTIVE_SLEEPER_HPP
 #define ADAPTIVE_SLEEPER_HPP
 
-#include <sys/eventfd.h>
-#include <sys/poll.h>
+#include "proxy_ctx.hpp"
+#include "util/debug.h"
 #include <chrono>
 #include <ctime>
 #include <string_view>
-#include "util/debug.h"
-#include "proxy_ctx.hpp"
+#include <sys/eventfd.h>
+#include <sys/poll.h>
 
 // handles level of sleep on the proxy thread, based on RDMA request volume
 // Adaptive sleeper states:
@@ -23,83 +23,83 @@ class AdaptiveSleeper {
       : state_(POLL),
         last_event_time_(std::chrono::steady_clock::time_point::min()) {
     work_eventfd_ = eventfd(0, EFD_NONBLOCK);
+    UCCL_LOG(INFO, UCCL_EP) << "Adaptive sleeper initialzed!";
+  }
+
+  ~AdaptiveSleeper() {
+    close(work_eventfd_);
   }
 
   // decide whether or not to put the CPU to sleep based on its current
   void maybe_sleep(ProxyCtx& proxy_ctx) {
     int ret;
 
-    if (state_ == POLL &&
-        std::chrono::steady_clock::now() - last_event_time_ >=
-            kNoActivityThreshold &&
-        last_event_time_ != std::chrono::steady_clock::time_point::min()) {
+    if (std::chrono::steady_clock::now() - last_event_time_ >=
+            kNoActivityThreshold && last_event_time_ != std::chrono::steady_clock::time_point::min()) {
       UCCL_LOG(INFO, UCCL_EP) << "No activity detected for the last 30 "
                                  "seconds, putting proxy to sleep";
-
+                                 
       state_ = SLEEP;
 
-      // clear all pending notifications from the notification channels and arm
-      // them
-      eventfd_t event_fd_buffer;
-      ret = eventfd_read(work_eventfd_, &event_fd_buffer);
-      UCCL_CHECK(ret == 0);
-
-      // TODO: do I have to clear anything from the completion channel if I did
-      // not ask for anything?
+      // TODO: do I have to clear anything from the completion channel if I
+      // did not ask for anything?
       // TODO: should I check for all types of notifications (solicited only)?
       ret = ibv_req_notify_cq(proxy_ctx.cq, 0);
-      UCCL_CHECK(ret == 0);
+      UCCL_PCHECK(ret == 0);
     }
 
-    if (state_ == POLL) {
+    if (state_ == POLL || proxy_ctx.comp_channel == nullptr) {
       return;
     } else if (state_ == SLEEP) {
       UCCL_LOG(INFO, UCCL_EP) << "Sleeping proxy thread";
 
       // continuously sleep while there are no new work entries
-      while (true) {
-        struct pollfd events_to_poll[kNumActivitiesToPoll] = {
-            {.fd = work_eventfd_, .events = POLLIN},
-            {.fd = proxy_ctx.comp_channel->fd, .events = POLLIN}};
+      struct pollfd events_to_poll[kNumActivitiesToPoll] = {
+          {.fd = work_eventfd_, .events = POLLIN},
+          {.fd = proxy_ctx.comp_channel->fd, .events = POLLIN},
+      };
 
-        int n = ppoll(events_to_poll, kNumActivitiesToPoll, &kPollSleepDuration,
-                      NULL);
-        if (n > 0) {
-          UCCL_LOG(INFO, UCCL_EP) << "Detected new event, waking proxy thread";
+      int n = ppoll(events_to_poll, kNumActivitiesToPoll, &kPollSleepDuration,
+                    NULL);
+      if (n > 0) {
+        UCCL_LOG(INFO, UCCL_EP) << "Detected new event, waking proxy thread";
 
-          // handle the necessary acknowledgements for the file descriptors
-          if (events_to_poll[0].revents == POLLIN) {
-            eventfd_t work_value;
-            ret = eventfd_read(work_eventfd_, &work_value);
-            UCCL_CHECK(ret == 0 && work_value == kWakeEventConst);
-          } else if (events_to_poll[1].revents == POLLIN) {
-            // TODO: need to dig into what each of these events does
-            void* ctx;
-            ibv_get_cq_event(proxy_ctx.comp_channel, &proxy_ctx.cq, &ctx);
-            // acknowledge the event to clear the notification
-            // TODO: what happens If I dont ack
-            // TODO: what happens if I ack more than I get?
-            ibv_ack_cq_events(proxy_ctx.cq, 1);
-          }
-
-          state_ = POLL;
-          return;
-        } else if (n == 0) {
-          UCCL_LOG(INFO, UCCL_EP)
-              << "Proxy thread woke due to poll timeout, sleeping again";
-        } else {
-          UCCL_LOG(FATAL) << "Encountered ppoll error";
+        // handle the necessary acknowledgements for the file descriptors
+        if (events_to_poll[0].revents == POLLIN) {
+          eventfd_t work_value;
+          ret = eventfd_read(work_eventfd_, &work_value);
+          // we check for % since cumulative unread writes will add on each
+          // other
+          UCCL_CHECK(ret == 0 && work_value % kWakeEventConst == 0);
+        } else if (events_to_poll[1].revents == POLLIN) {
+          // TODO: need to dig into what each of these events does
+          void* ctx;
+          ibv_get_cq_event(proxy_ctx.comp_channel, &proxy_ctx.cq, &ctx);
+          // acknowledge the event to clear the notification
+          // TODO: what happens If I dont ack
+          // TODO: what happens if I ack more than I get?
+          ibv_ack_cq_events(proxy_ctx.cq, 1);
         }
+
+        // TODO: there is some small bug that stops the second pass of bench kineto from running as quickly as it normally would
+        // does not affect correctness though
+        last_event_time_ = std::chrono::steady_clock::now();
+        state_ = POLL;
+      } else if (n == 0) {
+         UCCL_LOG(INFO, UCCL_EP)
+              << "Proxy thread woke due to poll timeout, sleeping again";
+      } else {
+        UCCL_LOG(FATAL) << "Encountered ppoll error";
       }
     }
   }
 
   void maybe_wake_proxy_thread() {
-    // TODO: what happens if you write multiple times to the same eventfd: will
-    // the value just overwrite?
     int ret = eventfd_write(work_eventfd_, kWakeEventConst);
     UCCL_CHECK(ret == 0);
+}
 
+  void init_timer() {
     last_event_time_ = std::chrono::steady_clock::now();
   }
 
@@ -113,7 +113,8 @@ class AdaptiveSleeper {
   }
 
  private:
-  static constexpr auto kNoActivityThreshold = std::chrono::seconds(30);
+  //  TODO: change back to 30 seconds after testing
+  static constexpr auto kNoActivityThreshold = std::chrono::seconds(2);
   static constexpr int kNumActivitiesToPoll = 2;
   static constexpr struct timespec kPollSleepDuration = {.tv_sec = 5};
   static constexpr int kWakeEventConst = 0x42;

--- a/ep/include/adaptive_sleeper.hpp
+++ b/ep/include/adaptive_sleeper.hpp
@@ -1,0 +1,127 @@
+#ifndef ADAPTIVE_SLEEPER_HPP
+#define ADAPTIVE_SLEEPER_HPP
+
+#include <sys/eventfd.h>
+#include <sys/poll.h>
+#include <chrono>
+#include <ctime>
+#include <string_view>
+#include "util/debug.h"
+#include "proxy_ctx.hpp"
+
+// handles level of sleep on the proxy thread, based on RDMA request volume
+// Adaptive sleeper states:
+// 1. POLL = no delay at all
+// 2. SLEEP = put the CPU to sleep, while letting it poll on GPU initiated
+// events and the completion events queue. This happens when there has been no
+// work for >= kNoActivityDuration
+class AdaptiveSleeper {
+ public:
+  enum SleepState { POLL = 0, SLEEP };
+
+  AdaptiveSleeper()
+      : state_(POLL),
+        last_event_time_(std::chrono::steady_clock::time_point::min()) {
+    work_eventfd_ = eventfd(0, EFD_NONBLOCK);
+  }
+
+  // decide whether or not to put the CPU to sleep based on its current
+  void maybe_sleep(ProxyCtx& proxy_ctx) {
+    int ret;
+
+    if (state_ == POLL &&
+        std::chrono::steady_clock::now() - last_event_time_ >=
+            kNoActivityThreshold &&
+        last_event_time_ != std::chrono::steady_clock::time_point::min()) {
+      UCCL_LOG(INFO, UCCL_EP) << "No activity detected for the last 30 "
+                                 "seconds, putting proxy to sleep";
+
+      state_ = SLEEP;
+
+      // clear all pending notifications from the notification channels and arm
+      // them
+      eventfd_t event_fd_buffer;
+      ret = eventfd_read(work_eventfd_, &event_fd_buffer);
+      UCCL_CHECK(ret == 0);
+
+      // TODO: do I have to clear anything from the completion channel if I did
+      // not ask for anything?
+      // TODO: should I check for all types of notifications (solicited only)?
+      ret = ibv_req_notify_cq(proxy_ctx.cq, 0);
+      UCCL_CHECK(ret == 0);
+    }
+
+    if (state_ == POLL) {
+      return;
+    } else if (state_ == SLEEP) {
+      UCCL_LOG(INFO, UCCL_EP) << "Sleeping proxy thread";
+
+      // continuously sleep while there are no new work entries
+      while (true) {
+        struct pollfd events_to_poll[kNumActivitiesToPoll] = {
+            {.fd = work_eventfd_, .events = POLLIN},
+            {.fd = proxy_ctx.comp_channel->fd, .events = POLLIN}};
+
+        int n = ppoll(events_to_poll, kNumActivitiesToPoll, &kPollSleepDuration,
+                      NULL);
+        if (n > 0) {
+          UCCL_LOG(INFO, UCCL_EP) << "Detected new event, waking proxy thread";
+
+          // handle the necessary acknowledgements for the file descriptors
+          if (events_to_poll[0].revents == POLLIN) {
+            eventfd_t work_value;
+            ret = eventfd_read(work_eventfd_, &work_value);
+            UCCL_CHECK(ret == 0 && work_value == kWakeEventConst);
+          } else if (events_to_poll[1].revents == POLLIN) {
+            // TODO: need to dig into what each of these events does
+            void* ctx;
+            ibv_get_cq_event(proxy_ctx.comp_channel, &proxy_ctx.cq, &ctx);
+            // acknowledge the event to clear the notification
+            // TODO: what happens If I dont ack
+            // TODO: what happens if I ack more than I get?
+            ibv_ack_cq_events(proxy_ctx.cq, 1);
+          }
+
+          state_ = POLL;
+          return;
+        } else if (n == 0) {
+          UCCL_LOG(INFO, UCCL_EP)
+              << "Proxy thread woke due to poll timeout, sleeping again";
+        } else {
+          UCCL_LOG(FATAL) << "Encountered ppoll error";
+        }
+      }
+    }
+  }
+
+  void maybe_wake_proxy_thread() {
+    // TODO: what happens if you write multiple times to the same eventfd: will
+    // the value just overwrite?
+    int ret = eventfd_write(work_eventfd_, kWakeEventConst);
+    UCCL_CHECK(ret == 0);
+
+    last_event_time_ = std::chrono::steady_clock::now();
+  }
+
+  std::string_view get_sleep_state() {
+    switch (state_) {
+      case (POLL):
+        return "POLL";
+      case (SLEEP):
+        return "SLEEP";
+    }
+  }
+
+ private:
+  static constexpr auto kNoActivityThreshold = std::chrono::seconds(30);
+  static constexpr int kNumActivitiesToPoll = 2;
+  static constexpr struct timespec kPollSleepDuration = {.tv_sec = 5};
+  static constexpr int kWakeEventConst = 0x42;
+
+  SleepState state_;
+  // used by python API to inform proxy threads of new work entry
+  int work_eventfd_;
+  std::chrono::steady_clock::time_point last_event_time_;
+};
+
+#endif

--- a/ep/include/adaptive_sleeper.hpp
+++ b/ep/include/adaptive_sleeper.hpp
@@ -26,19 +26,18 @@ class AdaptiveSleeper {
     UCCL_LOG(INFO, UCCL_EP) << "Adaptive sleeper initialzed!";
   }
 
-  ~AdaptiveSleeper() {
-    close(work_eventfd_);
-  }
+  ~AdaptiveSleeper() { close(work_eventfd_); }
 
   // decide whether or not to put the CPU to sleep based on its current
   void maybe_sleep(ProxyCtx& proxy_ctx) {
     int ret;
 
     if (std::chrono::steady_clock::now() - last_event_time_ >=
-            kNoActivityThreshold && last_event_time_ != std::chrono::steady_clock::time_point::min()) {
+            kNoActivityThreshold &&
+        last_event_time_ != std::chrono::steady_clock::time_point::min()) {
       UCCL_LOG(INFO, UCCL_EP) << "No activity detected for the last 30 "
                                  "seconds, putting proxy to sleep";
-                                 
+
       state_ = SLEEP;
 
       // TODO: do I have to clear anything from the completion channel if I
@@ -71,8 +70,8 @@ class AdaptiveSleeper {
           // we check for % since cumulative unread writes will add on each
           // other
           UCCL_CHECK(ret == 0 && work_value % kWakeEventConst == 0);
-        } 
-        
+        }
+
         if (events_to_poll[1].revents == POLLIN) {
           // TODO: need to dig into what each of these events does
           void* ctx;
@@ -83,13 +82,14 @@ class AdaptiveSleeper {
           ibv_ack_cq_events(proxy_ctx.cq, 1);
         }
 
-        // TODO: there is some small bug that stops the second pass of bench kineto from running as quickly as it normally would
-        // does not affect correctness though
+        // TODO: there is some small bug that stops the second pass of bench
+        // kineto from running as quickly as it normally would does not affect
+        // correctness though
         last_event_time_ = std::chrono::steady_clock::now();
         state_ = POLL;
       } else if (n == 0) {
-         UCCL_LOG(INFO, UCCL_EP)
-              << "Proxy thread woke due to poll timeout, sleeping again";
+        UCCL_LOG(INFO, UCCL_EP)
+            << "Proxy thread woke due to poll timeout, sleeping again";
       } else {
         UCCL_LOG(FATAL) << "Encountered ppoll error";
       }
@@ -99,11 +99,9 @@ class AdaptiveSleeper {
   void maybe_wake_proxy_thread() {
     int ret = eventfd_write(work_eventfd_, kWakeEventConst);
     UCCL_CHECK(ret == 0);
-}
-
-  void init_timer() {
-    last_event_time_ = std::chrono::steady_clock::now();
   }
+
+  void init_timer() { last_event_time_ = std::chrono::steady_clock::now(); }
 
   std::string_view get_sleep_state() {
     switch (state_) {
@@ -116,7 +114,7 @@ class AdaptiveSleeper {
 
  private:
   //  TODO: change back to 30 seconds after testing
-  static constexpr auto kNoActivityThreshold = std::chrono::seconds(2);
+  static constexpr auto kNoActivityThreshold = std::chrono::seconds(10);
   static constexpr int kNumActivitiesToPoll = 2;
   static constexpr struct timespec kPollSleepDuration = {.tv_sec = 5};
   static constexpr int kWakeEventConst = 0x42;

--- a/ep/include/proxy.hpp
+++ b/ep/include/proxy.hpp
@@ -23,6 +23,7 @@
 #include <deque>
 #include <set>
 #include <tuple>
+#include "adaptive_sleeper.hpp"
 
 struct PeerMeta {
   int rank;
@@ -87,9 +88,14 @@ class Proxy {
   CopyRingBuffer ring;
   Config cfg_;
 
+  void notify_proxy_thread_adaptive_sleeper() {
+    adaptive_sleeper_.maybe_wake_proxy_thread();
+  }
+
  private:
   friend class FifoProxy;  // Allow FifoProxy to access private methods
   ProxyCtx ctx_;
+  AdaptiveSleeper adaptive_sleeper_;
   void init_common();
   void init_sender();
   void init_remote();

--- a/ep/include/proxy.hpp
+++ b/ep/include/proxy.hpp
@@ -19,11 +19,11 @@
 #if defined(__x86_64__) || defined(__i386__)
 #include <immintrin.h>
 #endif
+#include "adaptive_sleeper.hpp"
 #include "d2h_queue_host.hpp"
 #include <deque>
 #include <set>
 #include <tuple>
-#include "adaptive_sleeper.hpp"
 
 struct PeerMeta {
   int rank;

--- a/ep/include/proxy_ctx.hpp
+++ b/ep/include/proxy_ctx.hpp
@@ -66,6 +66,7 @@ struct ProxyCtx {
   ibv_pd* pd = nullptr;
   ibv_mr* mr = nullptr;
   ibv_cq* cq = nullptr;
+  ibv_comp_channel* comp_channel = nullptr;
   ibv_cq_ex* cq_ex = nullptr;
   ibv_qp* qp = nullptr;
   std::vector<ibv_qp*> data_qps_by_channel;

--- a/ep/include/rdma.hpp
+++ b/ep/include/rdma.hpp
@@ -358,6 +358,7 @@ void create_per_thread_qp(ProxyCtx& S, void* gpu_buffer, size_t size,
                           size_t num_rings, bool use_normal_mode,
                           void* atomic_buffer_ptr = nullptr);
 ibv_cq* create_per_thread_cq(ProxyCtx& S);
+ibv_comp_channel* create_per_thread_comp_channel(ProxyCtx& S);
 void remote_poll_completions(ProxyCtx& S, int idx, CopyRingBuffer& g_ring,
                              std::vector<ProxyCtx*>& ctx_by_tag,
                              void* atomic_buffer_ptr, int num_ranks,

--- a/ep/include/uccl_proxy.hpp
+++ b/ep/include/uccl_proxy.hpp
@@ -77,6 +77,9 @@ class UcclProxy {
   void set_bench_d2h_channel_addrs(std::vector<uintptr_t> const& addrs) {
     proxy_->set_bench_d2h_channel_addrs(addrs);
   }
+  void notify_proxy_thread_adaptive_sleeper() {
+    proxy_->notify_proxy_thread_adaptive_sleeper();
+  }
 
  private:
   enum class Mode { None, Sender, Remote, Local, Dual };

--- a/ep/src/adaptive_sleeper.cc
+++ b/ep/src/adaptive_sleeper.cc
@@ -1,0 +1,95 @@
+#include "adaptive_sleeper.hpp"
+#include "util/debug.h"
+#include <cstring>
+
+AdaptiveSleeper::AdaptiveSleeper()
+    : state_(POLL),
+      last_event_time_(std::chrono::steady_clock::time_point::min()) {
+  work_eventfd_ = eventfd(0, EFD_NONBLOCK);
+}
+
+AdaptiveSleeper::~AdaptiveSleeper() { close(work_eventfd_); }
+
+void AdaptiveSleeper::maybe_sleep(ProxyCtx& proxy_ctx) {
+  int ret;
+
+  if (std::chrono::steady_clock::now() - last_event_time_ >=
+          kNoActivityThreshold &&
+      last_event_time_ != std::chrono::steady_clock::time_point::min()) {
+    UCCL_LOG(INFO, UCCL_EP) << "No activity detected for the last 30 "
+                               "seconds, putting proxy to sleep";
+
+    state_ = SLEEP;
+
+    // TODO: do I have to clear anything from the completion channel if I
+    // did not ask for anything?
+    // TODO: should I check for all types of notifications (solicited only)?
+    ret = ibv_req_notify_cq(proxy_ctx.cq, 0);
+    UCCL_PCHECK(ret == 0);
+  }
+
+  if (state_ == POLL || proxy_ctx.comp_channel == nullptr) {
+    return;
+  } else if (state_ == SLEEP) {
+    UCCL_LOG(INFO, UCCL_EP) << "Sleeping proxy thread";
+
+    // continuously sleep while there are no new work entries
+    struct pollfd events_to_poll[kNumActivitiesToPoll] = {
+        {.fd = work_eventfd_, .events = POLLIN},
+        {.fd = proxy_ctx.comp_channel->fd, .events = POLLIN},
+    };
+
+    int n =
+        ppoll(events_to_poll, kNumActivitiesToPoll, &kPollSleepDuration, NULL);
+    UCCL_PCHECK(n != -1);
+
+    if (n > 0) {
+      // handle the necessary acknowledgements for the file descriptors
+      if (events_to_poll[0].revents == POLLIN) {
+        UCCL_LOG(INFO, UCCL_EP)
+            << "Waking up because of dispatch/combine trigger";
+
+        eventfd_t work_value;
+        ret = eventfd_read(work_eventfd_, &work_value);
+        // we check for % since cumulative unread writes will add on each
+        // other
+        UCCL_CHECK(ret == 0 && work_value % kWakeEventConst == 0);
+      }
+
+      if (events_to_poll[1].revents == POLLIN) {
+        UCCL_LOG(INFO, UCCL_EP) << "Waking up because of RDMA event";
+        // TODO: need to dig into what each of these events does
+        void* ctx;
+        ibv_get_cq_event(proxy_ctx.comp_channel, &proxy_ctx.cq, &ctx);
+        // acknowledge the event to clear the notification
+        // TODO: what happens If I dont ack
+        // TODO: what happens if I ack more than I get?
+        ibv_ack_cq_events(proxy_ctx.cq, 1);
+      }
+
+      // TODO: there is some small bug that stops the second pass of bench
+      // kineto from running as quickly as it normally would does not affect
+      // correctness though
+      last_event_time_ = std::chrono::steady_clock::now();
+      state_ = POLL;
+    } else if (n == 0) {
+      UCCL_LOG(INFO, UCCL_EP)
+          << "Proxy thread woke due to poll timeout, sleeping again";
+    }
+  }
+}
+
+void AdaptiveSleeper::maybe_wake_proxy_thread() {
+  int ret = eventfd_write(work_eventfd_, kWakeEventConst);
+  UCCL_CHECK(ret == 0);
+}
+
+void AdaptiveSleeper::init_timer() {
+  char const* is_adaptive_sleep = std::getenv("UCCL_RDMA_ADAPTIVE_SLEEP");
+  if (is_adaptive_sleep && strcmp(is_adaptive_sleep, "1") == 0) {
+    UCCL_LOG(INFO, UCCL_EP) << "Adaptive sleeper configured";
+    last_event_time_ = std::chrono::steady_clock::now();
+  } else {
+    UCCL_LOG(WARN) << "This was not enabled " << is_adaptive_sleep;
+  }
+}

--- a/ep/src/adaptive_sleeper.cc
+++ b/ep/src/adaptive_sleeper.cc
@@ -79,7 +79,5 @@ void AdaptiveSleeper::init_timer() {
   if (is_adaptive_sleep && strcmp(is_adaptive_sleep, "1") == 0) {
     UCCL_LOG(INFO, UCCL_EP) << "Adaptive sleeper configured";
     last_event_time_ = std::chrono::steady_clock::now();
-  } else {
-    UCCL_LOG(WARN) << "This was not enabled " << is_adaptive_sleep;
   }
 }

--- a/ep/src/adaptive_sleeper.cc
+++ b/ep/src/adaptive_sleeper.cc
@@ -16,7 +16,7 @@ void AdaptiveSleeper::maybe_sleep(ProxyCtx& proxy_ctx) {
   if (std::chrono::steady_clock::now() - last_event_time_ >=
           kNoActivityThreshold &&
       last_event_time_ != std::chrono::steady_clock::time_point::min()) {
-    UCCL_LOG(INFO, UCCL_EP) << "No activity detected for the last 30 "
+    UCCL_LOG(INFO, UCCL_EP) << "No activity detected for the last 120 "
                                "seconds, putting proxy to sleep";
 
     state_ = SLEEP;

--- a/ep/src/adaptive_sleeper.cc
+++ b/ep/src/adaptive_sleeper.cc
@@ -21,9 +21,6 @@ void AdaptiveSleeper::maybe_sleep(ProxyCtx& proxy_ctx) {
 
     state_ = SLEEP;
 
-    // TODO: do I have to clear anything from the completion channel if I
-    // did not ask for anything?
-    // TODO: should I check for all types of notifications (solicited only)?
     ret = ibv_req_notify_cq(proxy_ctx.cq, 0);
     UCCL_PCHECK(ret == 0);
   }
@@ -44,7 +41,6 @@ void AdaptiveSleeper::maybe_sleep(ProxyCtx& proxy_ctx) {
     UCCL_PCHECK(n != -1);
 
     if (n > 0) {
-      // handle the necessary acknowledgements for the file descriptors
       if (events_to_poll[0].revents == POLLIN) {
         UCCL_LOG(INFO, UCCL_EP)
             << "Waking up because of dispatch/combine trigger";
@@ -58,18 +54,12 @@ void AdaptiveSleeper::maybe_sleep(ProxyCtx& proxy_ctx) {
 
       if (events_to_poll[1].revents == POLLIN) {
         UCCL_LOG(INFO, UCCL_EP) << "Waking up because of RDMA event";
-        // TODO: need to dig into what each of these events does
         void* ctx;
         ibv_get_cq_event(proxy_ctx.comp_channel, &proxy_ctx.cq, &ctx);
         // acknowledge the event to clear the notification
-        // TODO: what happens If I dont ack
-        // TODO: what happens if I ack more than I get?
         ibv_ack_cq_events(proxy_ctx.cq, 1);
       }
 
-      // TODO: there is some small bug that stops the second pass of bench
-      // kineto from running as quickly as it normally would does not affect
-      // correctness though
       last_event_time_ = std::chrono::steady_clock::now();
       state_ = POLL;
     } else if (n == 0) {

--- a/ep/src/proxy.cpp
+++ b/ep/src/proxy.cpp
@@ -2,6 +2,7 @@
 #include "bench_utils.hpp"
 #include "d2h_queue_host.hpp"
 #include "ep_util.hpp"
+#include "rdma.hpp"
 #include "util/util.h"
 #include <arpa/inet.h>  // for htonl, ntohl
 #include <chrono>
@@ -188,7 +189,10 @@ void Proxy::init_common() {
   per_thread_rdma_init(ctx_, cfg_.gpu_buffer, cfg_.total_size, my_rank,
                        cfg_.thread_idx, cfg_.local_rank);
   pin_thread_to_numa_wrapper();
-  if (!get_cq(ctx_)) (void)create_per_thread_cq(ctx_);
+  if (!get_cq(ctx_)) {
+    (void)create_per_thread_cq(ctx_);
+    (void)create_per_thread_comp_channel(ctx_);
+  }
 
   // Register atomic_buffer_ptr as a separate RDMA memory region if it was set
   // This must be done after PD is initialized by per_thread_rdma_init
@@ -571,6 +575,8 @@ void Proxy::run_dual() {
   size_t seen = 0;
   std::set<PendingUpdate> pending_atomic_updates;
   while (ctx_.progress_run.load(std::memory_order_acquire)) {
+    adaptive_sleeper_.maybe_sleep(ctx_);
+    
     poll_cq_dual(ctx_, acked_wrs_, cfg_.thread_idx, ring, ctx_by_tag_,
                  atomic_buffer_ptr_, cfg_.num_ranks, cfg_.num_experts,
                  pending_atomic_updates, cfg_.rank, cfg_.num_nodes,

--- a/ep/src/proxy.cpp
+++ b/ep/src/proxy.cpp
@@ -743,12 +743,9 @@ void Proxy::post_gpu_command(uint64_t& my_tail, size_t& seen) {
     // Force load head from DRAM (like original code)
     uint64_t cur_head = h->volatile_head();
     if (cur_head == ring_tail) {
-      std::cout << "There is no more work to be done from GPU side queue\n";
-
       continue;  // No new work in this ring
     }
 
-    std::cout << "There is more work to be done from GPU side queue\n";
     // Batch processing for this ring buffer
     size_t batch_size = cur_head - ring_seen;
     if (batch_size == 0) continue;

--- a/ep/src/proxy.cpp
+++ b/ep/src/proxy.cpp
@@ -190,8 +190,8 @@ void Proxy::init_common() {
                        cfg_.thread_idx, cfg_.local_rank);
   pin_thread_to_numa_wrapper();
   if (!get_cq(ctx_)) {
-    (void)create_per_thread_cq(ctx_);
     (void)create_per_thread_comp_channel(ctx_);
+    (void)create_per_thread_cq(ctx_);
   }
 
   // Register atomic_buffer_ptr as a separate RDMA memory region if it was set
@@ -743,9 +743,12 @@ void Proxy::post_gpu_command(uint64_t& my_tail, size_t& seen) {
     // Force load head from DRAM (like original code)
     uint64_t cur_head = h->volatile_head();
     if (cur_head == ring_tail) {
+      std::cout << "There is no more work to be done from GPU side queue\n";
+
       continue;  // No new work in this ring
     }
 
+    std::cout << "There is more work to be done from GPU side queue\n";
     // Batch processing for this ring buffer
     size_t batch_size = cur_head - ring_seen;
     if (batch_size == 0) continue;

--- a/ep/src/proxy.cpp
+++ b/ep/src/proxy.cpp
@@ -577,7 +577,7 @@ void Proxy::run_dual() {
   adaptive_sleeper_.init_timer();
   while (ctx_.progress_run.load(std::memory_order_acquire)) {
     adaptive_sleeper_.maybe_sleep(ctx_);
-    
+
     poll_cq_dual(ctx_, acked_wrs_, cfg_.thread_idx, ring, ctx_by_tag_,
                  atomic_buffer_ptr_, cfg_.num_ranks, cfg_.num_experts,
                  pending_atomic_updates, cfg_.rank, cfg_.num_nodes,

--- a/ep/src/proxy.cpp
+++ b/ep/src/proxy.cpp
@@ -574,6 +574,7 @@ void Proxy::run_dual() {
   uint64_t my_tail = 0;
   size_t seen = 0;
   std::set<PendingUpdate> pending_atomic_updates;
+  adaptive_sleeper_.init_timer();
   while (ctx_.progress_run.load(std::memory_order_acquire)) {
     adaptive_sleeper_.maybe_sleep(ctx_);
     

--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -852,7 +852,7 @@ ibv_cq* create_per_thread_cq(ProxyCtx& S) {
   struct ibv_cq_init_attr_ex cq_ex_attr = {};
   cq_ex_attr.cqe = cq_depth;
   cq_ex_attr.cq_context = nullptr;
-  cq_ex_attr.channel = nullptr;
+  cq_ex_attr.channel = S.comp_channel;
   cq_ex_attr.comp_vector = 0;
   cq_ex_attr.comp_mask = 0;
   cq_ex_attr.flags = 0;
@@ -885,8 +885,6 @@ ibv_cq* create_per_thread_cq(ProxyCtx& S) {
 }
 
 ibv_comp_channel* create_per_thread_comp_channel(ProxyCtx& S) {
-  // TODO(Shawn): check if there are different cases for EFA (which already has
-  // cq_ext)
   S.comp_channel = ibv_create_comp_channel(S.context);
 
   if (!S.comp_channel) {

--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -40,6 +40,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
+#include <fcntl.h>
 #include <stdio.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -887,9 +888,16 @@ ibv_comp_channel* create_per_thread_comp_channel(ProxyCtx& S) {
   // TODO(Shawn): check if there are different cases for EFA (which already has
   // cq_ext)
   S.comp_channel = ibv_create_comp_channel(S.context);
+
   if (!S.comp_channel) {
     UCCL_LOG(FATAL) << "Could not allocate completion channel";
   }
+
+  // make the channel nonblocking
+  int flags = fcntl(S.comp_channel->fd, F_GETFL, 0);
+  UCCL_PCHECK(flags != -1);
+  int ret = fcntl(S.comp_channel->fd, F_SETFL, flags | O_NONBLOCK);
+  UCCL_PCHECK(ret != -1);
 
   return S.comp_channel;
 }

--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -875,7 +875,7 @@ ibv_cq* create_per_thread_cq(ProxyCtx& S) {
   return ibv_cq_ex_to_cq(S.cq_ex);
 #else
   // Use standard CQ for other NICs like Broadcom
-  S.cq = ibv_create_cq(S.context, cq_depth, nullptr, nullptr, 0);
+  S.cq = ibv_create_cq(S.context, cq_depth, nullptr, S.comp_channel, 0);
   if (!S.cq) {
     perror("Failed to create CQ (ibv_create_cq)");
     exit(1);

--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -3,6 +3,7 @@
 #include "proxy_ctx.hpp"
 #include "rdma_util.hpp"
 #include "util/gpu_rt.h"
+#include <infiniband/verbs.h>
 #ifdef USE_DMABUF
 #include <condition_variable>
 #include <map>
@@ -33,6 +34,7 @@
 #include <immintrin.h>
 #endif
 #include "bench_utils.hpp"
+#include "util/debug.h"
 #include "util/util.h"
 #include <atomic>
 #include <cassert>
@@ -879,6 +881,17 @@ ibv_cq* create_per_thread_cq(ProxyCtx& S) {
   }
   return S.cq;
 #endif
+}
+
+ibv_comp_channel* create_per_thread_comp_channel(ProxyCtx& S) {
+  // TODO(Shawn): check if there are different cases for EFA (which already has
+  // cq_ext)
+  S.comp_channel = ibv_create_comp_channel(S.context);
+  if (!S.comp_channel) {
+    UCCL_LOG(FATAL) << "Could not allocate completion channel";
+  }
+
+  return S.comp_channel;
 }
 
 #ifdef EFA

--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -2382,7 +2382,8 @@ NB_MODULE(ep, m) {
             self.set_bench_d2h_channel_addrs(v);
           },
           nb::arg("addrs"), "Attach ring buffer addresses for benchmarking.")
-      .def("notify_proxy_thread_adaptive_sleeper", &UcclProxy::notify_proxy_thread_adaptive_sleeper);
+      .def("notify_proxy_thread_adaptive_sleeper",
+           &UcclProxy::notify_proxy_thread_adaptive_sleeper);
   // .def_prop_ro("gpu_buffer_addr", &UcclProxy::gpu_buffer_addr);
   nb::class_<EnvInfo>(m, "EnvInfo")
       .def_ro("blocks", &EnvInfo::blocks)

--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -2381,7 +2381,8 @@ NB_MODULE(ep, m) {
             for (nb::handle h : addrs) v.push_back(nb::cast<uintptr_t>(h));
             self.set_bench_d2h_channel_addrs(v);
           },
-          nb::arg("addrs"), "Attach ring buffer addresses for benchmarking.");
+          nb::arg("addrs"), "Attach ring buffer addresses for benchmarking.")
+      .def("notify_proxy_thread_adaptive_sleeper", &UcclProxy::notify_proxy_thread_adaptive_sleeper);
   // .def_prop_ro("gpu_buffer_addr", &UcclProxy::gpu_buffer_addr);
   nb::class_<EnvInfo>(m, "EnvInfo")
       .def_ro("blocks", &EnvInfo::blocks)


### PR DESCRIPTION
## Description
Partially implements #842 by sleeping the proxy thread when have been no requests for 120 seconds. Sleeping mode has to be enabled with the `UCCL_RDMA_ADAPTIVE_SLEEP=1`

Tested with a no request timeout of 3 seconds and adding intentional sleep to `ep/bench/test_low_latency.py` based on the following diff:
```
diff --git a/ep/bench/test_low_latency.py b/ep/bench/test_low_latency.py
index 774fc809..633b962b 100644
--- a/ep/bench/test_low_latency.py
+++ b/ep/bench/test_low_latency.py
@@ -151,6 +151,8 @@ def test_main(
             # Preserve the XOR aggregation behavior at per-label granularity.
             hash_details[label] = hash_details.get(label, 0) ^ hv

+    import time
+    time.sleep(5)
     for current_x in x_list:
         for return_recv_hook in (False, True):
             for dispatch_use_fp8_case in (False, True):
@@ -383,6 +385,8 @@ def test_main(
                                         f"|logfmt={use_logfmt}"
                                     )
                                     _record_hash(f"combine_out|{tag}", combined_x)
+
+                            time.sleep(5)

     # noinspection PyShadowingNames
     def large_gemm_with_hook(hook):
```

With the following script:

```
#!/bin/bash

NODE_RANK=$1

/home/yzhou/nfs/miniconda3/envs/shawn/bin/torchrun --nnodes=2 --nproc_per_node=1 \
  --node_rank=$NODE_RANK \
  --master_addr=10.0.0.2 --master_port=29501 \
  bench/test_low_latency.py \
  --num-tokens=32 --hidden=7168 --num-topk=8 --num-experts=16 &

TORCHRUN_PID=$!

# Wait until worker spawns
WORKER_PID=""
while [ -z "$WORKER_PID" ]; do
  sleep 0.5
  WORKER_PID=$(pgrep -P $TORCHRUN_PID)
done

sleep 2
echo "Profiling PID: $WORKER_PID"

sudo perf stat -e cycles,instructions,cpu-clock,context-switches,migrations -I 300\
  -p $WORKER_PID &
PERF_PID=$!

wait $TORCHRUN_PID
sudo kill -INT $PERF_PID
wait $PERF_PID
```

Validated on gb10 (ignore the 30 seconds that was hard coded):

```
[INFO EP spark1 1562554 1562595 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:19] No activity detected for the last 30 seconds, putting proxy to sleep
[INFO EP spark1 1562554 1562595 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:34] Sleeping proxy thread
[INFO EP spark1 1562554 1562597 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:19] No activity detected for the last 30 seconds, putting proxy to sleep
[INFO EP spark1 1562554 1562597 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:34] Sleeping proxy thread
[INFO EP spark1 1562554 1562594 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:19] No activity detected for the last 30 seconds, putting proxy to sleep
[INFO EP spark1 1562554 1562594 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:34] Sleeping proxy thread
[INFO EP spark1 1562554 1562596 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:19] No activity detected for the last 30 seconds, putting proxy to sleep
[INFO EP spark1 1562554 1562596 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:34] Sleeping proxy thread
    26.732962730      1,390,033,456      armv8_pmuv3_0/cycles/                                                   (99.97%)
    26.732962730            418,382      armv8_pmuv3_1/cycles/                                                   (0.03%)
    26.732962730      4,763,355,888      armv8_pmuv3_0/instructions/      #    3.43  insn per cycle              (99.97%)
    26.732962730             46,330      armv8_pmuv3_1/instructions/      #    0.11  insn per cycle              (0.03%)
    26.732962730                  0      cpu-clock                        #    0.000 CPUs utilized
    26.732962730                 14      context-switches
    26.732962730                  0      migrations
    26.934206916            921,323      armv8_pmuv3_0/cycles/                                                   (61.17%)
    26.934206916            664,871      armv8_pmuv3_1/cycles/                                                   (38.83%)
    26.934206916            145,809      armv8_pmuv3_0/instructions/      #    0.16  insn per cycle              (61.17%)
    26.934206916             96,826      armv8_pmuv3_1/instructions/      #    0.15  insn per cycle              (38.83%)
    26.934206916                  0      cpu-clock                        #    0.000 CPUs utilized
    26.934206916                 11      context-switches
    26.934206916                  0      migrations
    27.135454684            295,736      armv8_pmuv3_0/cycles/                                                   (44.90%)
    27.135454684            460,470      armv8_pmuv3_1/cycles/                                                   (55.10%)
    27.135454684             43,248      armv8_pmuv3_0/instructions/      #    0.15  insn per cycle              (44.90%)
    27.135454684             47,590      armv8_pmuv3_1/instructions/      #    0.10  insn per cycle              (55.10%)
    27.135454684                  0      cpu-clock                        #    0.000 CPUs utilized
    27.135454684                  6      context-switches
    27.135454684                  0      migrations
    27.336698405            343,183      armv8_pmuv3_0/cycles/                                                   (48.18%)
    27.336698405            456,016      armv8_pmuv3_1/cycles/                                                   (51.82%)
    27.336698405             44,105      armv8_pmuv3_0/instructions/      #    0.13  insn per cycle              (48.18%)
    27.336698405             47,229      armv8_pmuv3_1/instructions/      #    0.10  insn per cycle              (51.82%)
    27.336698405                  0      cpu-clock                        #    0.000 CPUs utilized
    27.336698405                  6      context-switches
    27.336698405                  0      migrations
    27.537973838          1,152,741      armv8_pmuv3_0/cycles/                                                   (64.60%)
    27.537973838            741,586      armv8_pmuv3_1/cycles/                                                   (35.40%)
    27.537973838            124,388      armv8_pmuv3_0/instructions/      #    0.11  insn per cycle              (64.60%)
    27.537973838             85,318      armv8_pmuv3_1/instructions/      #    0.12  insn per cycle              (35.40%)
    27.537973838                  0      cpu-clock                        #    0.000 CPUs utilized
    27.537973838                 12      context-switches
    27.537973838                  0      migrations
Start experiment with settings: return_recv_hook=True dispatch_use_fp8=False round_scale=False use_ue8m0=False
[INFO EP spark1 1562554 1562595 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:49] Waking up because of dispatch/combine trigger
[INFO EP spark1 1562554 1562597 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:49] Waking up because of dispatch/combine trigger
[INFO EP spark1 1562554 1562596 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:49] Waking up because of dispatch/combine trigger
[INFO EP spark1 1562554 1562594 maybe_sleep /home/yzhou/nfs/shawn/uccl/ep/src/adaptive_sleeper.cc:49] Waking up because of dispatch/combine trigger
    27.738871046        362,379,014      armv8_pmuv3_0/cycles/            #    2.792 GHz                         (81.75%)
    27.738871046        112,831,780      armv8_pmuv3_1/cycles/            #    0.869 GHz                         (18.23%)
    27.738871046      1,241,744,961      armv8_pmuv3_0/instructions/      #    3.43  insn per cycle              (81.80%)
    27.738871046        244,159,972      armv8_pmuv3_1/instructions/      #    2.16  insn per cycle              (18.18%)
    27.738871046        129,781,376      cpu-clock                        #    0.649 CPUs utilized
    27.738871046                 11      context-switches                 #   84.758 /sec
    27.738871046                  0      migrations                       #    0.000 /sec
    27.939926478      2,258,114,406      armv8_pmuv3_0/cycles/            #    4.110 GHz                         (99.97%)
    27.939926478            681,838      armv8_pmuv3_1/cycles/            #    0.001 GHz                         (0.03%)
    27.939926478      7,734,133,022      armv8_pmuv3_0/instructions/      #    3.43  insn per cycle              (99.97%)
    27.939926478             86,666      armv8_pmuv3_1/instructions/      #    0.13  insn per cycle              (0.03%)
    27.939926478        549,421,520      cpu-clock                        #    2.747 CPUs utilized
    27.939926478                 16      context-switches                 #   29.122 /sec
    27.939926478                  0      migrations                       #    0.000 /sec
    28.140646054      2,253,765,359      armv8_pmuv3_0/cycles/            #    4.967 GHz                         (99.99%)
    28.140646054            334,591      armv8_pmuv3_1/cycles/            #    0.001 GHz                         (0.01%)
    28.140646054      7,724,873,166      armv8_pmuv3_0/instructions/      #    3.43  insn per cycle              (99.99%)
    28.140646054             48,613      armv8_pmuv3_1/instructions/      #    0.15  insn per cycle              (0.01%)
    28.140646054        453,725,312      cpu-clock                        #    2.269 CPUs utilized
    28.140646054                  9      context-switches                 #   19.836 /sec
    28.140646054                  0      migrations                       #    0.000 /sec
```

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [x] I have run `build.sh` to verify compilation.
- [x] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
