### PR TITLE
[P2P] Boost writev/readv performance

### DIFF
--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -6,6 +6,7 @@
 #include <arpa/inet.h>
 #include <cc/cc_state.h>
 #include <netinet/in.h>
+#include <array>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -1060,18 +1061,34 @@ bool Endpoint::readv(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
   SendConnection* send_group =
       uccl_resolve_send_group(ep_, conn->uccl_conn_id_.flow_id);
 
-  // Fastest path: RDMA, fits in one inflight window. Post all iovs back to
-  // back (no per-iov slot scan, no variant visit, no send_channel_groups_
-  // lookup), flush once, then poll until all are acked.
-  if (send_group != nullptr && num_iovs <= kMaxInflightOps) {
-    ucclRequest ureqs[kMaxInflightOps] = {};
+  bool raw_batch_eligible = true;
+  for (size_t i = 0; i < num_iovs; ++i) {
+    if (ChunkSplitStrategy::getMessageChunkCount(size_v[i]) != 1) {
+      raw_batch_eligible = false;
+      break;
+    }
+  }
+
+  // Fastest path: RDMA, fits in one inflight window, compression/CC disabled.
+  // Post raw one-sided WRs directly by channel and skip per-iov request-object
+  // construction.
+  if (send_group != nullptr && num_iovs <= kMaxInflightOps &&
+      raw_batch_eligible &&
+      send_group->canUseRawOneSidedBatch(SendType::Read)) {
+    std::array<SendConnection::OneSidedBatchOp, kMaxInflightOps> ops{};
+    int64_t wr_ids[kMaxInflightOps] = {};
     bool done[kMaxInflightOps] = {false};
 
     for (size_t i = 0; i < num_iovs; ++i) {
-      uccl_read_async_on_group(send_group, conn, mhandle_v[i], dst_v[i],
-                               size_v[i], slot_item_v[i], &ureqs[i]);
+      ops[i].local_addr = dst_v[i];
+      ops[i].size = size_v[i];
+      ops[i].local_mr_array = &mhandle_v[i]->mr_array;
+      ops[i].slot_item = &slot_item_v[i];
     }
-    uccl_flush_send(ep_);
+    if (!send_group->postWriteOrReadBatch(SendType::Read, ops.data(), num_iovs,
+                                          wr_ids)) {
+      return false;
+    }
 
     size_t num_done = 0;
     while (num_done < num_iovs) {
@@ -1079,7 +1096,7 @@ bool Endpoint::readv(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
       uccl_drive_send(ep_);
       for (size_t i = 0; i < num_iovs; ++i) {
         if (done[i]) continue;
-        if (uccl_check_wr_fast(send_group, ureqs[i].engine_idx)) {
+        if (uccl_check_wr_fast(send_group, wr_ids[i])) {
           done[i] = true;
           num_done++;
         }
@@ -1289,18 +1306,34 @@ bool Endpoint::writev(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
   SendConnection* send_group =
       uccl_resolve_send_group(ep_, conn->uccl_conn_id_.flow_id);
 
-  // Fastest path: RDMA, fits in one inflight window. Post all iovs back to
-  // back (no per-iov slot scan, no variant visit, no send_channel_groups_
-  // lookup), flush once, then poll until all are acked.
-  if (send_group != nullptr && num_iovs <= kMaxInflightOps) {
-    ucclRequest ureqs[kMaxInflightOps] = {};
+  bool raw_batch_eligible = true;
+  for (size_t i = 0; i < num_iovs; ++i) {
+    if (ChunkSplitStrategy::getMessageChunkCount(size_v[i]) != 1) {
+      raw_batch_eligible = false;
+      break;
+    }
+  }
+
+  // Fastest path: RDMA, fits in one inflight window, compression/CC disabled.
+  // Post raw one-sided WRs directly by channel and skip per-iov request-object
+  // construction.
+  if (send_group != nullptr && num_iovs <= kMaxInflightOps &&
+      raw_batch_eligible &&
+      send_group->canUseRawOneSidedBatch(SendType::Write)) {
+    std::array<SendConnection::OneSidedBatchOp, kMaxInflightOps> ops{};
+    int64_t wr_ids[kMaxInflightOps] = {};
     bool done[kMaxInflightOps] = {false};
 
     for (size_t i = 0; i < num_iovs; ++i) {
-      uccl_write_async_on_group(send_group, conn, mhandle_v[i], src_v[i],
-                                size_v[i], slot_item_v[i], &ureqs[i]);
+      ops[i].local_addr = src_v[i];
+      ops[i].size = size_v[i];
+      ops[i].local_mr_array = &mhandle_v[i]->mr_array;
+      ops[i].slot_item = &slot_item_v[i];
     }
-    uccl_flush_send(ep_);
+    if (!send_group->postWriteOrReadBatch(SendType::Write, ops.data(), num_iovs,
+                                          wr_ids)) {
+      return false;
+    }
 
     size_t num_done = 0;
     while (num_done < num_iovs) {
@@ -1308,7 +1341,7 @@ bool Endpoint::writev(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
       uccl_drive_send(ep_);
       for (size_t i = 0; i < num_iovs; ++i) {
         if (done[i]) continue;
-        if (uccl_check_wr_fast(send_group, ureqs[i].engine_idx)) {
+        if (uccl_check_wr_fast(send_group, wr_ids[i])) {
           done[i] = true;
           num_done++;
         }

--- a/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.cc
+++ b/p2p/rdma/providers/ib/rdma_data_channel_impl_ib.cc
@@ -3,6 +3,7 @@
 
 #include "rdma_data_channel_impl_ib.h"
 #include "util/debug.h"
+#include <algorithm>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -15,10 +16,21 @@
 #define RNR_RETRY 7
 #define RETRY_CNT 7
 #define TIMEOUT 14
-#define MAX_RD_ATOMIC 1
-#define MAX_DEST_RD_ATOMIC 1
+static constexpr uint32_t kDefaultMaxReadAtomic = 16;
 static constexpr int kMaxCqe = kMaxSendWr + kMaxRecvWr;
 static constexpr uint64_t kRecvWrIdMask = 1ull << 63;
+
+static inline uint8_t get_read_atomic_depth(char const* env_name,
+                                            uint8_t device_cap) {
+  uint32_t requested = kDefaultMaxReadAtomic;
+  if (char const* env = std::getenv(env_name)) {
+    char* end = nullptr;
+    unsigned long value = std::strtoul(env, &end, 10);
+    if (end != env && value > 0) requested = static_cast<uint32_t>(value);
+  }
+  uint32_t cap = device_cap == 0 ? 1 : static_cast<uint32_t>(device_cap);
+  return static_cast<uint8_t>(std::max<uint32_t>(1, std::min(requested, cap)));
+}
 
 inline void IBChannelImpl::initQP(std::shared_ptr<RdmaContext> ctx,
                                   struct ibv_cq_ex** cq_ex, struct ibv_qp** qp,
@@ -104,7 +116,8 @@ inline void IBChannelImpl::ibrcQP_rtr_rts(struct ibv_qp* qp,
   attr.path_mtu = port_attr.active_mtu;
   attr.dest_qp_num = remote_meta.qpn;
   attr.rq_psn = 0;
-  attr.max_dest_rd_atomic = MAX_DEST_RD_ATOMIC;
+  attr.max_dest_rd_atomic = get_read_atomic_depth(
+      "UCCL_P2P_RDMA_MAX_DEST_RD_ATOMIC", ctx->getMaxQpRdAtom());
   attr.min_rnr_timer = MIN_RNR_TIMER;
   if (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET) {
     // RoCE
@@ -148,7 +161,8 @@ inline void IBChannelImpl::ibrcQP_rtr_rts(struct ibv_qp* qp,
   attr.retry_cnt = RETRY_CNT;
   attr.rnr_retry = RNR_RETRY;
   attr.sq_psn = 0;
-  attr.max_rd_atomic = MAX_RD_ATOMIC;
+  attr.max_rd_atomic = get_read_atomic_depth("UCCL_P2P_RDMA_MAX_RD_ATOMIC",
+                                             ctx->getMaxQpInitRdAtom());
   flags = IBV_QP_STATE | IBV_QP_TIMEOUT | IBV_QP_RETRY_CNT | IBV_QP_RNR_RETRY |
           IBV_QP_SQ_PSN | IBV_QP_MAX_QP_RD_ATOMIC;
   int const rts_rc = ibv_modify_qp(qp, &attr, flags);

--- a/p2p/rdma/rdma_connection.h
+++ b/p2p/rdma/rdma_connection.h
@@ -5,6 +5,8 @@
 #include "rdma_data_channel.h"
 #include <cc/cc_state.h>
 #include <cc/link_bandwidth.h>
+#include <array>
+#include <limits>
 #include <optional>
 #include <random>
 
@@ -153,6 +155,13 @@ class RDMAConnection {
 
 class SendConnection : public RDMAConnection {
  public:
+  struct OneSidedBatchOp {
+    void* local_addr = nullptr;
+    size_t size = 0;
+    MRArray const* local_mr_array = nullptr;
+    FifoItem const* slot_item = nullptr;
+  };
+
   SendConnection(int numa_node, bool auto_start_polling = true,
                  double link_bandwidth_bps = 400.0 * 1e9 / 8.0)
       : numa_node_(numa_node),
@@ -360,6 +369,145 @@ class SendConnection : public RDMAConnection {
   }
 
   bool check(int64_t wr_id) { return tracker_->isAcknowledged(wr_id); }
+
+  bool canUseRawOneSidedBatch(SendType send_type) {
+    if (cc_.enabled()) return false;
+    if (send_type == SendType::Write &&
+        Compressor::getInstance().getCompressStrategy() !=
+            CompressStrategy::kNone) {
+      return false;
+    }
+    return true;
+  }
+
+  bool postWriteOrReadBatch(SendType send_type, OneSidedBatchOp const* ops,
+                            size_t num_ops, int64_t* wr_ids) {
+    if (unlikely(send_type != SendType::Write && send_type != SendType::Read)) {
+      UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - invalid "
+                         "send_type";
+      return false;
+    }
+    if (unlikely(!canUseRawOneSidedBatch(send_type))) return false;
+    if (unlikely((num_ops > 0 && ops == nullptr) || wr_ids == nullptr)) {
+      UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - null input";
+      return false;
+    }
+
+    size_t const num_channels = normalChannelCount();
+    if (unlikely(num_channels == 0 || num_channels > kQpNumPerChannel)) {
+      UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - invalid "
+                         "channel count: "
+                      << num_channels;
+      return false;
+    }
+
+    for (size_t i = 0; i < num_ops; ++i) {
+      auto const& op = ops[i];
+      if (unlikely(op.local_addr == nullptr || op.size == 0 ||
+                   op.size > std::numeric_limits<uint32_t>::max() ||
+                   op.local_mr_array == nullptr || op.slot_item == nullptr)) {
+        UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - invalid op "
+                        << i;
+        return false;
+      }
+      if (unlikely(ChunkSplitStrategy::getMessageChunkCount(op.size) != 1)) {
+        UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - op " << i
+                        << " requires chunking";
+        return false;
+      }
+    }
+
+    struct PreparedBatchOp {
+      size_t op_index = 0;
+      uint32_t channel_id = 0;
+      RDMADataChannel* channel = nullptr;
+      uint32_t local_key = 0;
+      uint32_t remote_key = 0;
+    };
+
+    std::vector<PreparedBatchOp> prepared_ops;
+    prepared_ops.reserve(num_ops);
+    for (size_t i = 0; i < num_ops; ++i) {
+      auto const& op = ops[i];
+      auto [channel_id, ch_ptr] = selectNextChannelRoundRobinFast();
+      if (unlikely(channel_id == 0 || ch_ptr == nullptr ||
+                   channel_id > num_channels ||
+                   channel_id > kQpNumPerChannel)) {
+        UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - failed to "
+                           "select channel";
+        return false;
+      }
+
+      auto* local_mr = op.local_mr_array->getKeyByChannelID(channel_id);
+      if (unlikely(local_mr == nullptr)) {
+        UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - missing "
+                           "local MR for op "
+                        << i << " channel " << channel_id;
+        return false;
+      }
+
+      RKeyArray remote_rkeys;
+      remote_rkeys.copyFrom(static_cast<char const*>(op.slot_item->padding));
+
+      PreparedBatchOp prepared{};
+      prepared.op_index = i;
+      prepared.channel_id = channel_id;
+      prepared.channel = ch_ptr;
+      prepared.local_key = local_mr->lkey;
+      prepared.remote_key = remote_rkeys.getKeyByChannelID(channel_id);
+      prepared_ops.push_back(prepared);
+    }
+
+    for (size_t i = 0; i < num_ops; ++i) wr_ids[i] = -1;
+    std::array<std::vector<RDMADataChannel::RawSendRequest>, kQpNumPerChannel>
+        channel_batches;
+    std::array<RDMADataChannel*, kQpNumPerChannel> channel_ptrs{};
+    size_t const reserve_per_channel =
+        (num_ops + num_channels - 1) / num_channels;
+    for (size_t i = 0; i < num_channels; ++i) {
+      channel_batches[i].reserve(reserve_per_channel);
+    }
+
+    for (auto const& prepared : prepared_ops) {
+      auto const& op = ops[prepared.op_index];
+
+      int64_t wr_id = tracker_->sendPacket(op.size);
+      if (unlikely(wr_id < 0)) {
+        UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - failed to "
+                           "allocate tracker wr_id for op "
+                        << prepared.op_index;
+        return false;
+      }
+      wr_ids[prepared.op_index] = wr_id;
+
+      RDMADataChannel::RawSendRequest raw{};
+      raw.send_type = send_type;
+      raw.wr_id = static_cast<uint64_t>(wr_id);
+      raw.local_addr = reinterpret_cast<uint64_t>(op.local_addr);
+      raw.local_len = static_cast<uint32_t>(op.size);
+      raw.local_key = prepared.local_key;
+      raw.remote_addr = op.slot_item->addr;
+      raw.remote_key = prepared.remote_key;
+
+      size_t const channel_idx = prepared.channel_id - 1;
+      channel_ptrs[channel_idx] = prepared.channel;
+      channel_batches[channel_idx].push_back(raw);
+    }
+
+    for (size_t i = 0; i < num_channels; ++i) {
+      if (channel_batches[i].empty()) continue;
+      if (unlikely(channel_ptrs[i] == nullptr ||
+                   channel_ptrs[i]->postRawBatch(channel_batches[i]) != 0)) {
+        UCCL_LOG(FATAL) << "SendConnection::postWriteOrReadBatch - failed to "
+                           "post channel batch "
+                        << (i + 1)
+                        << "; raw one-sided batch post failure is "
+                           "unrecoverable after tracker wr_ids are allocated";
+        return false;
+      }
+    }
+    return true;
+  }
 
   void setRemoteDecompressBuf(RemoteMemInfo const& m) {
     if (m.length == 0) return;

--- a/p2p/rdma/rdma_context.h
+++ b/p2p/rdma/rdma_context.h
@@ -62,6 +62,8 @@ class RdmaContext {
       throw std::runtime_error("ibv_query_device failed");
     }
     vendor_id_ = dev_attr.vendor_id;
+    max_qp_rd_atom_ = dev_attr.max_qp_rd_atom;
+    max_qp_init_rd_atom_ = dev_attr.max_qp_init_rd_atom;
 
     struct ibv_pd* pd = ibv_alloc_pd(ctx_.get());
     if (!pd) throw std::runtime_error("Failed to alloc pd");
@@ -84,6 +86,8 @@ class RdmaContext {
   }
 
   uint32_t getVendorID() const { return vendor_id_; }
+  uint8_t getMaxQpRdAtom() const { return max_qp_rd_atom_; }
+  uint8_t getMaxQpInitRdAtom() const { return max_qp_init_rd_atom_; }
 
   // Query GID by index
   void getGID(int gid_index, union ibv_gid* gid, int port = 1) const {
@@ -436,11 +440,20 @@ class RdmaContext {
 
   RegistrationMode getRegistrationMode(void* addr) const {
     bool is_gpu = isGpuPointer(addr);
-    bool use_dmabuf = (vendor_id_ == 0x8086 && is_gpu);
+    auto env_enabled = [](char const* name) {
+      char const* value = std::getenv(name);
+      return value != nullptr &&
+             (std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 ||
+              std::strcmp(value, "TRUE") == 0 ||
+              std::strcmp(value, "on") == 0 || std::strcmp(value, "ON") == 0);
+    };
+    bool force_dmabuf =
+        env_enabled("UCCL_P2P_USE_DMABUF") || env_enabled("USE_DMABUF");
+    bool use_dmabuf = is_gpu && (force_dmabuf || vendor_id_ == 0x8086);
     if (use_dmabuf) {
       UCCL_LOG(INFO, UCCL_RDMA)
-          << "GPU memory detected on irdma NIC (vendor=0x" << std::hex
-          << vendor_id_ << std::dec << "), using DMA-BUF registration";
+          << "GPU memory detected (vendor=0x" << std::hex << vendor_id_
+          << std::dec << "), using DMA-BUF registration";
     }
     return {is_gpu, use_dmabuf};
   }
@@ -457,6 +470,8 @@ class RdmaContext {
 
   std::shared_ptr<struct ibv_context> ctx_;
   std::shared_ptr<struct ibv_pd> pd_;
+  uint8_t max_qp_rd_atom_ = 1;
+  uint8_t max_qp_init_rd_atom_ = 1;
   std::mutex mr_cache_mu_;
   std::unordered_map<MrCacheKey, std::unique_ptr<MrCacheEntry>, MrCacheKeyHash>
       mr_cache_;

--- a/p2p/rdma/rdma_context.h
+++ b/p2p/rdma/rdma_context.h
@@ -440,20 +440,11 @@ class RdmaContext {
 
   RegistrationMode getRegistrationMode(void* addr) const {
     bool is_gpu = isGpuPointer(addr);
-    auto env_enabled = [](char const* name) {
-      char const* value = std::getenv(name);
-      return value != nullptr &&
-             (std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 ||
-              std::strcmp(value, "TRUE") == 0 ||
-              std::strcmp(value, "on") == 0 || std::strcmp(value, "ON") == 0);
-    };
-    bool force_dmabuf =
-        env_enabled("UCCL_P2P_USE_DMABUF") || env_enabled("USE_DMABUF");
-    bool use_dmabuf = is_gpu && (force_dmabuf || vendor_id_ == 0x8086);
+    bool use_dmabuf = (vendor_id_ == 0x8086 && is_gpu);
     if (use_dmabuf) {
       UCCL_LOG(INFO, UCCL_RDMA)
-          << "GPU memory detected (vendor=0x" << std::hex << vendor_id_
-          << std::dec << "), using DMA-BUF registration";
+          << "GPU memory detected on irdma NIC (vendor=0x" << std::hex
+          << vendor_id_ << std::dec << "), using DMA-BUF registration";
     }
     return {is_gpu, use_dmabuf};
   }

--- a/p2p/rdma/rdma_data_channel.h
+++ b/p2p/rdma/rdma_data_channel.h
@@ -35,6 +35,17 @@ inline std::unique_ptr<RDMADataChannelImpl> createRDMADataChannelImpl() {
 
 class RDMADataChannel {
  public:
+  struct RawSendRequest {
+    SendType send_type = SendType::Write;
+    uint64_t wr_id = 0;
+    uint64_t local_addr = 0;
+    uint32_t local_len = 0;
+    uint32_t local_key = 0;
+    uint64_t remote_addr = 0;
+    uint32_t remote_key = 0;
+    ImmData imm_data = 0;
+  };
+
   explicit RDMADataChannel(std::shared_ptr<RdmaContext> ctx,
                            uint32_t channel_id = 0)
       : ctx_(ctx),
@@ -113,12 +124,24 @@ class RDMADataChannel {
       local.swap(batch_);
       batch_bytes_ = 0;
     }
+    std::lock_guard<std::mutex> post_lock(post_mu_);
     bool use_legacy = (ctx_->getVendorID() == 0x1dd8 ||  // Broadcom
                        ctx_->getVendorID() == 0x8086);   // Intel irdma
     if (use_legacy) {
       return __flushBatch_legacy(local);
     }
     return __flushBatch_ex(local);
+  }
+
+  int postRawBatch(std::vector<RawSendRequest> const& batch) {
+    if (batch.empty()) return 0;
+    std::lock_guard<std::mutex> post_lock(post_mu_);
+    bool use_legacy = (ctx_->getVendorID() == 0x1dd8 ||  // Broadcom
+                       ctx_->getVendorID() == 0x8086);   // Intel irdma
+    if (use_legacy) {
+      return __postRawBatch_legacy(batch);
+    }
+    return __postRawBatch_ex(batch);
   }
 
   // Given a CQE wr_id, return all wr_ids that should be acknowledged in the
@@ -199,6 +222,7 @@ class RDMADataChannel {
       signaled = true;
       ack_unsig_count_ = 0;
     }
+    std::lock_guard<std::mutex> post_lock(post_mu_);
     int rc = impl_->postWrite(qp_, ah_, remote_meta_->qpn, kAckSignalMarker,
                               &sge, remote_addr, remote_rkey, signaled);
     if (unlikely(rc != 0)) {
@@ -248,6 +272,10 @@ class RDMADataChannel {
   std::vector<std::shared_ptr<RDMASendRequest>> batch_;
   size_t batch_bytes_ = 0;
   std::mutex batch_mu_;
+
+  // Verbs posting on a QP must be single-producer. Serialize direct posts,
+  // deferred flushes, raw vector batches, and ack writes on this channel.
+  std::mutex post_mu_;
 
   // Selective-signaling state: each batched flush emits one signaled CQE.
   // When that CQE arrives, all preceding unsignaled WRs in the same batch
@@ -391,6 +419,7 @@ class RDMADataChannel {
   }
 
   inline int postRequest(std::shared_ptr<RDMASendRequest> req) {
+    std::lock_guard<std::mutex> post_lock(post_mu_);
     if (ctx_->getVendorID() == 0x1dd8 ||  // Broadcom
         ctx_->getVendorID() == 0x8086) {  // Intel irdma
       // These NICs don't support ibv_wr_* extended posting API.
@@ -503,6 +532,107 @@ class RDMADataChannel {
       std::lock_guard<std::mutex> lock(pending_mu_);
       pending_groups_.push_back(
           {static_cast<uint64_t>(batch[last]->wr_id), std::move(unsignaled)});
+    }
+    return 0;
+  }
+
+  inline int __postRawBatch_ex(std::vector<RawSendRequest> const& batch) {
+    if (batch.empty()) return 0;
+    std::vector<struct ibv_sge> sges(batch.size());
+    size_t const last = batch.size() - 1;
+    bool const signal_all = uccl::is_efa_transport();
+    std::vector<uint64_t> unsignaled;
+    if (!signal_all) unsignaled.reserve(last);
+    auto* qpx = ibv_qp_to_qp_ex(qp_);
+    ibv_wr_start(qpx);
+    for (size_t i = 0; i < batch.size(); ++i) {
+      auto const& req = batch[i];
+      qpx->wr_id = req.wr_id;
+      qpx->comp_mask = 0;
+      qpx->wr_flags = (signal_all || i == last) ? IBV_SEND_SIGNALED : 0;
+      if (req.send_type == SendType::Send) {
+        ibv_wr_rdma_write_imm(qpx, req.remote_key, req.remote_addr,
+                              req.imm_data);
+      } else if (req.send_type == SendType::Write) {
+        ibv_wr_rdma_write(qpx, req.remote_key, req.remote_addr);
+      } else if (req.send_type == SendType::Read) {
+        ibv_wr_rdma_read(qpx, req.remote_key, req.remote_addr);
+      } else {
+        UCCL_LOG(ERROR) << "Unknown SendType in __postRawBatch_ex";
+        ibv_wr_abort(qpx);
+        return -1;
+      }
+      sges[i].addr = req.local_addr;
+      sges[i].length = req.local_len;
+      sges[i].lkey = req.local_key;
+      ibv_wr_set_sge_list(qpx, 1, &sges[i]);
+      impl_->setDstAddress(qpx, ah_, remote_meta_->qpn);
+      if (!signal_all && i != last) unsignaled.push_back(req.wr_id);
+    }
+    int ret = ibv_wr_complete(qpx);
+    if (ret) {
+      UCCL_LOG(ERROR) << "ibv_wr_complete failed in __postRawBatch_ex: " << ret
+                      << " " << strerror(ret) << ", batch_size=" << batch.size()
+                      << ", local_qpn=" << qp_->qp_num;
+      return ret;
+    }
+    if (!unsignaled.empty()) {
+      std::lock_guard<std::mutex> lock(pending_mu_);
+      pending_groups_.push_back({batch[last].wr_id, std::move(unsignaled)});
+    }
+    return 0;
+  }
+
+  inline int __postRawBatch_legacy(std::vector<RawSendRequest> const& batch) {
+    if (batch.empty()) return 0;
+    size_t const last = batch.size() - 1;
+    std::vector<struct ibv_send_wr> wrs(batch.size());
+    std::vector<struct ibv_sge> sges(batch.size());
+    std::vector<uint64_t> unsignaled;
+    unsignaled.reserve(last);
+    for (size_t i = 0; i < batch.size(); ++i) {
+      auto const& req = batch[i];
+      auto& wr = wrs[i];
+      std::memset(&wr, 0, sizeof(wr));
+      wr.wr_id = req.wr_id;
+      wr.send_flags = (i == last) ? IBV_SEND_SIGNALED : 0;
+      sges[i].addr = req.local_addr;
+      sges[i].length = req.local_len;
+      sges[i].lkey = req.local_key;
+      wr.sg_list = &sges[i];
+      wr.num_sge = 1;
+      if (req.send_type == SendType::Send) {
+        wr.opcode = IBV_WR_RDMA_WRITE_WITH_IMM;
+        wr.wr.rdma.remote_addr = req.remote_addr;
+        wr.wr.rdma.rkey = req.remote_key;
+        wr.imm_data = req.imm_data;
+      } else if (req.send_type == SendType::Write) {
+        wr.opcode = IBV_WR_RDMA_WRITE;
+        wr.wr.rdma.remote_addr = req.remote_addr;
+        wr.wr.rdma.rkey = req.remote_key;
+      } else if (req.send_type == SendType::Read) {
+        wr.opcode = IBV_WR_RDMA_READ;
+        wr.wr.rdma.remote_addr = req.remote_addr;
+        wr.wr.rdma.rkey = req.remote_key;
+      } else {
+        UCCL_LOG(ERROR) << "Unknown SendType in __postRawBatch_legacy";
+        return -1;
+      }
+      wr.next = (i + 1 < batch.size()) ? &wrs[i + 1] : nullptr;
+      if (i != last) unsignaled.push_back(req.wr_id);
+    }
+    struct ibv_send_wr* bad_wr = nullptr;
+    int ret = ibv_post_send(qp_, wrs.data(), &bad_wr);
+    if (ret) {
+      UCCL_LOG(ERROR) << "ibv_post_send failed in __postRawBatch_legacy: "
+                      << ret << " " << strerror(ret)
+                      << ", batch_size=" << batch.size()
+                      << ", local_qpn=" << qp_->qp_num;
+      return ret;
+    }
+    if (!unsignaled.empty()) {
+      std::lock_guard<std::mutex> lock(pending_mu_);
+      pending_groups_.push_back({batch[last].wr_id, std::move(unsignaled)});
     }
     return 0;
   }


### PR DESCRIPTION
## Description

- Optimize `writev/readv` with a raw batched one-sided submit path for single-chunk IOVs (**biggest win for writev performance**).
- Reduce per-IOV overhead by avoiding repeated request-object allocation, shared pointer bookkeeping, and generic single-request submit logic.
- Increasing RDMA READ outstanding depth from fixed `1` to a configurable value. Add `UCCL_P2P_RDMA_MAX_RD_ATOMIC` and `UCCL_P2P_RDMA_MAX_DEST_RD_ATOMIC` to control requester/responder outstanding RDMA READ depth. (Default value is `16`) (**biggest win for readv performance**)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [x] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
