### PR TITLE
[EP] Fix RDMA NIC selection on p6-b300.48xlarge (16 EFAs, 2 same-distance NICs/GPU)

### DIFF
--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -488,13 +488,24 @@ void per_thread_rdma_init(ProxyCtx& S, void* gpu_buf, size_t bytes, int rank,
         selected_nic_name = candidates[thread_idx % 4];
         use_ll_sl = true;
       } else if (num_efas == 16) {
-        assert(candidates.size() == 4);
-        // On p5e/p5en, there are 4 NICs with the same distance.
-        // We hardcode the first half Proxies to use the first NIC, and the
-        // second half to use the second NIC.
-        auto half = (local_rank % 2) * 2;
-        // GPU0 uses candidates[0/1], GPU1 uses candidates[2/3], etc.
-        selected_nic_name = candidates[thread_idx % 2 + half];
+        if (candidates.size() == 4) {
+          // On p5e/p5en, there are 4 NICs with the same distance per GPU.
+          // We hardcode the first half Proxies to use the first NIC, and the
+          // second half to use the second NIC.
+          auto half = (local_rank % 2) * 2;
+          // GPU0 uses candidates[0/1], GPU1 uses candidates[2/3], etc.
+          selected_nic_name = candidates[thread_idx % 2 + half];
+        } else if (candidates.size() == 2) {
+          // On p6-b300.48xlarge (B300, 16x400Gbps EFA), there are 2 NICs with
+          // the same distance per GPU. Stripe all proxy threads across both.
+          selected_nic_name = candidates[thread_idx % 2];
+        } else {
+          fprintf(stderr,
+                  "[WARN] num_efas=16 with unexpected candidates size %zu, "
+                  "defaulting to candidates[0]\n",
+                  candidates.size());
+          selected_nic_name = candidates[0];
+        }
         use_ll_sl = true;
       } else {
         // On p6-b200, there is 2 NICs with the same distance.


### PR DESCRIPTION
## Description
The `num_efas == 16` branch in `select_rdma_nic()` (`ep/src/rdma.cpp`) hardcodes `assert(candidates.size() == 4)`, which holds on p5e/p5en (4 same-distance NICs per GPU) but **not** on AWS's new `p6-b300.48xlarge` instance:

- p6-b300.48xlarge: 8x NVIDIA B300 SXM6, 16x EFA NICs @ 400 Gbps (aggregate 6.4 Tbps)
- Same `num_efas == 16` as p5e/p5en, but each GPU only has **2** candidate NICs at the minimum NUMA-aware distance

When the assert fires (in builds where it is compiled out / NDEBUG), the proxy thread proceeds with an empty `selected_nic_name`, producing this crash chain:

```
terminate called after throwing an instance of 'std::bad_alloc'
[FATAL] Selected RDMA NIC '' not found in verbs device list
terminate called after throwing an instance of 'std::length_error'
SIGABRT
```

This makes UCCL EP unusable on p6-b300 out of the box.

The fix dispatches on `candidates.size()` inside the `num_efas == 16` branch:
- 4 candidates: existing p5e/p5en behavior, unchanged
- 2 candidates: stripe proxy threads across both NICs (p6-b300)
- otherwise: warn and fall back to `candidates[0]` instead of asserting

Fixes # (issue) — no existing issue, filing this directly as a fix.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

Manually validated on a pair of `p6-b300.48xlarge` instances using the EP microbenchmarks. Without the patch, every proxy thread aborts during `per_thread_rdma_init`. With the patch, UCCL EP runs end-to-end and reports:

| metric | p5en (16 x 200G, 4 cand/GPU) | p6-b300 (16 x 400G, 2 cand/GPU) — patched |
|---|---|---|
| Normal-mode dispatch BF16 | ~60.6 GB/s | ~90 GB/s |
| Normal-mode combine BF16  | ~17.1 GB/s | ~59 GB/s |

Numbers are per-GPU, internode, 8 ranks per node, 2 nodes.

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [x] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.

Notes on the unchecked boxes:
- `format.sh` requires `clang-format-14`; not available on the dev machine. The change uses the same indentation/style as the surrounding code, so it should pass clang-format-14 cleanly. Happy to amend if a maintainer with the right toolchain spots a deviation.
- `build.sh` was not re-run on this exact diff, but the patched binary (same change applied locally) was used to produce the perf numbers above on p6-b300, so the code compiles and runs.
- No automated tests added — NIC selection depends on EFA hardware topology, which is not part of CI. Manual test reproduction:
  1. Bring up a 2-node `p6-b300.48xlarge` cluster
  2. Build UCCL EP with EFA support
  3. Run `bench_dispatch_combine.py` (or any EP normal-mode test) with 8 ranks per node
  - Before patch: SIGABRT during proxy init
  - After patch: completes, ~90/59 GB/s dispatch/combine
