### PR TITLE
Fix deadlock in internode collective functions when num_tokens == 0

### DIFF
--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -908,26 +908,6 @@ class Buffer {
                     bool allocate_on_comm_stream,
                     std::uintptr_t compute_stream_ptr) {
     nb::gil_scoped_release release;
-    // Handle empty token case: when num_tokens == 0, this rank has nothing
-    // to dispatch. Return zeros without launching any communication.
-    if (num_tokens == 0) {
-      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
-      static_cast<void>(allocate_on_comm_stream);
-      if (previous_event.has_value()) {
-        stream_wait(comm_stream, previous_event.value());
-      } else {
-        stream_wait(comm_stream, compute_stream);
-      }
-      int const num_local_experts = num_experts / num_ranks;
-      std::vector<int> empty_expert_counts(num_local_experts, 0);
-      std::optional<EventHandle> event;
-      if (async) {
-        event = EventHandle(comm_stream);
-      } else {
-        stream_wait(compute_stream, comm_stream);
-      }
-      return {0, 0, empty_expert_counts, event};
-    }
     EP_HOST_ASSERT(num_tokens_per_rank_ptr != 0);
     EP_HOST_ASSERT(num_tokens_per_rdma_rank_ptr != 0);
     EP_HOST_ASSERT(num_tokens_per_expert_ptr != 0);
@@ -936,7 +916,9 @@ class Buffer {
     EP_HOST_ASSERT(recv_rdma_rank_prefix_sum_ptr != 0);
     EP_HOST_ASSERT(gbl_channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(recv_gbl_rank_prefix_sum_ptr != 0);
-    EP_HOST_ASSERT(hidden > 0 && num_experts > 0);
+    // Allow num_tokens == 0: DP-attention ranks may have no tokens to
+    // dispatch, but must still participate in the collective notification.
+    EP_HOST_ASSERT(num_tokens >= 0 && hidden > 0 && num_experts > 0);
     EP_HOST_ASSERT(config.num_sms % 2 == 0);
     EP_HOST_ASSERT(0 < get_num_rdma_ranks() &&
                    get_num_rdma_ranks() <= NUM_MAX_RDMA_PEERS);
@@ -1034,29 +1016,18 @@ class Buffer {
       std::uintptr_t send_rdma_head_ptr, std::uintptr_t send_nvl_head_ptr,
       std::optional<EventHandle>& previous_event, bool async,
       bool allocate_on_comm_stream, std::uintptr_t compute_stream_ptr) {
-    // Handle empty token case: nothing to dispatch from this rank.
-    if (num_tokens == 0) {
-      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
-      static_cast<void>(allocate_on_comm_stream);
-      if (previous_event.has_value()) {
-        stream_wait(comm_stream, previous_event.value());
-      } else {
-        stream_wait(comm_stream, compute_stream);
-      }
-      std::optional<EventHandle> event;
-      if (async) {
-        event = EventHandle(comm_stream);
-      } else {
-        stream_wait(compute_stream, comm_stream);
-      }
-      return event;
+    // Allow num_tokens == 0: DP-attention ranks may have no tokens to
+    // dispatch, but must still participate in the collective cached_notify
+    // and dispatch so that remote ranks are not left spinning.
+    EP_HOST_ASSERT(num_tokens >= 0 && hidden > 0);
+    if (num_tokens > 0) {
+      EP_HOST_ASSERT(x_ptr != 0 && recv_x_ptr != 0 &&
+                     is_token_in_rank_ptr != 0);
     }
-    EP_HOST_ASSERT(x_ptr != 0 && recv_x_ptr != 0 && is_token_in_rank_ptr != 0);
     EP_HOST_ASSERT(rdma_channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(recv_rdma_rank_prefix_sum_ptr != 0);
     EP_HOST_ASSERT(gbl_channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(recv_gbl_rank_prefix_sum_ptr != 0);
-    EP_HOST_ASSERT(num_tokens > 0 && hidden > 0);
     EP_HOST_ASSERT(config.num_sms % 2 == 0);
 
     int const num_channels = config.num_sms / 2;
@@ -1092,7 +1063,7 @@ class Buffer {
     }
 
     uccl::internode::dispatch(
-        reinterpret_cast<void*>(recv_x_ptr),
+        recv_x_ptr == 0 ? nullptr : reinterpret_cast<void*>(recv_x_ptr),
         recv_x_scales_ptr == 0 ? nullptr
                                : reinterpret_cast<float*>(recv_x_scales_ptr),
         recv_topk_idx_ptr == 0 ? nullptr
@@ -1101,7 +1072,7 @@ class Buffer {
             ? nullptr
             : reinterpret_cast<float*>(recv_topk_weights_ptr),
         cached_mode ? nullptr : reinterpret_cast<void*>(recv_src_meta_ptr),
-        reinterpret_cast<void const*>(x_ptr),
+        x_ptr == 0 ? nullptr : reinterpret_cast<void const*>(x_ptr),
         x_scales_ptr == 0 ? nullptr
                           : reinterpret_cast<float const*>(x_scales_ptr),
         topk_idx_ptr == 0 ? nullptr
@@ -1121,7 +1092,10 @@ class Buffer {
         reinterpret_cast<int const*>(recv_rdma_rank_prefix_sum_ptr),
         reinterpret_cast<int const*>(gbl_channel_prefix_matrix_ptr),
         reinterpret_cast<int const*>(recv_gbl_rank_prefix_sum_ptr),
-        reinterpret_cast<bool const*>(is_token_in_rank_ptr), num_tokens,
+        is_token_in_rank_ptr == 0
+            ? nullptr
+            : reinterpret_cast<bool const*>(is_token_in_rank_ptr),
+        num_tokens,
         num_worst_tokens, hidden_int4, num_scales, num_topk, num_experts,
         scale_token_stride, scale_hidden_stride, rdma_buffer_ptr,
         config.num_max_rdma_chunked_send_tokens,
@@ -1154,25 +1128,13 @@ class Buffer {
       std::uintptr_t combined_x_ptr, std::uintptr_t combined_topk_weights_ptr,
       std::optional<EventHandle>& previous_event, bool async,
       bool allocate_on_comm_stream, std::uintptr_t compute_stream_ptr) {
-    // Handle empty token case: nothing to combine for this rank.
-    if (num_combined_tokens == 0) {
-      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
-      static_cast<void>(allocate_on_comm_stream);
-      if (previous_event.has_value()) {
-        stream_wait(comm_stream, previous_event.value());
-      } else {
-        stream_wait(comm_stream, compute_stream);
-      }
-      std::optional<EventHandle> event;
-      if (async) {
-        event = EventHandle(comm_stream);
-      } else {
-        stream_wait(compute_stream, comm_stream);
-      }
-      return event;
+    // Allow num_combined_tokens == 0: DP-attention ranks may have no tokens
+    // to combine, but must still participate in the collective cached_notify
+    // and combine so that remote ranks are not left spinning.
+    if (num_combined_tokens > 0) {
+      EP_HOST_ASSERT(x_ptr != 0 && src_meta_ptr != 0 && combined_x_ptr != 0);
+      EP_HOST_ASSERT(is_combined_token_in_rank_ptr != 0);
     }
-    EP_HOST_ASSERT(x_ptr != 0 && src_meta_ptr != 0 && combined_x_ptr != 0);
-    EP_HOST_ASSERT(is_combined_token_in_rank_ptr != 0);
     EP_HOST_ASSERT(rdma_channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(rdma_rank_prefix_sum_ptr != 0);
     EP_HOST_ASSERT(gbl_channel_prefix_matrix_ptr != 0);
@@ -1210,19 +1172,23 @@ class Buffer {
     };
     uccl::internode::combine(
         cuda_dtype_from_code(x_dtype_code),
-        reinterpret_cast<void*>(combined_x_ptr),
+        combined_x_ptr == 0 ? nullptr
+                            : reinterpret_cast<void*>(combined_x_ptr),
         combined_topk_weights_ptr == 0
             ? nullptr
             : reinterpret_cast<float*>(combined_topk_weights_ptr),
-        reinterpret_cast<bool const*>(is_combined_token_in_rank_ptr),
-        reinterpret_cast<void const*>(x_ptr),
+        is_combined_token_in_rank_ptr == 0
+            ? nullptr
+            : reinterpret_cast<bool const*>(is_combined_token_in_rank_ptr),
+        x_ptr == 0 ? nullptr : reinterpret_cast<void const*>(x_ptr),
         topk_weights_ptr == 0
             ? nullptr
             : reinterpret_cast<float const*>(topk_weights_ptr),
         bias_ptrs[0], bias_ptrs[1],
         reinterpret_cast<int const*>(combined_rdma_head_ptr),
         reinterpret_cast<int const*>(combined_nvl_head_ptr),
-        reinterpret_cast<void const*>(src_meta_ptr),
+        src_meta_ptr == 0 ? nullptr
+                          : reinterpret_cast<void const*>(src_meta_ptr),
         reinterpret_cast<int const*>(rdma_channel_prefix_matrix_ptr),
         reinterpret_cast<int const*>(rdma_rank_prefix_sum_ptr),
         reinterpret_cast<int const*>(gbl_channel_prefix_matrix_ptr), num_tokens,

--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -536,17 +536,17 @@ class Buffer {
         stream_wait(comm_stream, compute_stream);
       }
       // Zero out per-rank and per-expert token counts
-      CUDA_CHECK(cudaMemsetAsync(
-          reinterpret_cast<void*>(num_tokens_per_rank_ptr), 0,
-          num_ranks * sizeof(int), comm_stream));
+      CUDA_CHECK(
+          cudaMemsetAsync(reinterpret_cast<void*>(num_tokens_per_rank_ptr), 0,
+                          num_ranks * sizeof(int), comm_stream));
       if (num_tokens_per_rdma_rank_ptr != 0) {
         CUDA_CHECK(cudaMemsetAsync(
             reinterpret_cast<void*>(num_tokens_per_rdma_rank_ptr), 0,
             num_ranks * sizeof(int), comm_stream));
       }
-      CUDA_CHECK(cudaMemsetAsync(
-          reinterpret_cast<void*>(num_tokens_per_expert_ptr), 0,
-          num_experts * sizeof(int), comm_stream));
+      CUDA_CHECK(
+          cudaMemsetAsync(reinterpret_cast<void*>(num_tokens_per_expert_ptr), 0,
+                          num_experts * sizeof(int), comm_stream));
       std::optional<EventHandle> event;
       if (async) {
         event = EventHandle(comm_stream);
@@ -1095,9 +1095,8 @@ class Buffer {
         is_token_in_rank_ptr == 0
             ? nullptr
             : reinterpret_cast<bool const*>(is_token_in_rank_ptr),
-        num_tokens,
-        num_worst_tokens, hidden_int4, num_scales, num_topk, num_experts,
-        scale_token_stride, scale_hidden_stride, rdma_buffer_ptr,
+        num_tokens, num_worst_tokens, hidden_int4, num_scales, num_topk,
+        num_experts, scale_token_stride, scale_hidden_stride, rdma_buffer_ptr,
         config.num_max_rdma_chunked_send_tokens,
         config.num_max_rdma_chunked_recv_tokens, buffer_ptrs_gpu,
         config.num_max_nvl_chunked_send_tokens,
@@ -1172,8 +1171,7 @@ class Buffer {
     };
     uccl::internode::combine(
         cuda_dtype_from_code(x_dtype_code),
-        combined_x_ptr == 0 ? nullptr
-                            : reinterpret_cast<void*>(combined_x_ptr),
+        combined_x_ptr == 0 ? nullptr : reinterpret_cast<void*>(combined_x_ptr),
         combined_topk_weights_ptr == 0
             ? nullptr
             : reinterpret_cast<float*>(combined_topk_weights_ptr),

--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -524,6 +524,37 @@ class Buffer {
       std::uintptr_t is_token_in_rank_ptr,
       std::optional<EventHandle>& previous_event, bool async,
       bool allocate_on_comm_stream, std::uintptr_t compute_stream_ptr) {
+    // Handle empty tensor case: when num_tokens == 0 (e.g., DP-attention
+    // ranks with no tokens to route), PyTorch returns data_ptr() == 0 for
+    // zero-element tensors. Zero out the output arrays and return early.
+    if (num_tokens == 0) {
+      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
+      static_cast<void>(allocate_on_comm_stream);
+      if (previous_event.has_value()) {
+        stream_wait(comm_stream, previous_event.value());
+      } else {
+        stream_wait(comm_stream, compute_stream);
+      }
+      // Zero out per-rank and per-expert token counts
+      CUDA_CHECK(cudaMemsetAsync(
+          reinterpret_cast<void*>(num_tokens_per_rank_ptr), 0,
+          num_ranks * sizeof(int), comm_stream));
+      if (num_tokens_per_rdma_rank_ptr != 0) {
+        CUDA_CHECK(cudaMemsetAsync(
+            reinterpret_cast<void*>(num_tokens_per_rdma_rank_ptr), 0,
+            num_ranks * sizeof(int), comm_stream));
+      }
+      CUDA_CHECK(cudaMemsetAsync(
+          reinterpret_cast<void*>(num_tokens_per_expert_ptr), 0,
+          num_experts * sizeof(int), comm_stream));
+      std::optional<EventHandle> event;
+      if (async) {
+        event = EventHandle(comm_stream);
+      } else {
+        stream_wait(compute_stream, comm_stream);
+      }
+      return event;
+    }
     EP_HOST_ASSERT(topk_idx_ptr != 0);
     EP_HOST_ASSERT(num_tokens_per_rank_ptr != 0);
     EP_HOST_ASSERT(num_tokens_per_expert_ptr != 0);
@@ -877,6 +908,26 @@ class Buffer {
                     bool allocate_on_comm_stream,
                     std::uintptr_t compute_stream_ptr) {
     nb::gil_scoped_release release;
+    // Handle empty token case: when num_tokens == 0, this rank has nothing
+    // to dispatch. Return zeros without launching any communication.
+    if (num_tokens == 0) {
+      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
+      static_cast<void>(allocate_on_comm_stream);
+      if (previous_event.has_value()) {
+        stream_wait(comm_stream, previous_event.value());
+      } else {
+        stream_wait(comm_stream, compute_stream);
+      }
+      int const num_local_experts = num_experts / num_ranks;
+      std::vector<int> empty_expert_counts(num_local_experts, 0);
+      std::optional<EventHandle> event;
+      if (async) {
+        event = EventHandle(comm_stream);
+      } else {
+        stream_wait(compute_stream, comm_stream);
+      }
+      return {0, 0, empty_expert_counts, event};
+    }
     EP_HOST_ASSERT(num_tokens_per_rank_ptr != 0);
     EP_HOST_ASSERT(num_tokens_per_rdma_rank_ptr != 0);
     EP_HOST_ASSERT(num_tokens_per_expert_ptr != 0);
@@ -885,7 +936,7 @@ class Buffer {
     EP_HOST_ASSERT(recv_rdma_rank_prefix_sum_ptr != 0);
     EP_HOST_ASSERT(gbl_channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(recv_gbl_rank_prefix_sum_ptr != 0);
-    EP_HOST_ASSERT(num_tokens > 0 && hidden > 0 && num_experts > 0);
+    EP_HOST_ASSERT(hidden > 0 && num_experts > 0);
     EP_HOST_ASSERT(config.num_sms % 2 == 0);
     EP_HOST_ASSERT(0 < get_num_rdma_ranks() &&
                    get_num_rdma_ranks() <= NUM_MAX_RDMA_PEERS);
@@ -983,6 +1034,23 @@ class Buffer {
       std::uintptr_t send_rdma_head_ptr, std::uintptr_t send_nvl_head_ptr,
       std::optional<EventHandle>& previous_event, bool async,
       bool allocate_on_comm_stream, std::uintptr_t compute_stream_ptr) {
+    // Handle empty token case: nothing to dispatch from this rank.
+    if (num_tokens == 0) {
+      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
+      static_cast<void>(allocate_on_comm_stream);
+      if (previous_event.has_value()) {
+        stream_wait(comm_stream, previous_event.value());
+      } else {
+        stream_wait(comm_stream, compute_stream);
+      }
+      std::optional<EventHandle> event;
+      if (async) {
+        event = EventHandle(comm_stream);
+      } else {
+        stream_wait(compute_stream, comm_stream);
+      }
+      return event;
+    }
     EP_HOST_ASSERT(x_ptr != 0 && recv_x_ptr != 0 && is_token_in_rank_ptr != 0);
     EP_HOST_ASSERT(rdma_channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(recv_rdma_rank_prefix_sum_ptr != 0);
@@ -1086,6 +1154,23 @@ class Buffer {
       std::uintptr_t combined_x_ptr, std::uintptr_t combined_topk_weights_ptr,
       std::optional<EventHandle>& previous_event, bool async,
       bool allocate_on_comm_stream, std::uintptr_t compute_stream_ptr) {
+    // Handle empty token case: nothing to combine for this rank.
+    if (num_combined_tokens == 0) {
+      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
+      static_cast<void>(allocate_on_comm_stream);
+      if (previous_event.has_value()) {
+        stream_wait(comm_stream, previous_event.value());
+      } else {
+        stream_wait(comm_stream, compute_stream);
+      }
+      std::optional<EventHandle> event;
+      if (async) {
+        event = EventHandle(comm_stream);
+      } else {
+        stream_wait(compute_stream, comm_stream);
+      }
+      return event;
+    }
     EP_HOST_ASSERT(x_ptr != 0 && src_meta_ptr != 0 && combined_x_ptr != 0);
     EP_HOST_ASSERT(is_combined_token_in_rank_ptr != 0);
     EP_HOST_ASSERT(rdma_channel_prefix_matrix_ptr != 0);
@@ -1200,6 +1285,20 @@ class Buffer {
                        bool use_fp8, bool round_scale, bool use_ue8m0,
                        bool async, bool return_recv_hook) {
     EP_HOST_ASSERT(low_latency_mode);
+    // Handle empty token case: when x_rows == 0, this rank has no tokens
+    // to dispatch. PyTorch returns data_ptr() == 0 for zero-element tensors,
+    // so x_ptr and topk_idx_ptr will legitimately be 0.
+    if (x_rows == 0) {
+      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
+      std::optional<EventHandle> event;
+      if (async) {
+        event = EventHandle(comm_stream);
+      } else {
+        stream_wait(compute_stream, comm_stream);
+      }
+      std::optional<std::function<void()>> hook;
+      return {event, hook};
+    }
     EP_HOST_ASSERT(x_ptr != 0 && topk_idx_ptr != 0);
     EP_HOST_ASSERT(packed_recv_x_ptr != 0 && packed_recv_count_ptr != 0);
     EP_HOST_ASSERT(packed_recv_src_info_ptr != 0 &&
@@ -1311,6 +1410,19 @@ class Buffer {
       int num_sms = 0, std::uintptr_t src_signals_ptr = 0,
       int src_signal_expect_value = 0) {
     EP_HOST_ASSERT(low_latency_mode);
+    // Handle empty token case: when topk_rows == 0, this rank dispatched
+    // no tokens so there is nothing to combine. Return early.
+    if (topk_rows == 0) {
+      auto compute_stream = reinterpret_cast<cudaStream_t>(compute_stream_ptr);
+      std::optional<EventHandle> event;
+      if (async) {
+        event = EventHandle(comm_stream);
+      } else if (not return_recv_hook) {
+        stream_wait(compute_stream, comm_stream);
+      }
+      std::optional<std::function<void()>> hook;
+      return {event, hook};
+    }
     EP_HOST_ASSERT(x_ptr != 0 && topk_idx_ptr != 0 && topk_weights_ptr != 0);
     EP_HOST_ASSERT(src_info_ptr != 0 && layout_range_ptr != 0);
     EP_HOST_ASSERT(out_ptr != 0);


### PR DESCRIPTION
### Problem

When SGLang uses DP-attention with DeepEP `normal` mode, some EP ranks may have 0 tokens to dispatch in a given step. The existing early-return paths in `internode_prepare`, `internode_dispatch`, and `internode_combine` would skip the collective `cached_notify` / `notify_dispatch` calls, causing remote ranks to spin forever on their CPU wait loops polling `moe_recv_counter`. This manifests as:

```
RuntimeError: DeepEP error: timeout (dispatch CPU)
rank=0, thread=0, value=0
```

while threads 1–7 report `value=1024`, indicating they received notifications from some ranks but not from the zero-token rank that early-returned.

### Root Cause

`internode_prepare`, `internode_dispatch`, and `internode_combine` all contain collective signaling (via `notify_dispatch`, `cached_notify`, and the dispatch/combine CUDA kernels). When a rank skips these calls, remote ranks deadlock waiting for notifications that never arrive.

### Fix

1. **`internode_prepare`**: Remove the early-return. Relax assertion from `num_tokens > 0` to `num_tokens >= 0`. The rank always participates in `notify_dispatch` even with 0 tokens.

2. **`internode_dispatch`**: Remove the early-return. Relax assertion to `num_tokens >= 0`. Guard data-pointer assertions behind `if (num_tokens > 0)`. Use null-safe ternary casts for `x_ptr`, `recv_x_ptr`, and `is_token_in_rank_ptr` so the dispatch kernel receives `nullptr` (safe because it iterates 0 times over the token dimension).

3. **`internode_combine`**: Remove the early-return. Guard data-pointer assertions behind `if (num_combined_tokens > 0)`. Use null-safe ternary casts for `combined_x_ptr`, `is_combined_token_in_rank_ptr`, `x_ptr`, and `src_meta_ptr`.

Non-collective functions (`get_dispatch_layout`, `low_latency_dispatch`, `low_latency_combine`) retain their early-returns since they use RDMA point-to-point operations that don't require collective participation.

### Testing

Verified on 2-node (16×H200) deployment with SGLang v0.5.11 serving DeepSeek-V3-0324, EP=16, DP-attention, DeepEP `normal` mode:

- Server starts and completes CUDA graph capture (previously succeeded)
- **Single request completes successfully** (previously deadlocked here)
- 3 concurrent requests complete successfully
- 32 requests at 4 RPS complete with 0 failures

### Performance

| Workload | RPS | Median TPOT | vs NCCL baseline |
|----------|-----|-------------|-----------------|
| 512×128 | 1 | 17.2ms | 6.2× faster |
| 1024×256 | 2 | 31.5ms | 3.4× faster |
| 1024×256 | 4 | 34.7ms | 3.1× faster |

NCCL EP baseline on same hardware/model: 107ms median TPOT.

### Environment

- SGLang v0.5.11
- PyTorch 2.11.0+cu130
- CUDA 13.0
- NCCL 2.30.4
- 2× p5en.48xlarge (16× H200, EFA)
- Model: deepseek-ai/DeepSeek-V3-0324 (FP8)

Fixes #935 
