### PR TITLE
[P2P] renaming to enhance readability

### DIFF
--- a/p2p/endpoint_wrapper.h
+++ b/p2p/endpoint_wrapper.h
@@ -4,24 +4,20 @@
 #include "util/gpu_rt.h"
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
-
-template <class T>
-struct always_false : std::false_type {};
-
-// Convert between the global ucclRequest and NcclRequest.
+// Convert between the global UcclRequest and NcclRequest.
 // They have different layouts (NCCL version has an extra context pointer).
-static inline NcclRequest to_nccl_req(ucclRequest const& r) {
+static inline NcclRequest to_nccl_req(UcclRequest const& r) {
   NcclRequest out{};
   out.type = static_cast<NcclReqType>(static_cast<int>(r.type));
-  out.n = r.n;
+  out.peer_id = r.peer_id;
   out.context = nullptr;
   out.engine_idx = r.engine_idx;
   return out;
 }
 
-static inline void from_nccl_req(NcclRequest const& in, ucclRequest* out) {
+static inline void from_nccl_req(NcclRequest const& in, UcclRequest* out) {
   out->type = static_cast<ReqType>(static_cast<int>(in.type));
-  out->n = in.n;
+  out->peer_id = in.peer_id;
   out->engine_idx = in.engine_idx;
 }
 
@@ -31,7 +27,7 @@ static inline ConnID to_conn_id(NcclConnID const& in) {
   out.context = in.context;
   out.sock_fd = in.sock_fd;
   out.dev = in.dev;
-  out.flow_id = in.flow_id;
+  out.peer_id = in.peer_id;
   return out;
 }
 
@@ -52,7 +48,7 @@ struct PooledSendBundle {
 static inline int set_request(std::shared_ptr<RDMAEndpoint> const& obj,
                               Conn* conn, P2PMhandle* local_mh, void* src,
                               size_t size, FifoItem const& slot_item,
-                              ucclRequest* ureq) {
+                              UcclRequest* ureq) {
   auto bundle = std::make_shared<PooledSendBundle>();
 
   bundle->remote_mem_obj.addr = slot_item.addr;
@@ -71,7 +67,7 @@ static inline int set_request(std::shared_ptr<RDMAEndpoint> const& obj,
   bundle->req.remote_mem =
       std::shared_ptr<RemoteMemInfo>(bundle, &bundle->remote_mem_obj);
   bundle->req.compress_ctx = local_mh->compress_ctx;
-  bundle->req.to_rank_id = conn->uccl_conn_id_.flow_id;
+  bundle->req.to_peer_id = conn->uccl_conn_id_.peer_id;
   bundle->req.send_type =
       (ureq->type == ReqType::ReqRead) ? SendType::Read : SendType::Write;
   bundle->req.need_signaled = true;
@@ -79,7 +75,7 @@ static inline int set_request(std::shared_ptr<RDMAEndpoint> const& obj,
   auto req = std::shared_ptr<RDMASendRequest>(bundle, &bundle->req);
 
   ureq->engine_idx = obj->writeOrRead(req);
-  ureq->n = conn->uccl_conn_id_.flow_id;
+  ureq->peer_id = conn->uccl_conn_id_.peer_id;
   return ureq->engine_idx;
 }
 
@@ -89,7 +85,7 @@ static inline int set_request(std::shared_ptr<RDMAEndpoint> const& obj,
 static inline int set_request_on_group(SendConnection* send_group, Conn* conn,
                                        P2PMhandle* local_mh, void* src,
                                        size_t size, FifoItem const& slot_item,
-                                       ucclRequest* ureq) {
+                                       UcclRequest* ureq) {
   auto bundle = std::make_shared<PooledSendBundle>();
 
   bundle->remote_mem_obj.addr = slot_item.addr;
@@ -107,7 +103,7 @@ static inline int set_request_on_group(SendConnection* send_group, Conn* conn,
   bundle->req.remote_mem =
       std::shared_ptr<RemoteMemInfo>(bundle, &bundle->remote_mem_obj);
   bundle->req.compress_ctx = local_mh->compress_ctx;
-  bundle->req.to_rank_id = conn->uccl_conn_id_.flow_id;
+  bundle->req.to_peer_id = conn->uccl_conn_id_.peer_id;
   bundle->req.send_type =
       (ureq->type == ReqType::ReqRead) ? SendType::Read : SendType::Write;
   bundle->req.need_signaled = true;
@@ -120,7 +116,7 @@ static inline int set_request_on_group(SendConnection* send_group, Conn* conn,
     if (wr_id < 0) std::this_thread::sleep_for(std::chrono::microseconds(10));
   }
   ureq->engine_idx = static_cast<int>(wr_id);
-  ureq->n = conn->uccl_conn_id_.flow_id;
+  ureq->peer_id = conn->uccl_conn_id_.peer_id;
   return ureq->engine_idx;
 }
 
@@ -212,14 +208,14 @@ inline bool uccl_regmr(GenericEndpoint const& ep, void* data, size_t len,
 
 inline int uccl_send_async(GenericEndpoint const& ep, Conn* conn,
                            P2PMhandle* mhandle, void const* data,
-                           size_t const size, ucclRequest* ureq) {
+                           size_t const size, UcclRequest* ureq) {
   return std::visit(
       [&](auto const& s) -> int {
         using T = std::decay_t<decltype(*s)>;
         if constexpr (std::is_same_v<T, NCCLEndpoint>) {
           (void)mhandle;
           ureq->type = ReqType::ReqTx;
-          ureq->n = conn->uccl_conn_id_.flow_id;
+          ureq->peer_id = conn->uccl_conn_id_.peer_id;
           NcclRequest nreq = to_nccl_req(*ureq);
           int ret = s->uccl_send_async(
               reinterpret_cast<NcclFlow*>(conn->uccl_conn_id_.context), nullptr,
@@ -234,13 +230,12 @@ inline int uccl_send_async(GenericEndpoint const& ep, Conn* conn,
           auto send_req =
               std::make_shared<RDMASendRequest>(send_mem, remote_mem);
           send_req->compress_ctx = mhandle->compress_ctx;
+          send_req->to_peer_id = conn->uccl_conn_id_.peer_id;
           ureq->type = ReqType::ReqTx;
-          send_req->to_rank_id = conn->uccl_conn_id_.flow_id;
-          ureq->engine_idx = s->sendWithoutInnerQueue(send_req);
-          while (ureq->engine_idx < 0) {
+          do {
             ureq->engine_idx = s->sendWithoutInnerQueue(send_req);
-          }
-          ureq->n = conn->uccl_conn_id_.flow_id;
+          } while (ureq->engine_idx < 0);
+          ureq->peer_id = conn->uccl_conn_id_.peer_id;
           return ureq->engine_idx;
         }
       },
@@ -249,14 +244,14 @@ inline int uccl_send_async(GenericEndpoint const& ep, Conn* conn,
 
 inline int uccl_recv_async(GenericEndpoint const& ep, Conn* conn,
                            P2PMhandle* mhandles, void** data, int* size, int n,
-                           ucclRequest* ureq) {
+                           UcclRequest* ureq) {
   return std::visit(
       [&](auto const& s) -> int {
         using T = std::decay_t<decltype(*s)>;
         if constexpr (std::is_same_v<T, NCCLEndpoint>) {
           (void)mhandles;
           ureq->type = ReqType::ReqRx;
-          ureq->n = conn->uccl_conn_id_.flow_id;
+          ureq->peer_id = conn->uccl_conn_id_.peer_id;
           NcclRequest nreq = to_nccl_req(*ureq);
           int ret = s->uccl_recv_async(
               reinterpret_cast<NcclFlow*>(conn->uccl_conn_id_.context), nullptr,
@@ -270,15 +265,15 @@ inline int uccl_recv_async(GenericEndpoint const& ep, Conn* conn,
           auto recv_req = std::make_shared<RDMARecvRequest>(recv_mem);
           recv_req->compress_ctx = mhandles->compress_ctx;
           ureq->type = ReqType::ReqRx;
-          ureq->engine_idx = s->recv(conn->uccl_conn_id_.flow_id, recv_req);
-          ureq->n = conn->uccl_conn_id_.flow_id;
+          ureq->engine_idx = s->recv(conn->uccl_conn_id_.peer_id, recv_req);
+          ureq->peer_id = conn->uccl_conn_id_.peer_id;
           return ureq->engine_idx;
         }
       },
       ep);
 }
 
-inline bool uccl_poll_ureq_once(GenericEndpoint const& ep, ucclRequest* ureq) {
+inline bool uccl_poll_ureq_once(GenericEndpoint const& ep, UcclRequest* ureq) {
   return std::visit(
       [&](auto const& s) -> bool {
         using T = std::decay_t<decltype(*s)>;
@@ -291,10 +286,10 @@ inline bool uccl_poll_ureq_once(GenericEndpoint const& ep, ucclRequest* ureq) {
           if (ureq->type == ReqType::ReqTx || ureq->type == ReqType::ReqWrite ||
               ureq->type == ReqType::ReqRead) {
             s->sendRoutine();
-            return s->checkSendComplete_once(ureq->n, ureq->engine_idx);
+            return s->checkSendComplete_once(ureq->peer_id, ureq->engine_idx);
           } else if (ureq->type == ReqType::ReqRx) {
             s->recvRoutine();
-            return s->checkRecvComplete_once(ureq->n, ureq->engine_idx);
+            return s->checkRecvComplete_once(ureq->peer_id, ureq->engine_idx);
           }
           UCCL_LOG(ERROR) << "Invalid request type: " << ureq->type;
           return false;
@@ -330,17 +325,17 @@ inline void uccl_flush_send(GenericEndpoint const& ep) {
       ep);
 }
 
-// Resolve the SendConnection for a rank_id once. Returns nullptr on the
+// Resolve the SendConnection for a peer_id once. Returns nullptr on the
 // NCCL path or if not found. Callers can then use uccl_check_wr_fast() to
 // avoid the per-call mutex + map lookup in checkSendComplete_once().
 inline SendConnection* uccl_resolve_send_group(GenericEndpoint const& ep,
-                                               uint64_t rank_id) {
+                                               uint64_t peer_id) {
   SendConnection* result = nullptr;
   std::visit(
       [&](auto const& s) {
         using T = std::decay_t<decltype(*s)>;
         if constexpr (!std::is_same_v<T, NCCLEndpoint>) {
-          result = s->getSendGroupRaw(rank_id);
+          result = s->getSendGroupRaw(peer_id);
         }
       },
       ep);
@@ -366,7 +361,7 @@ inline void uccl_drive_recv(GenericEndpoint const& ep) {
 // Check completion of a single request without driving the send/recv pollers.
 // Use together with uccl_drive_send/uccl_drive_recv to amortize the polling
 // work across many in-flight requests.
-inline bool uccl_check_ureq_once(GenericEndpoint const& ep, ucclRequest* ureq) {
+inline bool uccl_check_ureq_once(GenericEndpoint const& ep, UcclRequest* ureq) {
   return std::visit(
       [&](auto const& s) -> bool {
         using T = std::decay_t<decltype(*s)>;
@@ -378,9 +373,9 @@ inline bool uccl_check_ureq_once(GenericEndpoint const& ep, ucclRequest* ureq) {
         } else {
           if (ureq->type == ReqType::ReqTx || ureq->type == ReqType::ReqWrite ||
               ureq->type == ReqType::ReqRead) {
-            return s->checkSendComplete_once(ureq->n, ureq->engine_idx);
+            return s->checkSendComplete_once(ureq->peer_id, ureq->engine_idx);
           } else if (ureq->type == ReqType::ReqRx) {
-            return s->checkRecvComplete_once(ureq->n, ureq->engine_idx);
+            return s->checkRecvComplete_once(ureq->peer_id, ureq->engine_idx);
           }
           UCCL_LOG(ERROR) << "Invalid request type: " << ureq->type;
           return false;
@@ -391,14 +386,14 @@ inline bool uccl_check_ureq_once(GenericEndpoint const& ep, ucclRequest* ureq) {
 
 inline int uccl_read_async(GenericEndpoint const& ep, Conn* conn,
                            P2PMhandle* local_mh, void* dst, size_t size,
-                           FifoItem const& slot_item, ucclRequest* ureq) {
+                           FifoItem const& slot_item, UcclRequest* ureq) {
   return std::visit(
       [&](auto const& s) -> int {
         using T = std::decay_t<decltype(*s)>;
         if constexpr (std::is_same_v<T, NCCLEndpoint>) {
           (void)local_mh;
           ureq->type = ReqType::ReqRead;
-          ureq->n = conn->uccl_conn_id_.flow_id;
+          ureq->peer_id = conn->uccl_conn_id_.peer_id;
           NcclFifoItem nccl_item{};
           nccl_item.addr = slot_item.addr;
           nccl_item.size = static_cast<uint32_t>(size);
@@ -419,14 +414,14 @@ inline int uccl_read_async(GenericEndpoint const& ep, Conn* conn,
 
 inline int uccl_write_async(GenericEndpoint const& ep, Conn* conn,
                             P2PMhandle* local_mh, void* src, size_t size,
-                            FifoItem const& slot_item, ucclRequest* ureq) {
+                            FifoItem const& slot_item, UcclRequest* ureq) {
   return std::visit(
       [&](auto const& s) -> int {
         using T = std::decay_t<decltype(*s)>;
         if constexpr (std::is_same_v<T, NCCLEndpoint>) {
           (void)local_mh;
           ureq->type = ReqType::ReqWrite;
-          ureq->n = conn->uccl_conn_id_.flow_id;
+          ureq->peer_id = conn->uccl_conn_id_.peer_id;
           NcclFifoItem nccl_item{};
           nccl_item.addr = slot_item.addr;
           nccl_item.size = static_cast<uint32_t>(size);
@@ -450,7 +445,7 @@ inline int uccl_write_async(GenericEndpoint const& ep, Conn* conn,
 inline int uccl_write_async_on_group(SendConnection* send_group, Conn* conn,
                                      P2PMhandle* local_mh, void* src,
                                      size_t size, FifoItem const& slot_item,
-                                     ucclRequest* ureq) {
+                                     UcclRequest* ureq) {
   ureq->type = ReqType::ReqWrite;
   return set_request_on_group(send_group, conn, local_mh, src, size, slot_item,
                               ureq);
@@ -459,7 +454,7 @@ inline int uccl_write_async_on_group(SendConnection* send_group, Conn* conn,
 inline int uccl_read_async_on_group(SendConnection* send_group, Conn* conn,
                                     P2PMhandle* local_mh, void* dst,
                                     size_t size, FifoItem const& slot_item,
-                                    ucclRequest* ureq) {
+                                    UcclRequest* ureq) {
   ureq->type = ReqType::ReqRead;
   return set_request_on_group(send_group, conn, local_mh, dst, size, slot_item,
                               ureq);
@@ -537,10 +532,10 @@ inline std::shared_ptr<EpollClient> get_oob_client(GenericEndpoint const& ep) {
 }
 
 inline std::string get_oob_conn_key(GenericEndpoint const& ep,
-                                    uint64_t rank_id) {
+                                    uint64_t peer_id) {
   return std::visit(
       [&](auto const& s) -> std::string {
-        return s->get_oob_conn_key(rank_id);
+        return s->get_oob_conn_key(peer_id);
       },
       ep);
 }

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -223,7 +223,7 @@ Endpoint::Endpoint(uint32_t const gpu_idx) : passive_accept_(false) {
         uccl::cc::CongestionControlState::parseMode("UCCL_P2P_RDMA_CC") !=
         uccl::cc::CongestionControlState::Mode::kNone;
     ep_ = std::shared_ptr<RDMAEndpoint>(
-        new RDMAEndpoint(local_gpu_idx_, INVALID_RANK_ID, 0, cc_polling));
+        new RDMAEndpoint(local_gpu_idx_, 0, cc_polling));
   }
 
   std::cout << "Engine initialized for GPU " << local_gpu_idx_ << std::endl;
@@ -296,8 +296,8 @@ Endpoint::Endpoint() : local_gpu_idx_(INVALID_GPU), passive_accept_(false) {
   if (uccl::is_nccl_transport()) {
     ep_ = std::make_shared<NCCLEndpoint>(local_gpu_idx_, 0);
   } else {
-    ep_ = std::shared_ptr<RDMAEndpoint>(
-        new RDMAEndpoint(INVALID_GPU, INVALID_RANK_ID, 0, false));
+    ep_ =
+        std::shared_ptr<RDMAEndpoint>(new RDMAEndpoint(INVALID_GPU, 0, false));
   }
 
   std::cout << "Endpoint initialized successfully" << std::endl;
@@ -559,7 +559,7 @@ bool Endpoint::accept(std::string& ip_addr, int& remote_gpu_idx,
   ConnID uccl_conn_id = uccl_conn_id_future.get();
 
   // Return if Conn ID is invalid
-  if (uccl_conn_id.sock_fd < 0 || uccl_conn_id.flow_id == UINT64_MAX) {
+  if (uccl_conn_id.sock_fd < 0 || uccl_conn_id.peer_id == UINT64_MAX) {
     return false;
   }
 
@@ -696,7 +696,7 @@ bool Endpoint::send(uint64_t conn_id, uint64_t mr_id, void const* data,
     return false;
   }
 
-  ucclRequest ureq;
+  UcclRequest ureq;
 
   auto* cur_data = const_cast<void*>(data);
   auto to_send = size;
@@ -723,7 +723,7 @@ bool Endpoint::recv(uint64_t conn_id, uint64_t mr_id, void* data, size_t size) {
   }
   int size_int = static_cast<int>(size);
 
-  ucclRequest ureq;
+  UcclRequest ureq;
 
   void* cur_data = data;
   while (uccl_recv_async(ep_, conn, mhandle, &cur_data, &size_int, 1, &ureq) ==
@@ -788,7 +788,7 @@ bool Endpoint::sendv(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
     return false;
   }
 
-  ucclRequest ureq[kMaxInflightOps] = {};
+  UcclRequest ureq[kMaxInflightOps] = {};
   bool done[kMaxInflightOps] = {false};
   std::vector<P2PMhandle*> mhandles(num_iovs);
 
@@ -874,7 +874,7 @@ bool Endpoint::recvv(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
     return false;
   }
 
-  ucclRequest ureq[kMaxInflightOps] = {};
+  UcclRequest ureq[kMaxInflightOps] = {};
   bool done[kMaxInflightOps] = {false};
   std::vector<P2PMhandle*> mhandles(num_iovs);
 
@@ -961,7 +961,7 @@ bool Endpoint::read(uint64_t conn_id, uint64_t mr_id, void* dst, size_t size,
     return false;
   }
 
-  ucclRequest ureq = {};
+  UcclRequest ureq = {};
   FifoItem curr_slot_item = slot_item;
   curr_slot_item.size = size;
 
@@ -996,7 +996,7 @@ bool Endpoint::read_async(uint64_t conn_id, uint64_t mr_id, void* dst,
       return false;
     }
 
-    ucclRequest ureq = {};
+    UcclRequest ureq = {};
     FifoItem curr_slot_item = slot_item;
     curr_slot_item.size = size;
     while (uccl_read_async(ep_, conn, mhandle, dst, size, curr_slot_item,
@@ -1061,7 +1061,7 @@ bool Endpoint::readv(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
   // Resolve the send group once so per-slot completion checks avoid the
   // per-call shared_lock + map.find().
   SendConnection* send_group =
-      uccl_resolve_send_group(ep_, conn->uccl_conn_id_.flow_id);
+      uccl_resolve_send_group(ep_, conn->uccl_conn_id_.peer_id);
 
   bool raw_batch_eligible = true;
   for (size_t i = 0; i < num_iovs; ++i) {
@@ -1107,7 +1107,7 @@ bool Endpoint::readv(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
     return true;
   }
 
-  ucclRequest ureq[kMaxInflightOps] = {};
+  UcclRequest ureq[kMaxInflightOps] = {};
   bool active[kMaxInflightOps] = {false};
 
   size_t next_iov = 0;
@@ -1204,7 +1204,7 @@ bool Endpoint::write(uint64_t conn_id, uint64_t mr_id, void* src, size_t size,
     std::cerr << "[write] Error: Invalid mr_id " << mr_id << std::endl;
     return false;
   }
-  ucclRequest ureq = {};
+  UcclRequest ureq = {};
   FifoItem curr_slot_item = slot_item;
   curr_slot_item.size = size;
 
@@ -1239,7 +1239,7 @@ bool Endpoint::write_async(uint64_t conn_id, uint64_t mr_id, void* src,
       return false;
     }
 
-    ucclRequest ureq = {};
+    UcclRequest ureq = {};
     FifoItem curr_slot_item = slot_item;
     curr_slot_item.size = size;
     while (uccl_write_async(ep_, conn, mhandle, src, size, curr_slot_item,
@@ -1306,7 +1306,7 @@ bool Endpoint::writev(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
   // Resolve the send group once so per-slot completion checks avoid the
   // per-call shared_lock + map.find().
   SendConnection* send_group =
-      uccl_resolve_send_group(ep_, conn->uccl_conn_id_.flow_id);
+      uccl_resolve_send_group(ep_, conn->uccl_conn_id_.peer_id);
 
   bool raw_batch_eligible = true;
   for (size_t i = 0; i < num_iovs; ++i) {
@@ -1352,7 +1352,7 @@ bool Endpoint::writev(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
     return true;
   }
 
-  ucclRequest ureq[kMaxInflightOps] = {};
+  UcclRequest ureq[kMaxInflightOps] = {};
   bool active[kMaxInflightOps] = {false};
 
   size_t next_iov = 0;
@@ -2624,11 +2624,11 @@ std::string Endpoint::get_oob_conn_key(uint64_t conn_id) const {
   if (it == conn_id_to_conn_.end()) {
     return "";
   }
-  uint64_t rank_id = it->second->uccl_conn_id_.flow_id;
+  uint64_t peer_id = it->second->uccl_conn_id_.peer_id;
 
   return std::visit(
       [&](auto const& s) -> std::string {
-        return s->get_oob_conn_key(rank_id);
+        return s->get_oob_conn_key(peer_id);
       },
       ep_);
 }
@@ -2644,13 +2644,13 @@ int Endpoint::send_notification(uint64_t conn_id,
   if (conn == nullptr) {
     return -1;
   }
-  uint64_t flow_id = conn->uccl_conn_id_.flow_id;
-  if (flow_id == UINT64_MAX) {
+  uint64_t peer_id = conn->uccl_conn_id_.peer_id;
+  if (peer_id == UINT64_MAX) {
     return -1;
   }
   auto* nccl_ep = std::get_if<std::shared_ptr<NCCLEndpoint>>(&ep_);
   if (!nccl_ep || !*nccl_ep) return -1;
-  return (*nccl_ep)->send_notification(flow_id, notification);
+  return (*nccl_ep)->send_notification(peer_id, notification);
 }
 
 MR* Endpoint::get_mr(uint64_t mr_id) const {

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -214,7 +214,7 @@ Endpoint::Endpoint(uint32_t const gpu_idx) : passive_accept_(false) {
 
   uccl::ucclLogger.setLogLevel(Endpoint::parse_log_level_from_env());
 
-  if (uccl::is_nccl_transport()) {
+  if (is_nccl_transport()) {
     ep_ = std::make_shared<NCCLEndpoint>(local_gpu_idx_, 0);
     numa_node_ = get_numa_node_from_iface();
   } else {
@@ -234,7 +234,7 @@ Endpoint::Endpoint(uint32_t const gpu_idx) : passive_accept_(false) {
   recv_unified_task_ring_ =
       uccl::create_ring(sizeof(UnifiedTask*), kTaskRingSize);
 
-  if (!uccl::is_nccl_transport()) {
+  if (!is_nccl_transport()) {
     numa_node_ = RdmaDeviceManager::instance().get_numa_node(
         RdmaDeviceManager::instance().get_best_dev_idx(local_gpu_idx_)[0]);
   }
@@ -293,7 +293,7 @@ Endpoint::Endpoint() : local_gpu_idx_(INVALID_GPU), passive_accept_(false) {
   GPU_RT_CHECK(gpuDeviceGetPCIBusId(bdf_buf, sizeof(bdf_buf), cur_dev));
   gpu_bus_id_ = uccl::normalize_pci_bus_id(bdf_buf);
 
-  if (uccl::is_nccl_transport()) {
+  if (is_nccl_transport()) {
     ep_ = std::make_shared<NCCLEndpoint>(local_gpu_idx_, 0);
   } else {
     ep_ =
@@ -573,7 +573,7 @@ bool Endpoint::accept(std::string& ip_addr, int& remote_gpu_idx,
 }
 
 bool Endpoint::reg(void const* data, size_t size, uint64_t& mr_id,
-                   uccl::FloatType float_type) {
+                   FloatType float_type) {
   mr_id = next_mr_id_.fetch_add(1);
 
   if (!engine_initialized_) {
@@ -2635,7 +2635,7 @@ std::string Endpoint::get_oob_conn_key(uint64_t conn_id) const {
 
 int Endpoint::send_notification(uint64_t conn_id,
                                 NotifyMsg const& notification) const {
-  if (!uccl::is_nccl_transport()) {
+  if (!is_nccl_transport()) {
     (void)conn_id;
     (void)notification;
     return -1;
@@ -2685,7 +2685,7 @@ void Endpoint::initialize_engine() {
   int n_streams = std::max(1, (int)kNumGpuRtStreams);
   GPU_RT_CHECK(gpuSetDevice(local_gpu_idx_));
 
-  if (uccl::is_nccl_transport()) {
+  if (is_nccl_transport()) {
     numa_node_ = get_numa_node_from_iface();
   } else {
     numa_node_ = RdmaDeviceManager::instance().get_numa_node(

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -292,7 +292,7 @@ class Endpoint {
 
   /* Register the data with a specific interface. */
   bool reg(void const* data, size_t size, uint64_t& mr_id,
-           uccl::FloatType float_type = uccl::FloatType::kFloat32);
+           FloatType float_type = FloatType::kFloat32);
 
   bool regv(std::vector<void const*> const& data_v,
             std::vector<size_t> const& size_v, std::vector<uint64_t>& mr_id_v);

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -34,9 +34,9 @@ using GenericEndpoint =
 // The NCCL shim functions in endpoint_wrapper.h convert as needed.
 enum ReqType { ReqTx, ReqRx, ReqRead, ReqWrite };
 
-struct ucclRequest {
+struct UcclRequest {
   enum ReqType type;
-  uint32_t n;
+  uint32_t peer_id;
   uint32_t engine_idx;
 };
 
@@ -180,7 +180,7 @@ struct TransferStatus {
   std::atomic<bool> done{false};
   std::shared_ptr<UnifiedTask> task_ptr;
   bool poll_net_ureq{false};
-  ucclRequest ureq{};
+  UcclRequest ureq{};
 };
 
 struct alignas(64) UnifiedTask {

--- a/p2p/engine_api.cc
+++ b/p2p/engine_api.cc
@@ -1504,9 +1504,8 @@ NB_MODULE(p2p, m) {
             return nb::make_tuple(success, is_done);
           },
           "Poll the status of an asynchronous transfer", nb::arg("transfer_id"))
-      .def(
-          "conn_id_of_rank", &Endpoint::conn_id_of_rank,
-          "Get the connection ID for a given peer rank (or UINT64_MAX if none)",
-          nb::arg("rank"))
+      .def("conn_id_of_rank", &Endpoint::conn_id_of_rank,
+           "Get the connection ID for a given peer (or UINT64_MAX if none)",
+           nb::arg("rank"))
       .def("__repr__", [](Endpoint const& e) { return "<UCCL P2P Endpoint>"; });
 }

--- a/p2p/engine_api.cc
+++ b/p2p/engine_api.cc
@@ -170,13 +170,13 @@ NB_MODULE(p2p, m) {
                " size=" + std::to_string(d.size) +
                " mr_id=" + std::to_string(d.mr_id) + ">";
       });
-  nb::enum_<uccl::FloatType>(m, "FloatType")
-      .value("kUndefined", uccl::FloatType::kUndefined)
-      .value("kFloat16", uccl::FloatType::kFloat16)
-      .value("kBFloat16", uccl::FloatType::kBFloat16)
-      .value("kFloat32", uccl::FloatType::kFloat32)
-      .value("kFloat8E4M3FN", uccl::FloatType::kFloat8E4M3FN)
-      .value("kFloat8E5M2", uccl::FloatType::kFloat8E5M2)
+  nb::enum_<FloatType>(m, "FloatType")
+      .value("kUndefined", FloatType::kUndefined)
+      .value("kFloat16", FloatType::kFloat16)
+      .value("kBFloat16", FloatType::kBFloat16)
+      .value("kFloat32", FloatType::kFloat32)
+      .value("kFloat8E4M3FN", FloatType::kFloat8E4M3FN)
+      .value("kFloat8E5M2", FloatType::kFloat8E5M2)
       .export_values();
 
   // Endpoint class binding
@@ -279,8 +279,7 @@ NB_MODULE(p2p, m) {
           "Accept an incoming connection")
       .def(
           "reg",
-          [](Endpoint& self, uint64_t ptr, size_t size,
-             uccl::FloatType floatType) {
+          [](Endpoint& self, uint64_t ptr, size_t size, FloatType floatType) {
             uint64_t mr_id;
             bool success;
             {
@@ -292,7 +291,7 @@ NB_MODULE(p2p, m) {
             return nb::make_tuple(success, mr_id);
           },
           "Register a data buffer", nb::arg("ptr"), nb::arg("size"),
-          nb::arg("floatType") = uccl::FloatType::kUndefined)
+          nb::arg("floatType") = FloatType::kUndefined)
       .def(
           "regv",
           [](Endpoint& self, std::vector<uintptr_t> const& ptrs,

--- a/p2p/nccl/nccl_endpoint.cc
+++ b/p2p/nccl/nccl_endpoint.cc
@@ -110,8 +110,7 @@ NcclConnID make_invalid_conn() {
   NcclConnID invalid{};
   invalid.context = nullptr;
   invalid.sock_fd = -1;
-  invalid.flow_id = UINT64_MAX;
-  invalid.peer_id = 0;
+  invalid.peer_id = UINT64_MAX;
   invalid.dev = -1;
   return invalid;
 }
@@ -137,8 +136,8 @@ int get_numa_node_from_iface() {
 struct NCCLEndpoint::Conn {
   // One NCCL control socket + two NCCL communicators (one per direction).
   int sock_fd = -1;
-  int rank = -1;
-  int remote_rank = -1;
+  int peer = -1;
+  int remote_peer = -1;
   int local_gpu_idx = 0;
   ncclComm_t comm[2] = {nullptr, nullptr};
   gpuStream_t stream[2] = {nullptr, nullptr};
@@ -262,9 +261,9 @@ bool NCCLEndpoint::init_comm_(Conn& conn, ncclUniqueId const& uid,
   // comm_index selects which NCCL communicator (0 or 1) to init.
   if (comm_index < 0 || comm_index > 1) return false;
   if (gpuSetDevice(conn.local_gpu_idx) != gpuSuccess) return false;
-  ncclResult_t rc = ncclCommInitRank(&conn.comm[comm_index], 2, uid, conn.rank);
+  ncclResult_t rc = ncclCommInitRank(&conn.comm[comm_index], 2, uid, conn.peer);
   if (rc != ncclSuccess) {
-    std::cerr << "[nccl] ncclCommInitRank failed: " << ncclGetErrorString(rc)
+    std::cerr << "[nccl] ncclCommInitPeer failed: " << ncclGetErrorString(rc)
               << std::endl;
     return false;
   }
@@ -374,7 +373,7 @@ bool NCCLEndpoint::send_internal_(Conn& conn, void const* data, size_t size,
     return false;
   }
   // Enqueue NCCL send on the selected communicator/stream.
-  ncclResult_t rc = ncclSend(data, size, ncclChar, conn.remote_rank,
+  ncclResult_t rc = ncclSend(data, size, ncclChar, conn.remote_peer,
                              conn.comm[comm_index], conn.stream[comm_index]);
   if (rc != ncclSuccess) {
     std::cerr << "[nccl] ncclSend failed: " << ncclGetErrorString(rc)
@@ -391,7 +390,7 @@ bool NCCLEndpoint::send_internal_(Conn& conn, void const* data, size_t size,
     return false;
   }
 
-  // Track completion via ucclRequest.
+  // Track completion via UcclRequest.
   auto* handle = new AsyncHandle();
   handle->event = evt;
   ureq->context = handle;
@@ -414,7 +413,7 @@ bool NCCLEndpoint::recv_internal_(Conn& conn, void* data, size_t size,
     return false;
   }
   // Enqueue NCCL recv on the selected communicator/stream.
-  ncclResult_t rc = ncclRecv(data, size, ncclChar, conn.remote_rank,
+  ncclResult_t rc = ncclRecv(data, size, ncclChar, conn.remote_peer,
                              conn.comm[comm_index], conn.stream[comm_index]);
   if (rc != ncclSuccess) {
     std::cerr << "[nccl] ncclRecv failed: " << ncclGetErrorString(rc)
@@ -431,7 +430,7 @@ bool NCCLEndpoint::recv_internal_(Conn& conn, void* data, size_t size,
     return false;
   }
 
-  // Track completion via ucclRequest.
+  // Track completion via UcclRequest.
   auto* handle = new AsyncHandle();
   handle->event = evt;
   ureq->context = handle;
@@ -516,8 +515,8 @@ NcclConnID NCCLEndpoint::uccl_connect(int dev, int local_gpuidx, int remote_dev,
   // Build connection state and initialize NCCL communicators.
   auto conn = std::make_unique<Conn>();
   conn->sock_fd = fd;
-  conn->rank = 1;
-  conn->remote_rank = 0;
+  conn->peer = 1;
+  conn->remote_peer = 0;
   conn->local_gpu_idx = local_idx;
 
   if (!init_comms_(*conn, sh.uid_rank0, sh.uid_rank1)) {
@@ -525,11 +524,11 @@ NcclConnID NCCLEndpoint::uccl_connect(int dev, int local_gpuidx, int remote_dev,
     return make_invalid_conn();
   }
 
-  uint64_t flow_id = next_flow_id_.fetch_add(1);
+  uint64_t peer_id = next_peer_id_.fetch_add(1);
   Conn* conn_ptr = conn.get();
   {
     std::lock_guard<std::mutex> lock(conn_mu_);
-    conn_map_.emplace(flow_id, std::move(conn));
+    conn_map_.emplace(peer_id, std::move(conn));
   }
   conn_ptr->ctrl_thread =
       std::thread(&NCCLEndpoint::control_loop_, this, conn_ptr);
@@ -537,8 +536,7 @@ NcclConnID NCCLEndpoint::uccl_connect(int dev, int local_gpuidx, int remote_dev,
   NcclConnID conn_id{};
   conn_id.context = conn_ptr;
   conn_id.sock_fd = conn_ptr->sock_fd;
-  conn_id.flow_id = flow_id;
-  conn_id.peer_id = 0;
+  conn_id.peer_id = peer_id;
   conn_id.dev = dev;
   return conn_id;
 }
@@ -627,8 +625,8 @@ NcclConnID NCCLEndpoint::uccl_accept(int dev, int listen_fd, int local_gpuidx,
   // Build connection state and initialize NCCL communicators.
   auto conn = std::make_unique<Conn>();
   conn->sock_fd = conn_fd;
-  conn->rank = 0;
-  conn->remote_rank = 1;
+  conn->peer = 0;
+  conn->remote_peer = 1;
   conn->local_gpu_idx = local_idx;
 
   if (!init_comms_(*conn, uid_rank0, uid_rank1)) {
@@ -636,11 +634,11 @@ NcclConnID NCCLEndpoint::uccl_accept(int dev, int listen_fd, int local_gpuidx,
     return make_invalid_conn();
   }
 
-  uint64_t flow_id = next_flow_id_.fetch_add(1);
+  uint64_t peer_id = next_peer_id_.fetch_add(1);
   Conn* conn_ptr = conn.get();
   {
     std::lock_guard<std::mutex> lock(conn_mu_);
-    conn_map_.emplace(flow_id, std::move(conn));
+    conn_map_.emplace(peer_id, std::move(conn));
   }
   conn_ptr->ctrl_thread =
       std::thread(&NCCLEndpoint::control_loop_, this, conn_ptr);
@@ -648,8 +646,7 @@ NcclConnID NCCLEndpoint::uccl_accept(int dev, int listen_fd, int local_gpuidx,
   NcclConnID conn_id{};
   conn_id.context = conn_ptr;
   conn_id.sock_fd = conn_ptr->sock_fd;
-  conn_id.flow_id = flow_id;
-  conn_id.peer_id = 0;
+  conn_id.peer_id = peer_id;
   conn_id.dev = dev;
   return conn_id;
 }
@@ -815,19 +812,19 @@ int NCCLEndpoint::prepare_fifo_metadata(NcclFlow* flow, NcclMhandle** mhandle,
   return 0;
 }
 
-int NCCLEndpoint::get_sock_fd(uint64_t flow_id) {
+int NCCLEndpoint::get_sock_fd(uint64_t peer_id) {
   std::lock_guard<std::mutex> lock(conn_mu_);
-  auto it = conn_map_.find(flow_id);
+  auto it = conn_map_.find(peer_id);
   if (it == conn_map_.end()) {
     return -1;
   }
   return it->second->sock_fd;
 }
 
-int NCCLEndpoint::send_notification(uint64_t flow_id,
+int NCCLEndpoint::send_notification(uint64_t peer_id,
                                     ::NotifyMsg const& notification) {
   std::lock_guard<std::mutex> lock(conn_mu_);
-  auto it = conn_map_.find(flow_id);
+  auto it = conn_map_.find(peer_id);
   if (it == conn_map_.end()) {
     return -1;
   }

--- a/p2p/nccl/nccl_endpoint.h
+++ b/p2p/nccl/nccl_endpoint.h
@@ -11,13 +11,11 @@
 #include <string>
 #include <unordered_map>
 
-using NcclFlowID = uint64_t;
 using NcclPeerID = uint64_t;
 
 struct NcclConnID {
   void* context;
   int sock_fd;
-  NcclFlowID flow_id;
   NcclPeerID peer_id;
   int dev;
 };
@@ -42,7 +40,7 @@ enum class NcclReqType { ReqTx, ReqRx, ReqRead, ReqWrite };
 
 struct NcclRequest {
   NcclReqType type;
-  uint32_t n;
+  uint32_t peer_id;
   void* context;
   uint32_t engine_idx;
 };
@@ -69,8 +67,8 @@ class NCCLEndpoint {
   // RDMA endpoint exposes these for OOB metadata exchange; NCCL path doesn't
   // use EpollClient but we keep stubs so engine code can compile unchanged.
   std::shared_ptr<EpollClient> get_oob_client() const { return nullptr; }
-  std::string get_oob_conn_key(uint64_t rank_id) const {
-    (void)rank_id;
+  std::string get_oob_conn_key(uint64_t peer_id) const {
+    (void)peer_id;
     return "";
   }
 
@@ -116,10 +114,10 @@ class NCCLEndpoint {
   int get_best_dev_idx(int gpu_idx) { return 0; }
 
   // Get the socket file descriptor for a connection.
-  int get_sock_fd(uint64_t flow_id);
+  int get_sock_fd(uint64_t peer_id);
 
   // Send a notification message to a peer (uses NotifyMsg from common.h)
-  int send_notification(uint64_t flow_id,
+  int send_notification(uint64_t peer_id,
                         struct ::NotifyMsg const& notification);
 
   bool initialize_engine_by_dev(int dev, bool enable_p2p_listen) {
@@ -162,7 +160,7 @@ class NCCLEndpoint {
   // Control-plane listening socket.
   uint16_t listen_port_;
   int listen_fd_;
-  std::atomic<uint64_t> next_flow_id_{1};
+  std::atomic<uint64_t> next_peer_id_{1};
   std::atomic<bool> stop_accept_{false};
   std::mutex conn_mu_;
   std::unordered_map<uint64_t, std::unique_ptr<Conn>> conn_map_;

--- a/p2p/rdma/compression.cc
+++ b/p2p/rdma/compression.cc
@@ -62,44 +62,44 @@ CompressStrategy getCompressStrategyFromEnv() {
 }
 
 #if defined USE_DIETGPU
-dietgpu::FloatType to_dietgpu(uccl::FloatType t) {
+dietgpu::FloatType to_dietgpu(FloatType t) {
   switch (t) {
-    case uccl::FloatType::kFloat16:
+    case FloatType::kFloat16:
       return dietgpu::FloatType::kFloat16;
-    case uccl::FloatType::kBFloat16:
+    case FloatType::kBFloat16:
       return dietgpu::FloatType::kBFloat16;
-    case uccl::FloatType::kFloat32:
+    case FloatType::kFloat32:
       return dietgpu::FloatType::kFloat32;
-    case uccl::FloatType::kFloat8E4M3FN:
+    case FloatType::kFloat8E4M3FN:
       return dietgpu::FloatType::kFloat8E4M3FN;
-    case uccl::FloatType::kFloat8E5M2:
+    case FloatType::kFloat8E5M2:
       return dietgpu::FloatType::kFloat8E5M2;
-    case uccl::FloatType::kUndefined:
+    case FloatType::kUndefined:
     default:
       return dietgpu::FloatType::kUndefined;
   }
 }
 
-uccl::FloatType from_dietgpu(dietgpu::FloatType t) {
+FloatType from_dietgpu(dietgpu::FloatType t) {
   switch (t) {
     case dietgpu::FloatType::kFloat16:
-      return uccl::FloatType::kFloat16;
+      return FloatType::kFloat16;
     case dietgpu::FloatType::kBFloat16:
-      return uccl::FloatType::kBFloat16;
+      return FloatType::kBFloat16;
     case dietgpu::FloatType::kFloat32:
-      return uccl::FloatType::kFloat32;
+      return FloatType::kFloat32;
     case dietgpu::FloatType::kFloat8E4M3FN:
-      return uccl::FloatType::kFloat8E4M3FN;
+      return FloatType::kFloat8E4M3FN;
     case dietgpu::FloatType::kFloat8E5M2:
-      return uccl::FloatType::kFloat8E5M2;
+      return FloatType::kFloat8E5M2;
     default:
-      return uccl::FloatType::kUndefined;
+      return FloatType::kUndefined;
   }
 }
 
 FloatCompressCtx::FloatCompressCtx() = default;
 
-FloatCompressCtx::FloatCompressCtx(uccl::FloatType ft)
+FloatCompressCtx::FloatCompressCtx(FloatType ft)
     : dietgpu::FloatCompressSplitContext(to_dietgpu(ft)) {}
 
 FloatCompressCtx::~FloatCompressCtx() {
@@ -114,13 +114,13 @@ FloatCompressCtx::~FloatCompressCtx() {
   }
 }
 
-uccl::FloatType FloatCompressCtx::getFloatType() const {
+FloatType FloatCompressCtx::getFloatType() const {
   return from_dietgpu(float_type);
 }
 
 size_t FloatCompressCtx::getMaxSize() const { return maxSize; }
 
-CompressCtx makeCompressCtx(uccl::FloatType ft) {
+CompressCtx makeCompressCtx(FloatType ft) {
   return std::make_shared<FloatCompressCtx>(ft);
 }
 
@@ -128,14 +128,13 @@ CompressCtx makeCompressCtx(uccl::FloatType ft) {
 
 DummyCompressCtx::DummyCompressCtx() = default;
 
-DummyCompressCtx::DummyCompressCtx(uccl::FloatType ft)
-    : float_type(ft), maxSize(0) {}
+DummyCompressCtx::DummyCompressCtx(FloatType ft) : float_type(ft), maxSize(0) {}
 
-uccl::FloatType DummyCompressCtx::getFloatType() const { return float_type; }
+FloatType DummyCompressCtx::getFloatType() const { return float_type; }
 
 size_t DummyCompressCtx::getMaxSize() const { return maxSize; }
 
-CompressCtx makeCompressCtx(uccl::FloatType ft) {
+CompressCtx makeCompressCtx(FloatType ft) {
   return std::make_shared<DummyCompressCtx>(ft);
 }
 
@@ -166,13 +165,13 @@ bool NullCompressorBackend::prepareDecompress(
 
 bool NullCompressorBackend::decompress(RemoteMemInfo const& /*input*/,
                                        RegMemBlock& /*output*/,
-                                       uccl::FloatType /*float_type*/) {
+                                       FloatType /*float_type*/) {
   return false;
 }
 
 void NullCompressorBackend::decompressAsync(RemoteMemInfo const& /*input*/,
                                             RegMemBlock& /*output*/,
-                                            uccl::FloatType /*float_type*/,
+                                            FloatType /*float_type*/,
                                             gpuHostFn_t on_done,
                                             void* user_data) {
   if (on_done) on_done(user_data);  // synchronous fallback
@@ -323,7 +322,7 @@ bool DietGPUCompressorBackend::prepareDecompress(
 
 bool DietGPUCompressorBackend::decompress(RemoteMemInfo const& input,
                                           RegMemBlock& output,
-                                          uccl::FloatType float_type) {
+                                          FloatType float_type) {
   if (unlikely(!stream_ || !res_)) {
     UCCL_LOG(WARN)
         << "DietGPUCompressorBackend::decompress - Invalid internal state";
@@ -383,7 +382,7 @@ bool DietGPUCompressorBackend::decompress(RemoteMemInfo const& input,
 
 void DietGPUCompressorBackend::decompressAsync(RemoteMemInfo const& input,
                                                RegMemBlock& output,
-                                               uccl::FloatType float_type,
+                                               FloatType float_type,
                                                gpuHostFn_t on_done,
                                                void* user_data) {
   if (unlikely(!stream_ || !res_ || input.addr == 0 || input.length == 0 ||
@@ -439,7 +438,7 @@ void DietGPUCompressorBackend::prepareSplitContext(void* addr, size_t size,
     return;
   }
   // kUndefined means no float_type was supplied; skip compression.
-  if (unlikely(ctx->getFloatType() == uccl::FloatType::kUndefined)) {
+  if (unlikely(ctx->getFloatType() == FloatType::kUndefined)) {
     return;
   }
   auto float_ctx = std::static_pointer_cast<FloatCompressCtx>(ctx);
@@ -572,13 +571,12 @@ bool Compressor::prepareDecompress(std::shared_ptr<RDMARecvRequest> req) {
 }
 
 bool Compressor::decompress(RemoteMemInfo const& input, RegMemBlock& output,
-                            uccl::FloatType float_type) {
+                            FloatType float_type) {
   return backend_->decompress(input, output, float_type);
 }
 
 void Compressor::decompressAsync(RemoteMemInfo const& input,
-                                 RegMemBlock& output,
-                                 uccl::FloatType float_type,
+                                 RegMemBlock& output, FloatType float_type,
                                  gpuHostFn_t on_done, void* user_data) {
   backend_->decompressAsync(input, output, float_type, on_done, user_data);
 }

--- a/p2p/rdma/compression.h
+++ b/p2p/rdma/compression.h
@@ -35,18 +35,18 @@ CompressStrategy getCompressStrategyFromEnv();
 #include <cuda_fp16.h>
 #endif
 
-dietgpu::FloatType to_dietgpu(uccl::FloatType t);
-uccl::FloatType from_dietgpu(dietgpu::FloatType t);
+dietgpu::FloatType to_dietgpu(FloatType t);
+FloatType from_dietgpu(dietgpu::FloatType t);
 
 /**
  * @brief Wrapper around dietgpu::FloatCompressSplitContext that exposes a
- * uccl::FloatType-based constructor and getFloatType() accessor, hiding the
+ * FloatType-based constructor and getFloatType() accessor, hiding the
  * internal dietgpu::FloatType from external callers.
  */
 struct FloatCompressCtx : public dietgpu::FloatCompressSplitContext,
                           public CompressionContext {
   FloatCompressCtx();
-  explicit FloatCompressCtx(uccl::FloatType ft);
+  explicit FloatCompressCtx(FloatType ft);
 
   // Raw device buffer for the [in_ptr, inSize, out_ptr] tuple in params_dev.
   // Plain cudaMalloc so each ctx frees independently (no LIFO constraint).
@@ -57,7 +57,7 @@ struct FloatCompressCtx : public dietgpu::FloatCompressSplitContext,
 
   ~FloatCompressCtx() override;
 
-  uccl::FloatType getFloatType() const override;
+  FloatType getFloatType() const override;
   size_t getMaxSize() const override;
 };
 
@@ -79,22 +79,22 @@ struct DummyDevAlloc {
  * without #ifdef guards scattered throughout.
  */
 struct DummyCompressCtx : public CompressionContext {
-  uccl::FloatType float_type = uccl::FloatType::kUndefined;
+  FloatType float_type = FloatType::kUndefined;
   size_t maxSize = 0;
   DummyDevAlloc params_dev;
   DummyDevAlloc histogram_dev;
   DummyDevAlloc toComp_dev;
 
   DummyCompressCtx();
-  explicit DummyCompressCtx(uccl::FloatType ft);
+  explicit DummyCompressCtx(FloatType ft);
 
-  uccl::FloatType getFloatType() const override;
+  FloatType getFloatType() const override;
   size_t getMaxSize() const override;
 };
 
 #endif
 
-CompressCtx makeCompressCtx(uccl::FloatType ft);
+CompressCtx makeCompressCtx(FloatType ft);
 
 /**
  * @brief Abstract interface for compressor backends.
@@ -141,12 +141,12 @@ class ICompressorBackend {
    * @return true on success, false on failure.
    */
   virtual bool decompress(RemoteMemInfo const& input, RegMemBlock& output,
-                          uccl::FloatType float_type) = 0;
+                          FloatType float_type) = 0;
 
   // Queue decompress asynchronously. on_done fires via gpuLaunchHostFunc after
   // the kernel completes; it must not call any GPU APIs.
   virtual void decompressAsync(RemoteMemInfo const& input, RegMemBlock& output,
-                               uccl::FloatType float_type, gpuHostFn_t on_done,
+                               FloatType float_type, gpuHostFn_t on_done,
                                void* user_data) = 0;
 
   /**
@@ -214,10 +214,10 @@ class NullCompressorBackend : public ICompressorBackend {
   bool prepareDecompress(std::shared_ptr<RDMARecvRequest> req) override;
 
   bool decompress(RemoteMemInfo const& input, RegMemBlock& output,
-                  uccl::FloatType float_type) override;
+                  FloatType float_type) override;
 
   void decompressAsync(RemoteMemInfo const& input, RegMemBlock& output,
-                       uccl::FloatType float_type, gpuHostFn_t on_done,
+                       FloatType float_type, gpuHostFn_t on_done,
                        void* user_data) override;
 
   bool shouldCompress(size_t size) override;
@@ -258,10 +258,10 @@ class DietGPUCompressorBackend : public ICompressorBackend {
   bool prepareDecompress(std::shared_ptr<RDMARecvRequest> req) override;
 
   bool decompress(RemoteMemInfo const& input, RegMemBlock& output,
-                  uccl::FloatType float_type) override;
+                  FloatType float_type) override;
 
   void decompressAsync(RemoteMemInfo const& input, RegMemBlock& output,
-                       uccl::FloatType float_type, gpuHostFn_t on_done,
+                       FloatType float_type, gpuHostFn_t on_done,
                        void* user_data) override;
 
   bool shouldCompress(size_t size) override;
@@ -339,10 +339,10 @@ class Compressor {
    * @return true on success, false on failure.
    */
   bool decompress(RemoteMemInfo const& input, RegMemBlock& output,
-                  uccl::FloatType float_type);
+                  FloatType float_type);
 
   void decompressAsync(RemoteMemInfo const& input, RegMemBlock& output,
-                       uccl::FloatType float_type, gpuHostFn_t on_done,
+                       FloatType float_type, gpuHostFn_t on_done,
                        void* user_data);
 
   /**

--- a/p2p/rdma/rdma_connection.cc
+++ b/p2p/rdma/rdma_connection.cc
@@ -607,8 +607,8 @@ bool SendConnection::postSingleChunk(
   }
 
   chunk_req->channel_id = chunk_channel_id;
-  chunk_req->from_rank_id = req->from_rank_id;
-  chunk_req->to_rank_id = req->to_rank_id;
+  chunk_req->from_peer_id = req->from_peer_id;
+  chunk_req->to_peer_id = req->to_peer_id;
   chunk_req->wr_id = req->wr_id;
   chunk_req->send_type = req->send_type;
 

--- a/p2p/rdma/rdma_connection.cc
+++ b/p2p/rdma/rdma_connection.cc
@@ -208,8 +208,8 @@ int64_t SendConnection::postWriteOrRead(std::shared_ptr<RDMASendRequest> req) {
   bool c_ack = static_cast<bool>(ack_ring_);
   bool c_rdb = remote_decompress_buf_.length > 0;
   bool c_ctx = static_cast<bool>(req->compress_ctx);
-  bool c_ft = c_ctx && (req->compress_ctx->getFloatType() !=
-                        uccl::FloatType::kUndefined);
+  bool c_ft =
+      c_ctx && (req->compress_ctx->getFloatType() != FloatType::kUndefined);
   bool c_fit = static_cast<uint64_t>(req->local_mem->size) <=
                remote_decompress_buf_.length;
   bool c_should = Compressor::getInstance().shouldCompressAndSplitFirst(
@@ -794,7 +794,7 @@ int64_t SendConnection::compressWriteRequestSplitFirst(
   entry.meta.decompress_offset = arena_offset;
   entry.meta.float_type = static_cast<uint32_t>(
       req->compress_ctx ? req->compress_ctx->getFloatType()
-                        : uccl::FloatType::kUndefined);
+                        : FloatType::kUndefined);
   entry.meta.ack_slot = ack_slot;
   entry.meta.wr_id = wr_id;
   {
@@ -1168,7 +1168,7 @@ void RecvConnection::handleCompressedWriteArrival(WriteReqMeta const& m) {
       static_cast<uint64_t>(m.wr_id) + 1);
 
   Compressor::getInstance().decompressAsync(
-      in, out, static_cast<uccl::FloatType>(m.float_type),
+      in, out, static_cast<FloatType>(m.float_type),
       /*on_done=*/nullptr, /*user_data=*/nullptr);
 }
 

--- a/p2p/rdma/rdma_context.cc
+++ b/p2p/rdma/rdma_context.cc
@@ -387,6 +387,7 @@ bool RdmaContext::containsRange(uintptr_t outer_addr, size_t outer_size,
 RdmaContext::RegistrationMode RdmaContext::getRegistrationMode(
     void* addr) const {
   bool is_gpu = isGpuPointer(addr);
+  // Intel RDMA NICs use DMA-BUF for GPU memory registration.
   bool use_dmabuf = (vendor_id_ == 0x8086 && is_gpu);
   if (use_dmabuf) {
     UCCL_LOG(INFO, UCCL_RDMA)

--- a/p2p/rdma/rdma_data_channel.cc
+++ b/p2p/rdma/rdma_data_channel.cc
@@ -10,7 +10,7 @@
 #include <utility>
 
 std::unique_ptr<RDMADataChannelImpl> createRDMADataChannelImpl() {
-  if (uccl::is_efa_transport())
+  if (is_efa_transport())
     return std::make_unique<EFADataChannelImpl>();
   else
     return std::make_unique<IBDataChannelImpl>();
@@ -52,7 +52,7 @@ RDMADataChannel::~RDMADataChannel() {
 
 void RDMADataChannel::establishChannel(ChannelMetaData const& remote_meta) {
   remote_meta_ = std::make_shared<ChannelMetaData>(remote_meta);
-  if (uccl::is_efa_transport()) {
+  if (is_efa_transport()) {
     ah_ = ctx_->createAH(remote_meta_->gid);
   }
   impl_->connectQP(qp_, ctx_, *remote_meta_);
@@ -343,7 +343,7 @@ int RDMADataChannel::__flushBatch_ex(
   // SGE storage must remain valid until ibv_wr_complete.
   std::vector<struct ibv_sge> sges(batch.size());
   size_t const last = batch.size() - 1;
-  bool const signal_all = uccl::is_efa_transport();
+  bool const signal_all = is_efa_transport();
   std::vector<uint64_t> unsignaled;
   if (!signal_all) unsignaled.reserve(last);
   auto* qpx = ibv_qp_to_qp_ex(qp_);
@@ -444,7 +444,7 @@ int RDMADataChannel::__postRawBatch_ex(
   if (batch.empty()) return 0;
   std::vector<struct ibv_sge> sges(batch.size());
   size_t const last = batch.size() - 1;
-  bool const signal_all = uccl::is_efa_transport();
+  bool const signal_all = is_efa_transport();
   std::vector<uint64_t> unsignaled;
   if (!signal_all) unsignaled.reserve(last);
   auto* qpx = ibv_qp_to_qp_ex(qp_);

--- a/p2p/rdma/rdma_device.h
+++ b/p2p/rdma/rdma_device.h
@@ -24,7 +24,7 @@ class RDMADeviceSelectionStrategy {
 // Factory: select IB or EFA device strategy at runtime.
 inline std::unique_ptr<RDMADeviceSelectionStrategy>
 createDeviceSelectionStrategy() {
-  if (uccl::is_efa_transport())
+  if (is_efa_transport())
     return std::make_unique<EFADeviceSelectionStrategy>();
   else
     return std::make_unique<IBDeviceSelectionStrategy>();

--- a/p2p/rdma/rdma_endpoint.cc
+++ b/p2p/rdma/rdma_endpoint.cc
@@ -3,14 +3,13 @@
 #include "util/gpu_rt.h"
 #include "util/util.h"
 
-RDMAEndpoint::RDMAEndpoint(int gpu_index, uint64_t rank_id, uint64_t port,
+RDMAEndpoint::RDMAEndpoint(int gpu_index, uint64_t port,
                            bool auto_start_polling,
                            std::vector<size_t> const& device_ids)
     : gpu_index_(gpu_index),
-      rank_id_(rank_id),
       auto_start_polling_(auto_start_polling),
-      send_id_(0),
-      recv_id_(0) {
+      next_send_peer_id_(0),
+      next_recv_peer_id_(0) {
   if (gpu_index != INVALID_GPU) {
     initialize_rdma_ctx_for_gpu(gpu_index, device_ids);
   }
@@ -164,27 +163,27 @@ bool RDMAEndpoint::deregMem(std::shared_ptr<RegMemBlock> reg_block) {
   return true;
 }
 
-int RDMAEndpoint::build_connect(uint64_t rank_id, bool sync, int timeout_ms) {
-  std::string const oob_con = build_oob_connect(rank_id);
-  uint64_t receved_rank_id =
-      this->build_control_channel(oob_con, rank_id, sync, timeout_ms);
-  if (receved_rank_id < 0) {
+int RDMAEndpoint::build_connect(uint64_t peer_id, bool sync, int timeout_ms) {
+  std::string const oob_con = build_oob_connect(peer_id);
+  uint64_t receved_peer_id =
+      this->build_control_channel(oob_con, peer_id, sync, timeout_ms);
+  if (receved_peer_id < 0) {
     return -1;
   }
-  if (!this->build_normal_channels(oob_con, rank_id, sync, timeout_ms)) {
+  if (!this->build_data_channels(oob_con, peer_id, sync, timeout_ms)) {
     return -1;
   }
-  return static_cast<int>(receved_rank_id);
+  return static_cast<int>(receved_peer_id);
 }
 
-void RDMAEndpoint::checkSendComplete(uint64_t rank_id, int64_t wr_id) {
+void RDMAEndpoint::checkSendComplete(uint64_t peer_id, int64_t wr_id) {
   UCCL_LOG(INFO, UCCL_RDMA)
-      << "checkSendComplete - rank_id: " << rank_id << ", wr_id: " << wr_id;
+      << "checkSendComplete - peer_id: " << peer_id << ", wr_id: " << wr_id;
 
-  auto it = send_channel_groups_.find(rank_id);
+  auto it = send_channel_groups_.find(peer_id);
   if (it == send_channel_groups_.end()) {
-    throw std::runtime_error("Send channel group not found for rank_id: " +
-                             std::to_string(rank_id));
+    throw std::runtime_error("Send channel group not found for peer_id: " +
+                             std::to_string(peer_id));
   }
 
   auto send_group = it->second;
@@ -192,53 +191,53 @@ void RDMAEndpoint::checkSendComplete(uint64_t rank_id, int64_t wr_id) {
     std::this_thread::sleep_for(std::chrono::microseconds(1));
   }
   UCCL_LOG(INFO, UCCL_RDMA)
-      << "checkSendComplete - Completed for rank_id: " << rank_id
+      << "checkSendComplete - Completed for peer_id: " << peer_id
       << ", wr_id: " << wr_id;
 }
 
-bool RDMAEndpoint::checkSendComplete_once(uint64_t rank_id, int64_t wr_id) {
-  // UCCL_LOG(INFO, UCCL_RDMA) << "checkSendComplete - rank_id: " << rank_id
+bool RDMAEndpoint::checkSendComplete_once(uint64_t peer_id, int64_t wr_id) {
+  // UCCL_LOG(INFO, UCCL_RDMA) << "checkSendComplete - peer_id: " << peer_id
   //           << ", wr_id: " << wr_id;
   std::shared_lock<std::shared_mutex> lock(send_channel_mutex_);
-  auto it = send_channel_groups_.find(rank_id);
+  auto it = send_channel_groups_.find(peer_id);
   if (unlikely(it == send_channel_groups_.end())) {
-    throw std::runtime_error("Send channel group not found for rank_id: " +
-                             std::to_string(rank_id));
+    throw std::runtime_error("Send channel group not found for peer_id: " +
+                             std::to_string(peer_id));
   }
 
   auto send_group = it->second;
   return send_group->check(wr_id);
 }
 
-SendConnection* RDMAEndpoint::getSendGroupRaw(uint64_t rank_id) {
+SendConnection* RDMAEndpoint::getSendGroupRaw(uint64_t peer_id) {
   std::shared_lock<std::shared_mutex> lock(send_channel_mutex_);
-  auto it = send_channel_groups_.find(rank_id);
+  auto it = send_channel_groups_.find(peer_id);
   if (it == send_channel_groups_.end()) return nullptr;
   return it->second.get();
 }
 
-bool RDMAEndpoint::checkRecvComplete_once(uint64_t rank_id, uint64_t index) {
+bool RDMAEndpoint::checkRecvComplete_once(uint64_t peer_id, uint64_t index) {
   UCCL_LOG(INFO, UCCL_RDMA)
-      << "checkRecvComplete - Checking for rank_id: " << rank_id
+      << "checkRecvComplete - Checking for peer_id: " << peer_id
       << ", index: " << index;
-  auto it = recv_channel_groups_.find(rank_id);
+  auto it = recv_channel_groups_.find(peer_id);
   if (unlikely(it == recv_channel_groups_.end())) {
-    throw std::runtime_error("Recv channel group not found for rank_id: " +
-                             std::to_string(rank_id));
+    throw std::runtime_error("Recv channel group not found for peer_id: " +
+                             std::to_string(peer_id));
   }
 
   auto recv_group = it->second;
   return recv_group->check(index);
 }
 
-void RDMAEndpoint::checkRecvComplete(uint64_t rank_id, uint64_t index) {
+void RDMAEndpoint::checkRecvComplete(uint64_t peer_id, uint64_t index) {
   UCCL_LOG(INFO, UCCL_RDMA)
-      << "checkRecvComplete - Checking for rank_id: " << rank_id
+      << "checkRecvComplete - Checking for peer_id: " << peer_id
       << ", index: " << index;
-  auto it = recv_channel_groups_.find(rank_id);
+  auto it = recv_channel_groups_.find(peer_id);
   if (it == recv_channel_groups_.end()) {
-    throw std::runtime_error("Recv channel group not found for rank_id: " +
-                             std::to_string(rank_id));
+    throw std::runtime_error("Recv channel group not found for peer_id: " +
+                             std::to_string(peer_id));
   }
 
   auto recv_group = it->second;
@@ -246,16 +245,16 @@ void RDMAEndpoint::checkRecvComplete(uint64_t rank_id, uint64_t index) {
     std::this_thread::sleep_for(std::chrono::microseconds(1));
   }
   UCCL_LOG(INFO, UCCL_RDMA)
-      << "checkRecvComplete - Completed for rank_id: " << rank_id
+      << "checkRecvComplete - Completed for peer_id: " << peer_id
       << ", index: " << index;
 }
 
 int64_t RDMAEndpoint::writeOrRead(std::shared_ptr<RDMASendRequest> req) {
-  uint64_t rank_id = req->to_rank_id;
-  auto it = send_channel_groups_.find(rank_id);
+  uint64_t peer_id = req->to_peer_id;
+  auto it = send_channel_groups_.find(peer_id);
   if (it == send_channel_groups_.end()) {
-    throw std::runtime_error("Send channel group not found for rank_id: " +
-                             std::to_string(rank_id));
+    throw std::runtime_error("Send channel group not found for peer_id: " +
+                             std::to_string(peer_id));
   }
 
   auto send_group = it->second;
@@ -264,9 +263,9 @@ int64_t RDMAEndpoint::writeOrRead(std::shared_ptr<RDMASendRequest> req) {
   // Blocking call until send succeeds
   while (wr_id < 0) {
     // UCCL_LOG(INFO, UCCL_RDMA) << "RDMAEndpoint::write - Attempting to send
-    // to rank_id:
+    // to peer_id:
     // "
-    //           << rank_id << ", peer rank_id " << rank_id;
+    //           << peer_id;
     wr_id = send_group->postWriteOrRead(req);
 
     if (wr_id < 0) {
@@ -277,12 +276,12 @@ int64_t RDMAEndpoint::writeOrRead(std::shared_ptr<RDMASendRequest> req) {
   return wr_id;
 }
 
-int64_t RDMAEndpoint::send(uint64_t rank_id,
+int64_t RDMAEndpoint::send(uint64_t peer_id,
                            std::shared_ptr<RDMASendRequest> req) {
-  auto it = send_channel_groups_.find(rank_id);
+  auto it = send_channel_groups_.find(peer_id);
   if (it == send_channel_groups_.end()) {
-    throw std::runtime_error("Send channel group not found for rank_id: " +
-                             std::to_string(rank_id));
+    throw std::runtime_error("Send channel group not found for peer_id: " +
+                             std::to_string(peer_id));
   }
 
   auto send_group = it->second;
@@ -291,8 +290,7 @@ int64_t RDMAEndpoint::send(uint64_t rank_id,
   // Blocking call until send succeeds
   while (wr_id < 0) {
     UCCL_LOG(INFO, UCCL_RDMA)
-        << "RDMAEndpoint::send - Attempting to send to rank_id: " << rank_id
-        << ", peer rank_id " << rank_id;
+        << "RDMAEndpoint::send - Attempting to send to peer_id: " << peer_id;
     wr_id = send_group->send(req);
 
     if (wr_id < 0) {
@@ -303,12 +301,12 @@ int64_t RDMAEndpoint::send(uint64_t rank_id,
   return wr_id;
 }
 
-int64_t RDMAEndpoint::recv(uint64_t rank_id,
+int64_t RDMAEndpoint::recv(uint64_t peer_id,
                            std::shared_ptr<RDMARecvRequest> req) {
-  auto it = recv_channel_groups_.find(rank_id);
+  auto it = recv_channel_groups_.find(peer_id);
   if (it == recv_channel_groups_.end()) {
-    throw std::runtime_error("Recv channel group not found for rank_id: " +
-                             std::to_string(rank_id));
+    throw std::runtime_error("Recv channel group not found for peer_id: " +
+                             std::to_string(peer_id));
   }
 
   auto recv_group = it->second;
@@ -317,8 +315,7 @@ int64_t RDMAEndpoint::recv(uint64_t rank_id,
   while (index < 0) {
     index = recv_group->recv(req);
     UCCL_LOG(INFO, UCCL_RDMA)
-        << "RDMAEndpoint::recv - Attempting to recv from rank_id: " << rank_id
-        << ", peer rank_id " << rank_id;
+        << "RDMAEndpoint::recv - Attempting to recv from peer_id: " << peer_id;
     if (index < 0) {
       std::this_thread::sleep_for(std::chrono::microseconds(10));
     }
@@ -327,30 +324,31 @@ int64_t RDMAEndpoint::recv(uint64_t rank_id,
   return index;
 }
 
-void RDMAEndpoint::add_rank_oob_meta(
+void RDMAEndpoint::add_peer_oob_meta(
     std::unordered_map<uint64_t, std::shared_ptr<OOBMetaData>> const&
         new_meta) {
-  for (auto const& [rank_id, meta_ptr] : new_meta) {
-    rank_oob_meta_[rank_id] = meta_ptr;
+  for (auto const& [peer_id, meta_ptr] : new_meta) {
+    peer_oob_meta_[peer_id] = meta_ptr;
   }
 }
 
 ConnID RDMAEndpoint::uccl_connect(int remote_gpuidx, std::string remote_ip,
                                   uint16_t remote_port) {
-  int32_t current_send_id = send_id_.fetch_add(1, std::memory_order_relaxed);
+  int32_t current_send_peer_id =
+      next_send_peer_id_.fetch_add(1, std::memory_order_relaxed);
 
   assert(gpu_index_ != INVALID_GPU);
 
-  add_rank_oob_meta({{current_send_id,
+  add_peer_oob_meta({{current_send_peer_id,
                       std::make_shared<OOBMetaData>(remote_ip, remote_port)}});
   UCCL_LOG(INFO, UCCL_RDMA)
       << "remote_gpuidx: " << remote_gpuidx << ", remote_ip: " << remote_ip
       << ", remote_port: " << remote_port;
-  build_connect(current_send_id);  // sync mode (default)
+  build_connect(current_send_peer_id);  // sync mode (default)
   ConnID conn_id;
   conn_id.context =
-      reinterpret_cast<void*>(static_cast<intptr_t>(current_send_id));
-  conn_id.flow_id = current_send_id;
+      reinterpret_cast<void*>(static_cast<intptr_t>(current_send_peer_id));
+  conn_id.peer_id = current_send_peer_id;
   return conn_id;
 }
 
@@ -362,15 +360,15 @@ std::shared_ptr<EpollClient> RDMAEndpoint::get_oob_client() {
   return oob_client_;
 }
 
-std::string RDMAEndpoint::get_oob_conn_key(uint64_t rank_id) {
-  std::shared_lock<std::shared_mutex> lock(rank_oob_conn_keys_mutex_);
-  auto it = rank_oob_conn_keys_.find(rank_id);
-  return (it != rank_oob_conn_keys_.end()) ? it->second : "";
+std::string RDMAEndpoint::get_oob_conn_key(uint64_t peer_id) {
+  std::shared_lock<std::shared_mutex> lock(peer_oob_conn_keys_mutex_);
+  auto it = peer_oob_conn_keys_.find(peer_id);
+  return (it != peer_oob_conn_keys_.end()) ? it->second : "";
 }
 
 ConnID RDMAEndpoint::uccl_accept(std::string& remote_ip, int* remote_gpuidx) {
   AcceptedMeta accepted;
-  uint64_t rank_id = 0;
+  uint64_t peer_id = 0;
 
   // Block until there's an accepted connection
   while (!stop_accept_.load(std::memory_order_acquire)) {
@@ -380,14 +378,14 @@ ConnID RDMAEndpoint::uccl_accept(std::string& remote_ip, int* remote_gpuidx) {
         if (!accepted_meta_.empty()) {
           // Get the first accepted connection
           auto it = accepted_meta_.begin();
-          rank_id = it->first;
+          peer_id = it->first;
           accepted = it->second;
           // Remove it from the map
-          if (getOrCreateRecvGroup(rank_id)->channelCount() ==
+          if (getOrCreateRecvGroup(peer_id)->channelCount() ==
               kQpNumPerChannel + 1) {
             accepted_meta_.erase(it);
             UCCL_LOG(INFO, UCCL_RDMA)
-                << "Accepted connection: rank_id=" << rank_id
+                << "Accepted connection: peer_id=" << peer_id
                 << ", ip=" << accepted.ip << ", port=" << accepted.port
                 << ", gpu_id=" << accepted.gpu_id;
             break;
@@ -399,7 +397,7 @@ ConnID RDMAEndpoint::uccl_accept(std::string& remote_ip, int* remote_gpuidx) {
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
   }
   UCCL_LOG(INFO, UCCL_RDMA)
-      << "Done Accepted connection: rank_id=" << rank_id
+      << "Done Accepted connection: peer_id=" << peer_id
       << ", ip=" << accepted.ip << ", port=" << accepted.port
       << ", gpu_id=" << accepted.gpu_id;
   // Assign output parameters
@@ -410,8 +408,8 @@ ConnID RDMAEndpoint::uccl_accept(std::string& remote_ip, int* remote_gpuidx) {
 
   // Create and return ConnID
   ConnID conn_id;
-  conn_id.context = reinterpret_cast<void*>(static_cast<intptr_t>(rank_id));
-  conn_id.flow_id = rank_id;
+  conn_id.context = reinterpret_cast<void*>(static_cast<intptr_t>(peer_id));
+  conn_id.peer_id = peer_id;
   conn_id.sock_fd = 0;
   return conn_id;
 }
@@ -516,7 +514,7 @@ void RDMAEndpoint::recvRoutine() {
     return;  // Do nothing if auto polling is enabled
   }
   std::shared_lock<std::shared_mutex> lock(recv_channel_mutex_);
-  for (auto& [rank_id, recv_group] : recv_channel_groups_) {
+  for (auto& [peer_id, recv_group] : recv_channel_groups_) {
     if (recv_group) {
       recv_group->pollAndProcessCompletions();
     }
@@ -528,7 +526,7 @@ void RDMAEndpoint::sendRoutine() {
     return;  // Do nothing if auto polling is enabled
   }
   std::shared_lock<std::shared_mutex> lock(send_channel_mutex_);
-  for (auto& [rank_id, send_group] : send_channel_groups_) {
+  for (auto& [peer_id, send_group] : send_channel_groups_) {
     if (send_group) {
       send_group->pollingLoopForMeta();
     }
@@ -537,7 +535,7 @@ void RDMAEndpoint::sendRoutine() {
 
 void RDMAEndpoint::flushAllSends() {
   std::shared_lock<std::shared_mutex> lock(send_channel_mutex_);
-  for (auto& [rank_id, send_group] : send_channel_groups_) {
+  for (auto& [peer_id, send_group] : send_channel_groups_) {
     if (send_group) send_group->flushBatches();
   }
 }
@@ -548,22 +546,22 @@ int RDMAEndpoint::sendWithoutInnerQueue(std::shared_ptr<RDMASendRequest> req) {
     return -1;
   }
 
-  uint64_t rank_id = req->to_rank_id;
+  uint64_t peer_id = req->to_peer_id;
   std::shared_lock<std::shared_mutex> lock(send_channel_mutex_);
-  auto it = send_channel_groups_.find(rank_id);
+  auto it = send_channel_groups_.find(peer_id);
   if (it == send_channel_groups_.end()) {
     UCCL_LOG(WARN)
         << "RDMAEndpoint::sendRoutine - Send channel group not found "
-           "for rank_id: "
-        << rank_id;
+           "for peer_id: "
+        << peer_id;
     return -1;
   }
 
   auto send_group = it->second;
   if (!send_group) {
     UCCL_LOG(WARN) << "RDMAEndpoint::sendRoutine - Send channel group is null "
-                      "for rank_id: "
-                   << rank_id;
+                      "for peer_id: "
+                   << peer_id;
     return -1;
   }
 
@@ -658,10 +656,8 @@ void RDMAEndpoint::process_meta(std::string const& input, std::string& output,
   std::shared_ptr<RdmaContext> ctx_ptr = contexts_[context_id];
 
   if (meta.flag == ChannelType::Control) {
-    uint64_t actual_rank_id = meta.rank_id;
-    if (rank_id_ == INVALID_RANK_ID) {
-      actual_rank_id = recv_id_.fetch_add(1, std::memory_order_relaxed);
-    }
+    uint64_t actual_peer_id =
+        next_recv_peer_id_.fetch_add(1, std::memory_order_relaxed);
 
     auto ctrl_mem =
         allocator_->allocate(kRingBufferSize, MemoryType::HOST, ctx_ptr);
@@ -678,8 +674,8 @@ void RDMAEndpoint::process_meta(std::string const& input, std::string& output,
     // Create response (include our OOB port for potential future use)
     RemoteMemInfo ctrl_info(ctrl_mem);
     MetaInfoToExchange response(
-        rank_id_, meta.channel_id, recv_ctrl_channel->get_local_meta(), nullptr,
-        ChannelType::Control, gpu_index_, oob_server_->get_port());
+        INVALID_PEER_ID, meta.channel_id, recv_ctrl_channel->get_local_meta(),
+        nullptr, ChannelType::Control, gpu_index_, oob_server_->get_port());
     response.mem_meta = ctrl_info;
     fillCompressionMeta(response);
     UCCL_LOG(INFO, UCCL_RDMA)
@@ -688,10 +684,10 @@ void RDMAEndpoint::process_meta(std::string const& input, std::string& output,
 
     // Set the control channel
     auto ctrl_ch_copy = recv_ctrl_channel;
-    setRecvControlChannel(actual_rank_id, std::move(ctrl_ch_copy));
+    setRecvControlChannel(actual_peer_id, std::move(ctrl_ch_copy));
     // Remember peer's ack_ring address+rkey - the receive side needs it
     // when decompress finishes and we post an ack back to the sender.
-    setRecvCompressionPeerMeta(actual_rank_id, meta);
+    setRecvCompressionPeerMeta(actual_peer_id, meta);
 
     // Store accepted connection metadata
     {
@@ -700,10 +696,10 @@ void RDMAEndpoint::process_meta(std::string const& input, std::string& output,
       accepted.ip = client_ip;
       accepted.port = static_cast<uint16_t>(client_port);
       accepted.gpu_id = meta.gpu_id;
-      accepted.rank_id = actual_rank_id;
-      accepted_meta_[actual_rank_id] = accepted;
+      accepted.peer_id = actual_peer_id;
+      accepted_meta_[actual_peer_id] = accepted;
       UCCL_LOG(INFO, UCCL_RDMA)
-          << "Stored accepted connection: rank_id=" << actual_rank_id
+          << "Stored accepted connection: peer_id=" << actual_peer_id
           << ", ip=" << client_ip << ", port=" << client_port
           << ", gpu_id=" << meta.gpu_id;
     }
@@ -712,11 +708,11 @@ void RDMAEndpoint::process_meta(std::string const& input, std::string& output,
       std::string rev_conn_key =
           oob_client_->connect_to_server(client_ip, meta.oob_port);
       if (!rev_conn_key.empty()) {
-        std::unique_lock<std::shared_mutex> lock(rank_oob_conn_keys_mutex_);
-        rank_oob_conn_keys_[actual_rank_id] = rev_conn_key;
+        std::unique_lock<std::shared_mutex> lock(peer_oob_conn_keys_mutex_);
+        peer_oob_conn_keys_[actual_peer_id] = rev_conn_key;
         UCCL_LOG(INFO, UCCL_RDMA)
             << "Established reverse connection to " << client_ip << ":"
-            << meta.oob_port << " for rank_id=" << actual_rank_id
+            << meta.oob_port << " for peer_id=" << actual_peer_id
             << ", conn_key=" << rev_conn_key;
       } else {
         UCCL_LOG(WARN) << "Failed to establish reverse connection to "
@@ -724,18 +720,16 @@ void RDMAEndpoint::process_meta(std::string const& input, std::string& output,
       }
     }
   } else {
-    // Normal channel
-    uint64_t actual_rank_id = meta.rank_id;
-    if (rank_id_ == INVALID_RANK_ID) {
-      // Find matching rank_id from accepted_meta_
-      std::shared_lock<std::shared_mutex> lock(accepted_meta_mutex_);
-      for (auto const& [rank_id, accepted] : accepted_meta_) {
-        if (accepted.ip == client_ip &&
-            accepted.port == static_cast<uint16_t>(client_port) &&
-            accepted.gpu_id == meta.gpu_id) {
-          actual_rank_id = rank_id;
-          break;
-        }
+    // Data channel
+    uint64_t actual_peer_id = INVALID_PEER_ID;
+    // Find matching peer_id from accepted_meta_.
+    std::shared_lock<std::shared_mutex> lock(accepted_meta_mutex_);
+    for (auto const& [peer_id, accepted] : accepted_meta_) {
+      if (accepted.ip == client_ip &&
+          accepted.port == static_cast<uint16_t>(client_port) &&
+          accepted.gpu_id == meta.gpu_id) {
+        actual_peer_id = peer_id;
+        break;
       }
     }
 
@@ -743,12 +737,12 @@ void RDMAEndpoint::process_meta(std::string const& input, std::string& output,
         std::make_shared<RDMADataChannel>(ctx_ptr, meta.channel_meta,
                                           meta.channel_id);
     // Create response (echo back the same data)
-    MetaInfoToExchange response(rank_id_, meta.channel_id,
+    MetaInfoToExchange response(INVALID_PEER_ID, meta.channel_id,
                                 new_channel->get_local_meta(), nullptr,
                                 ChannelType::Normal, gpu_index_);
     UCCL_LOG(INFO, UCCL_RDMA) << "response:::::::" << response;
     output = serialize(response);
-    addOneRecvChannel(actual_rank_id, meta.channel_id, new_channel);
+    addOneRecvChannel(actual_peer_id, meta.channel_id, new_channel);
   }
 }
 
@@ -758,14 +752,14 @@ uint64_t RDMAEndpoint::handle_send_meta_response(
   MetaInfoToExchange response_meta = deserialize<MetaInfoToExchange>(response);
   UCCL_LOG(INFO, UCCL_RDMA) << response_meta;
   channel->establishChannel(response_meta.channel_meta);
-  return response_meta.rank_id;
+  return response_meta.peer_id;
 }
 
 std::shared_ptr<RecvConnection> RDMAEndpoint::getOrCreateRecvGroup(
-    uint64_t rank_id) {
+    uint64_t peer_id) {
   {
     std::shared_lock read_lock(recv_channel_mutex_);
-    auto it = recv_channel_groups_.find(rank_id);
+    auto it = recv_channel_groups_.find(peer_id);
     if (it != recv_channel_groups_.end()) {
       return it->second;
     }
@@ -775,7 +769,7 @@ std::shared_ptr<RecvConnection> RDMAEndpoint::getOrCreateRecvGroup(
   {
     std::unique_lock write_lock(recv_channel_mutex_);
     auto [it, inserted] = recv_channel_groups_.try_emplace(
-        rank_id,
+        peer_id,
         std::make_shared<RecvConnection>(
             numa_node, auto_start_polling_));  // try_emplace constructs only
                                                // if inserting
@@ -784,24 +778,24 @@ std::shared_ptr<RecvConnection> RDMAEndpoint::getOrCreateRecvGroup(
 }
 
 void RDMAEndpoint::addOneRecvChannel(
-    uint64_t rank_id, uint32_t channel_id,
+    uint64_t peer_id, uint32_t channel_id,
     std::shared_ptr<RDMADataChannel> new_channel) {
-  std::shared_ptr<RecvConnection> group_ptr = getOrCreateRecvGroup(rank_id);
+  std::shared_ptr<RecvConnection> group_ptr = getOrCreateRecvGroup(peer_id);
   group_ptr->addChannel(channel_id, new_channel);
 }
 
 void RDMAEndpoint::setRecvControlChannel(
-    uint64_t rank_id, std::shared_ptr<RecvControlChannel>&& ctrl_channel) {
-  auto it = getOrCreateRecvGroup(rank_id);
-  recv_channel_groups_[rank_id]->setControlChannel(
+    uint64_t peer_id, std::shared_ptr<RecvControlChannel>&& ctrl_channel) {
+  auto it = getOrCreateRecvGroup(peer_id);
+  recv_channel_groups_[peer_id]->setControlChannel(
       std::forward<std::shared_ptr<RecvControlChannel>>(ctrl_channel));
 }
 
 std::shared_ptr<SendConnection> RDMAEndpoint::getOrCreateSendGroup(
-    uint64_t rank_id) {
+    uint64_t peer_id) {
   {
     std::shared_lock read_lock(send_channel_mutex_);
-    auto it = send_channel_groups_.find(rank_id);
+    auto it = send_channel_groups_.find(peer_id);
     if (it != send_channel_groups_.end()) return it->second;
   }
   auto numa_node = RdmaDeviceManager::instance().get_numa_node(
@@ -813,43 +807,43 @@ std::shared_ptr<SendConnection> RDMAEndpoint::getOrCreateSendGroup(
   {
     std::unique_lock write_lock(send_channel_mutex_);
     auto [it, inserted] = send_channel_groups_.try_emplace(
-        rank_id, std::make_shared<SendConnection>(
+        peer_id, std::make_shared<SendConnection>(
                      numa_node, auto_start_polling_, link_bw));
     return it->second;
   }
 }
 
 void RDMAEndpoint::addOneSendChannel(
-    uint64_t rank_id, uint32_t channel_id,
+    uint64_t peer_id, uint32_t channel_id,
     std::shared_ptr<RDMADataChannel> new_channel) {
-  auto group_ptr = getOrCreateSendGroup(rank_id);
+  auto group_ptr = getOrCreateSendGroup(peer_id);
   group_ptr->addChannel(channel_id, new_channel);
 }
 
 void RDMAEndpoint::setSendControlChannel(
-    uint64_t rank_id, std::shared_ptr<SendControlChannel>&& ctrl_channel) {
-  auto it = getOrCreateSendGroup(rank_id);
-  send_channel_groups_[rank_id]->setControlChannel(
+    uint64_t peer_id, std::shared_ptr<SendControlChannel>&& ctrl_channel) {
+  auto it = getOrCreateSendGroup(peer_id);
+  send_channel_groups_[peer_id]->setControlChannel(
       std::forward<std::shared_ptr<SendControlChannel>>(ctrl_channel));
 }
 
-void RDMAEndpoint::setSendCompressionPeerMeta(uint64_t rank_id,
+void RDMAEndpoint::setSendCompressionPeerMeta(uint64_t peer_id,
                                               MetaInfoToExchange const& peer) {
   if (!ack_ring_ || peer.decompress_buf_meta.length == 0) return;
-  auto group = getOrCreateSendGroup(rank_id);
+  auto group = getOrCreateSendGroup(peer_id);
   group->setRemoteDecompressBuf(peer.decompress_buf_meta);
   group->setLocalAckRing(ack_ring_);
 }
 
-void RDMAEndpoint::setRecvCompressionPeerMeta(uint64_t rank_id,
+void RDMAEndpoint::setRecvCompressionPeerMeta(uint64_t peer_id,
                                               MetaInfoToExchange const& peer) {
   if (peer.ack_ring_meta.length == 0) return;
-  auto group = getOrCreateRecvGroup(rank_id);
+  auto group = getOrCreateRecvGroup(peer_id);
   group->setRemoteAckRing(peer.ack_ring_meta);
 }
 
-std::string const RDMAEndpoint::build_oob_connect(uint64_t rank_id) {
-  auto const& item = rank_oob_meta_.find(rank_id);
+std::string const RDMAEndpoint::build_oob_connect(uint64_t peer_id) {
+  auto const& item = peer_oob_meta_.find(peer_id);
   std::shared_ptr<OOBMetaData> ip_port_ptr = item->second;
   std::string oob_con;
   while (oob_con.empty()) {
@@ -858,13 +852,13 @@ std::string const RDMAEndpoint::build_oob_connect(uint64_t rank_id) {
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   }
   // Store conn_key for later use (e.g., notifications)
-  std::unique_lock<std::shared_mutex> lock(rank_oob_conn_keys_mutex_);
-  rank_oob_conn_keys_[rank_id] = oob_con;
+  std::unique_lock<std::shared_mutex> lock(peer_oob_conn_keys_mutex_);
+  peer_oob_conn_keys_[peer_id] = oob_con;
   return oob_con;
 }
 
 int RDMAEndpoint::build_control_channel(std::string const& oob_con,
-                                        uint64_t rank_id, bool sync,
+                                        uint64_t peer_id, bool sync,
                                         int timeout_ms) {
   auto ctrl_mem =
       allocator_->allocate(kRingBufferSize, MemoryType::HOST, contexts_[0]);
@@ -874,8 +868,8 @@ int RDMAEndpoint::build_control_channel(std::string const& oob_con,
 
   // Include OOB server port for back-connection (notifications)
   MetaInfoToExchange ctrl_meta(
-      rank_id_, kControlChannelID, control_channel->get_local_meta(), ctrl_info,
-      ChannelType::Control, gpu_index_, oob_server_->get_port());
+      INVALID_PEER_ID, kControlChannelID, control_channel->get_local_meta(),
+      ctrl_info, ChannelType::Control, gpu_index_, oob_server_->get_port());
   fillCompressionMeta(ctrl_meta);
 
   UCCL_LOG(INFO, UCCL_RDMA)
@@ -891,7 +885,7 @@ int RDMAEndpoint::build_control_channel(std::string const& oob_con,
   bool sent = oob_client_->send_meta(
       oob_con, ctrl_serialized_meta,
       [this, control_channel, promise,
-       rank_id](std::string const& response) mutable {
+       peer_id](std::string const& response) mutable {
         MetaInfoToExchange response_meta =
             deserialize<MetaInfoToExchange>(response);
         control_channel->establishChannel(response_meta.channel_meta);
@@ -901,42 +895,42 @@ int RDMAEndpoint::build_control_channel(std::string const& oob_con,
           control_channel->bindWriteMetaRing(
               write_meta_ring_, response_meta.write_meta_ring_meta);
         }
-        this->setSendControlChannel(rank_id, std::move(control_channel));
+        this->setSendControlChannel(peer_id, std::move(control_channel));
         // Remember peer's decompress_buf so the SendConnection can target
         // it during compressWriteRequestSplitFirst.
-        this->setSendCompressionPeerMeta(rank_id, response_meta);
-        promise->set_value(response_meta.rank_id);  // no try/catch; fail-fast
+        this->setSendCompressionPeerMeta(peer_id, response_meta);
+        promise->set_value(response_meta.peer_id);  // no try/catch; fail-fast
       });
 
   if (!sent) {
-    UCCL_LOG(ERROR) << "Failed to send control channel metadata for rank "
-                    << rank_id;
+    UCCL_LOG(ERROR) << "Failed to send control channel metadata for peer "
+                    << peer_id;
     return -1;
   }
 
   if (!sync) {
-    return rank_id;
+    return peer_id;
   }
 
   if (future.wait_for(std::chrono::milliseconds(timeout_ms)) ==
       std::future_status::timeout) {
-    UCCL_LOG(ERROR) << "Timeout waiting for control channel handshake for rank "
-                    << rank_id;
+    UCCL_LOG(ERROR) << "Timeout waiting for control channel handshake for peer "
+                    << peer_id;
     return -1;
   }
 
-  uint64_t recv_rank_id = future.get();
+  uint64_t recv_peer_id = future.get();
 
   UCCL_LOG(INFO, UCCL_RDMA)
-      << "Control channel handshake completed successfully for rank "
-      << recv_rank_id;
+      << "Control channel handshake completed successfully for peer "
+      << recv_peer_id;
 
-  return static_cast<int>(recv_rank_id);
+  return static_cast<int>(recv_peer_id);
 }
 
-bool RDMAEndpoint::build_normal_channels(std::string const& oob_con,
-                                         uint64_t rank_id, bool sync,
-                                         int timeout_ms) {
+bool RDMAEndpoint::build_data_channels(std::string const& oob_con,
+                                       uint64_t peer_id, bool sync,
+                                       int timeout_ms) {
   std::vector<std::future<void>> futures;
   futures.reserve(kQpNumPerChannel);
 
@@ -946,8 +940,9 @@ bool RDMAEndpoint::build_normal_channels(std::string const& oob_con,
     auto channel = std::make_shared<RDMADataChannel>(
         getContextByChannelId(channel_id), channel_id);
 
-    MetaInfoToExchange meta(rank_id_, channel_id, channel->get_local_meta(),
-                            nullptr, ChannelType::Normal, gpu_index_);
+    MetaInfoToExchange meta(INVALID_PEER_ID, channel_id,
+                            channel->get_local_meta(), nullptr,
+                            ChannelType::Normal, gpu_index_);
 
     UCCL_LOG(INFO, UCCL_RDMA) << meta << std::endl;
     std::string serialized_meta = serialize(meta);
@@ -958,10 +953,10 @@ bool RDMAEndpoint::build_normal_channels(std::string const& oob_con,
     bool sent = oob_client_->send_meta(
         oob_con, serialized_meta,
         [this, channel, channel_id, promise,
-         rank_id](std::string const& response) {
+         peer_id](std::string const& response) {
           uint64_t peer_rank =
               this->handle_send_meta_response(channel, response);
-          addOneSendChannel(rank_id, channel_id, channel);
+          addOneSendChannel(peer_id, channel_id, channel);
           promise->set_value();  // no try/catch; fail-fast
         });
 
@@ -973,7 +968,7 @@ bool RDMAEndpoint::build_normal_channels(std::string const& oob_con,
 
   if (!sync) {
     UCCL_LOG(INFO, UCCL_RDMA)
-        << "Normal channels async build initiated for rank " << rank_id;
+        << "Normal channels async build initiated for peer " << peer_id;
     return true;
   }
 
@@ -996,7 +991,7 @@ bool RDMAEndpoint::build_normal_channels(std::string const& oob_con,
 
   UCCL_LOG(INFO, UCCL_RDMA)
       << "All " << kQpNumPerChannel
-      << " normal channels built successfully for rank " << rank_id;
+      << " normal channels built successfully for peer " << peer_id;
 
   return true;
 }

--- a/p2p/rdma/rdma_endpoint.h
+++ b/p2p/rdma/rdma_endpoint.h
@@ -17,8 +17,8 @@
 class RDMAEndpoint {
  public:
   explicit RDMAEndpoint(
-      int gpu_index = INVALID_GPU, uint64_t rank_id = INVALID_RANK_ID,
-      uint64_t port = 0, bool auto_start_polling = true,
+      int gpu_index = INVALID_GPU, uint64_t port = 0,
+      bool auto_start_polling = true,
       std::vector<size_t> const& device_ids = std::vector<size_t>());
   // Destructor
   ~RDMAEndpoint();
@@ -46,35 +46,35 @@ class RDMAEndpoint {
 
   bool deregMem(std::shared_ptr<RegMemBlock> reg_block);
 
-  int build_connect(uint64_t rank_id, bool sync = true, int timeout_ms = 10000);
+  int build_connect(uint64_t peer_id, bool sync = true, int timeout_ms = 10000);
 
   // Blocking check for send completion
-  void checkSendComplete(uint64_t rank_id, int64_t wr_id);
+  void checkSendComplete(uint64_t peer_id, int64_t wr_id);
 
-  bool checkSendComplete_once(uint64_t rank_id, int64_t wr_id);
+  bool checkSendComplete_once(uint64_t peer_id, int64_t wr_id);
 
-  // Resolve the SendConnection for a given rank_id once so the caller can
+  // Resolve the SendConnection for a given peer_id once so the caller can
   // perform many completion checks without re-acquiring the mutex + doing a
   // map lookup per check.
-  SendConnection* getSendGroupRaw(uint64_t rank_id);
+  SendConnection* getSendGroupRaw(uint64_t peer_id);
 
-  bool checkRecvComplete_once(uint64_t rank_id, uint64_t index);
+  bool checkRecvComplete_once(uint64_t peer_id, uint64_t index);
 
   // Blocking check for recv completion
-  void checkRecvComplete(uint64_t rank_id, uint64_t index);
+  void checkRecvComplete(uint64_t peer_id, uint64_t index);
 
   int64_t writeOrRead(std::shared_ptr<RDMASendRequest> req);
 
-  // Blocking send: wraps SendConnection::send with rank_id parameter
+  // Blocking send: wraps SendConnection::send with peer_id parameter
   // Returns wr_id for checking completion later
-  int64_t send(uint64_t rank_id, std::shared_ptr<RDMASendRequest> req);
+  int64_t send(uint64_t peer_id, std::shared_ptr<RDMASendRequest> req);
 
-  // Blocking recv: wraps RecvConnection::recv with rank_id parameter
+  // Blocking recv: wraps RecvConnection::recv with peer_id parameter
   // Returns index for checking completion later
-  int64_t recv(uint64_t rank_id, std::shared_ptr<RDMARecvRequest> req);
+  int64_t recv(uint64_t peer_id, std::shared_ptr<RDMARecvRequest> req);
 
-  // Add or update rank OOB metadata from a given map
-  void add_rank_oob_meta(
+  // Add or update peer OOB metadata from a given map
+  void add_peer_oob_meta(
       std::unordered_map<uint64_t, std::shared_ptr<OOBMetaData>> const&
           new_meta);
   ConnID uccl_connect(int remote_gpuidx, std::string remote_ip,
@@ -86,7 +86,7 @@ class RDMAEndpoint {
 
   std::shared_ptr<EpollClient> get_oob_client();
 
-  std::string get_oob_conn_key(uint64_t rank_id);
+  std::string get_oob_conn_key(uint64_t peer_id);
 
   ConnID uccl_accept(std::string& remote_ip, int* remote_gpuidx);
 
@@ -129,39 +129,38 @@ class RDMAEndpoint {
   uint64_t handle_send_meta_response(std::shared_ptr<RDMADataChannel> channel,
                                      std::string const& response);
 
-  std::shared_ptr<RecvConnection> getOrCreateRecvGroup(uint64_t rank_id);
+  std::shared_ptr<RecvConnection> getOrCreateRecvGroup(uint64_t peer_id);
 
-  void addOneRecvChannel(uint64_t rank_id, uint32_t channel_id,
+  void addOneRecvChannel(uint64_t peer_id, uint32_t channel_id,
                          std::shared_ptr<RDMADataChannel> new_channel);
 
   void setRecvControlChannel(
-      uint64_t rank_id, std::shared_ptr<RecvControlChannel>&& ctrl_channel);
+      uint64_t peer_id, std::shared_ptr<RecvControlChannel>&& ctrl_channel);
 
-  std::shared_ptr<SendConnection> getOrCreateSendGroup(uint64_t rank_id);
+  std::shared_ptr<SendConnection> getOrCreateSendGroup(uint64_t peer_id);
 
-  void addOneSendChannel(uint64_t rank_id, uint32_t channel_id,
+  void addOneSendChannel(uint64_t peer_id, uint32_t channel_id,
                          std::shared_ptr<RDMADataChannel> new_channel);
 
   void setSendControlChannel(
-      uint64_t rank_id, std::shared_ptr<SendControlChannel>&& ctrl_channel);
+      uint64_t peer_id, std::shared_ptr<SendControlChannel>&& ctrl_channel);
 
   // Hand the peer-side compression descriptors to the corresponding
   // connection so the compressed-write data path can target them.
-  void setSendCompressionPeerMeta(uint64_t rank_id,
+  void setSendCompressionPeerMeta(uint64_t peer_id,
                                   MetaInfoToExchange const& peer);
 
-  void setRecvCompressionPeerMeta(uint64_t rank_id,
+  void setRecvCompressionPeerMeta(uint64_t peer_id,
                                   MetaInfoToExchange const& peer);
 
-  std::string const build_oob_connect(uint64_t rank_id);
+  std::string const build_oob_connect(uint64_t peer_id);
 
-  int build_control_channel(std::string const& oob_con, uint64_t rank_id,
+  int build_control_channel(std::string const& oob_con, uint64_t peer_id,
                             bool sync = true, int timeout_ms = 10000);
 
-  bool build_normal_channels(std::string const& oob_con, uint64_t rank_id,
-                             bool sync = true, int timeout_ms = 10000);
+  bool build_data_channels(std::string const& oob_con, uint64_t peer_id,
+                           bool sync = true, int timeout_ms = 10000);
 
-  uint64_t rank_id_;
   int gpu_index_;
   std::vector<std::shared_ptr<RdmaContext>> contexts_;
   mutable std::shared_mutex recv_channel_mutex_;
@@ -171,10 +170,10 @@ class RDMAEndpoint {
   std::unordered_map<uint64_t, std::shared_ptr<SendConnection>>
       send_channel_groups_;
 
-  std::unordered_map<uint64_t, std::shared_ptr<OOBMetaData>> rank_oob_meta_;
-  mutable std::shared_mutex rank_oob_conn_keys_mutex_;
+  std::unordered_map<uint64_t, std::shared_ptr<OOBMetaData>> peer_oob_meta_;
+  mutable std::shared_mutex peer_oob_conn_keys_mutex_;
   std::unordered_map<uint64_t, std::string>
-      rank_oob_conn_keys_;  // Track conn_key per rank
+      peer_oob_conn_keys_;  // Track conn_key per peer
   std::shared_ptr<EpollClient> oob_client_;
   std::shared_ptr<EpollServer> oob_server_;
   std::shared_ptr<MemoryAllocator> allocator_;
@@ -183,8 +182,8 @@ class RDMAEndpoint {
   mutable std::shared_mutex accepted_meta_mutex_;
   std::unordered_map<uint64_t, AcceptedMeta> accepted_meta_;
   bool auto_start_polling_;
-  std::atomic<int32_t> send_id_;
-  std::atomic<int32_t> recv_id_;
+  std::atomic<int32_t> next_send_peer_id_;
+  std::atomic<int32_t> next_recv_peer_id_;
 
   std::atomic<bool> stop_accept_{false};
 };

--- a/p2p/rdma/tests/test_efa_endpoint.cpp
+++ b/p2p/rdma/tests/test_efa_endpoint.cpp
@@ -12,9 +12,9 @@
 
 // Define command line flags
 DEFINE_int32(gpu_index, 0, "GPU index to use");
-DEFINE_uint64(rank_id, 0, "Local rank ID");
+DEFINE_uint64(peer_id, 0, "Local peer ID");
 DEFINE_uint64(port, 19997, "Local port for OOB server");
-DEFINE_uint64(remote_rank, 1, "Remote rank ID to connect to");
+DEFINE_uint64(remote_peer, 1, "Remote peer ID to connect to");
 DEFINE_string(remote_ip, "", "Remote IP address");
 DEFINE_uint64(remote_port, 19997, "Remote port number");
 DEFINE_string(test_mode, "correctness",
@@ -24,27 +24,27 @@ DEFINE_uint64(buffer_size, 1024 * 1024, "Buffer size in bytes");
 
 // Example usage:
 // Correctness test (100 iterations with verification):
-// ./test_efa_endpoint --gpu_index=0 --rank_id=0 --port=19997 --remote_rank=1
+// ./test_efa_endpoint --gpu_index=0 --peer_id=0 --port=19997 --remote_peer=1
 // --remote_ip=172.31.47.234 --remote_port=19997 --test_mode=correctness
 // --buffer_size=104857600
-// ./test_efa_endpoint --gpu_index=0 --rank_id=1 --port=19997 --remote_rank=0
+// ./test_efa_endpoint --gpu_index=0 --peer_id=1 --port=19997 --remote_peer=0
 // --remote_ip=172.31.36.62 --remote_port=19997 --test_mode=correctness
 // --buffer_size=104857600
 //
 //
-// Unidirectional test (rank 0 sends, rank 1 receives):
-// ./test_efa_endpoint --gpu_index=0 --rank_id=0 --port=19997 --remote_rank=1
+// Unidirectional test (rank 0 sends, peer 1 receives):
+// ./test_efa_endpoint --gpu_index=0 --peer_id=0 --port=19997 --remote_peer=1
 // --remote_ip=172.31.47.234 --remote_port=19997 --test_mode=unidirectional
 // --iterations=100 --buffer_size=104857600
-// ./test_efa_endpoint --gpu_index=0 --rank_id=1 --port=19997 --remote_rank=0
+// ./test_efa_endpoint --gpu_index=0 --peer_id=1 --port=19997 --remote_peer=0
 // --remote_ip=172.31.36.62 --remote_port=19997 --test_mode=unidirectional
 // --iterations=100 --buffer_size=104857600
 
 // Bandwidth test (bidirectional):
-// ./test_efa_endpoint --gpu_index=0 --rank_id=0 --port=19997 --remote_rank=1
+// ./test_efa_endpoint --gpu_index=0 --peer_id=0 --port=19997 --remote_peer=1
 // --remote_ip=172.31.47.234 --remote_port=19997 --test_mode=bandwidth
 // --iterations=100 --buffer_size=104857600
-// ./test_efa_endpoint --gpu_index=0 --rank_id=1 --port=19997 --remote_rank=0
+// ./test_efa_endpoint --gpu_index=0 --peer_id=1 --port=19997 --remote_peer=0
 // --remote_ip=172.31.36.62 --remote_port=19997 --test_mode=bandwidth
 // --iterations=100 --buffer_size=104857600
 
@@ -79,9 +79,9 @@ void correctness_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator) {
 
   for (int i = 0; i < num_iterations; i++) {
     // Prepare unique test data for this iteration with header and footer
-    std::string header = "START:Rank " + std::to_string(FLAGS_rank_id) +
+    std::string header = "START:Peer " + std::to_string(FLAGS_peer_id) +
                          " iteration " + std::to_string(i);
-    std::string footer = "END:Rank " + std::to_string(FLAGS_rank_id) +
+    std::string footer = "END:Peer " + std::to_string(FLAGS_peer_id) +
                          " iteration " + std::to_string(i);
 
     memset(h_send_data, 0, test_buffer_size);
@@ -108,7 +108,7 @@ void correctness_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator) {
     auto recv_req = std::make_shared<RDMARecvRequest>(recv_mem);
 
     // Post recv first
-    int64_t recv_index = endpoint.recv(FLAGS_remote_rank, recv_req);
+    int64_t recv_index = endpoint.recv(FLAGS_remote_peer, recv_req);
     std::cout << "recv_index:" << recv_index << std::endl << std::flush;
     if (recv_index < 0) {
       std::cerr << "Failed to post recv request\n" << std::flush;
@@ -117,7 +117,7 @@ void correctness_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator) {
     }
 
     // Post send
-    int64_t send_wr_id = endpoint.send(FLAGS_remote_rank, send_req);
+    int64_t send_wr_id = endpoint.send(FLAGS_remote_peer, send_req);
 
     std::cout << "send_wr_id:" << send_wr_id << std::endl << std::flush;
     ;
@@ -128,20 +128,20 @@ void correctness_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator) {
     }
 
     // Wait for completion
-    endpoint.checkRecvComplete(FLAGS_remote_rank, recv_index);
+    endpoint.checkRecvComplete(FLAGS_remote_peer, recv_index);
     std::cout << "After checkRecvComplete\n" << std::flush;
     ;
-    endpoint.checkSendComplete(FLAGS_remote_rank, send_wr_id);
+    endpoint.checkSendComplete(FLAGS_remote_peer, send_wr_id);
 
     // Verify received data - check both header and footer
     cudaMemcpy(h_recv_data, recv_mem->addr, test_buffer_size,
                cudaMemcpyDeviceToHost);
 
-    std::string expected_header = "START:Rank " +
-                                  std::to_string(FLAGS_remote_rank) +
+    std::string expected_header = "START:Peer " +
+                                  std::to_string(FLAGS_remote_peer) +
                                   " iteration " + std::to_string(i);
-    std::string expected_footer = "END:Rank " +
-                                  std::to_string(FLAGS_remote_rank) +
+    std::string expected_footer = "END:Peer " +
+                                  std::to_string(FLAGS_remote_peer) +
                                   " iteration " + std::to_string(i);
 
     // Extract received header and footer
@@ -193,13 +193,13 @@ void correctness_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator) {
   std::cout << "Success rate: " << (100.0 * passed / num_iterations) << "%\n";
 }
 
-// Unidirectional bandwidth test: rank 0 only sends, rank 1 only receives
+// Unidirectional bandwidth test: peer 0 only sends, peer 1 only receives
 void unidirectional_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
                          int iterations) {
   std::cout << "\n=== Starting Unidirectional Bandwidth Test (" << iterations
             << " iterations) ===\n";
-  std::cout << "Rank " << FLAGS_rank_id
-            << " role: " << (FLAGS_rank_id == 0 ? "SENDER" : "RECEIVER")
+  std::cout << "Peer " << FLAGS_peer_id
+            << " role: " << (FLAGS_peer_id == 0 ? "SENDER" : "RECEIVER")
             << "\n";
 
   size_t test_buffer_size = FLAGS_buffer_size;
@@ -227,18 +227,18 @@ void unidirectional_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
   // Warmup
   std::cout << "Running warmup (10 iterations)...\n";
   for (int i = 0; i < 50; i++) {
-    if (FLAGS_rank_id == 0) {
-      // Rank 0: only send
+    if (FLAGS_peer_id == 0) {
+      // Peer 0: only send
       auto remote_mem_placeholder = std::make_shared<RemoteMemInfo>();
       auto send_req =
           std::make_shared<RDMASendRequest>(send_mem, remote_mem_placeholder);
-      int64_t send_wr_id = endpoint.send(FLAGS_remote_rank, send_req);
-      endpoint.checkSendComplete(FLAGS_remote_rank, send_wr_id);
+      int64_t send_wr_id = endpoint.send(FLAGS_remote_peer, send_req);
+      endpoint.checkSendComplete(FLAGS_remote_peer, send_wr_id);
     } else {
-      // Rank 1: only receive
+      // Peer 1: only receive
       auto recv_req = std::make_shared<RDMARecvRequest>(recv_mem);
-      int64_t recv_index = endpoint.recv(FLAGS_remote_rank, recv_req);
-      endpoint.checkRecvComplete(FLAGS_remote_rank, recv_index);
+      int64_t recv_index = endpoint.recv(FLAGS_remote_peer, recv_req);
+      endpoint.checkRecvComplete(FLAGS_remote_peer, recv_index);
     }
   }
 
@@ -247,8 +247,8 @@ void unidirectional_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
   // Benchmark
   auto start_time = std::chrono::high_resolution_clock::now();
 
-  if (FLAGS_rank_id == 0) {
-    // Rank 0: sender only
+  if (FLAGS_peer_id == 0) {
+    // Peer 0: sender only
     std::vector<std::pair<int, int64_t>>
         send_infos;  // (channel_id, send_wr_id)
     send_infos.reserve(iterations);
@@ -259,9 +259,9 @@ void unidirectional_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
       auto send_req =
           std::make_shared<RDMASendRequest>(send_mem, remote_mem_placeholder);
 
-      int64_t send_wr_id = endpoint.send(FLAGS_remote_rank, send_req);
+      int64_t send_wr_id = endpoint.send(FLAGS_remote_peer, send_req);
       send_infos.push_back({send_req->channel_id, send_wr_id});
-      endpoint.checkSendComplete(FLAGS_remote_rank, send_wr_id);
+      endpoint.checkSendComplete(FLAGS_remote_peer, send_wr_id);
       // if ((i + 1) % 100 == 0) {
       //   std::cout << "Sent " << (i + 1) << " messages\n";
       // }
@@ -269,11 +269,11 @@ void unidirectional_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
 
     // Then, check all send completions
     // for (auto const& [channel_id, send_wr_id] : send_infos) {
-    //   endpoint.checkSendComplete(FLAGS_remote_rank, send_wr_id);
+    //   endpoint.checkSendComplete(FLAGS_remote_peer, send_wr_id);
     // }
     // std::cout << "All sends completed\n";
   } else {
-    // Rank 1: receiver only
+    // Peer 1: receiver only
     std::vector<int64_t> recv_indices;
     recv_indices.reserve(iterations);
 
@@ -281,9 +281,9 @@ void unidirectional_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
     for (int i = 0; i < iterations; i++) {
       auto recv_req = std::make_shared<RDMARecvRequest>(recv_mem);
 
-      int64_t recv_index = endpoint.recv(FLAGS_remote_rank, recv_req);
+      int64_t recv_index = endpoint.recv(FLAGS_remote_peer, recv_req);
       recv_indices.push_back(recv_index);
-      endpoint.checkRecvComplete(FLAGS_remote_rank, recv_index);
+      endpoint.checkRecvComplete(FLAGS_remote_peer, recv_index);
       // if ((i + 1) % 100 == 0) {
       //   std::cout << "Received " << (i + 1) << " messages\n";
       // }
@@ -291,7 +291,7 @@ void unidirectional_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
 
     // Then, check all recv completions
     // for (int64_t recv_index : recv_indices) {
-    //   endpoint.checkRecvComplete(FLAGS_remote_rank, recv_index);
+    //   endpoint.checkRecvComplete(FLAGS_remote_peer, recv_index);
     // }
   }
 
@@ -309,9 +309,9 @@ void unidirectional_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
   double bandwidth_gbps = (total_bytes / elapsed_seconds) / 1e9;
   double latency_us = (elapsed_seconds / iterations) * 1000000.0;
 
-  std::cout << "\n=== Unidirectional Bandwidth Test Results (Rank "
-            << FLAGS_rank_id << ") ===\n";
-  std::cout << "Role: " << (FLAGS_rank_id == 0 ? "SENDER" : "RECEIVER") << "\n";
+  std::cout << "\n=== Unidirectional Bandwidth Test Results (Peer "
+            << FLAGS_peer_id << ") ===\n";
+  std::cout << "Role: " << (FLAGS_peer_id == 0 ? "SENDER" : "RECEIVER") << "\n";
   std::cout << "Iterations: " << iterations << "\n";
   std::cout << "Buffer size: " << test_buffer_size << " bytes\n";
   std::cout << "Total time: " << elapsed_seconds << " seconds\n";
@@ -360,11 +360,11 @@ void bandwidth_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
         std::make_shared<RDMASendRequest>(send_mem, remote_mem_placeholder);
     auto recv_req = std::make_shared<RDMARecvRequest>(recv_mem);
 
-    int64_t recv_index = endpoint.recv(FLAGS_remote_rank, recv_req);
-    int64_t send_wr_id = endpoint.send(FLAGS_remote_rank, send_req);
+    int64_t recv_index = endpoint.recv(FLAGS_remote_peer, recv_req);
+    int64_t send_wr_id = endpoint.send(FLAGS_remote_peer, send_req);
 
-    endpoint.checkSendComplete(FLAGS_remote_rank, send_wr_id);
-    endpoint.checkRecvComplete(FLAGS_remote_rank, recv_index);
+    endpoint.checkSendComplete(FLAGS_remote_peer, send_wr_id);
+    endpoint.checkRecvComplete(FLAGS_remote_peer, recv_index);
   }
 
   std::cout << "Starting benchmark...\n" << std::flush;
@@ -384,13 +384,13 @@ void bandwidth_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
         std::make_shared<RDMASendRequest>(send_mem, remote_mem_placeholder);
     auto recv_req = std::make_shared<RDMARecvRequest>(recv_mem);
 
-    int64_t recv_index = endpoint.recv(FLAGS_remote_rank, recv_req);
+    int64_t recv_index = endpoint.recv(FLAGS_remote_peer, recv_req);
     recv_indices.push_back(recv_index);
 
-    int64_t send_wr_id = endpoint.send(FLAGS_remote_rank, send_req);
+    int64_t send_wr_id = endpoint.send(FLAGS_remote_peer, send_req);
     send_infos.push_back({send_req->channel_id, send_wr_id});
-    endpoint.checkSendComplete(FLAGS_remote_rank, send_wr_id);
-    endpoint.checkRecvComplete(FLAGS_remote_rank, recv_index);
+    endpoint.checkSendComplete(FLAGS_remote_peer, send_wr_id);
+    endpoint.checkRecvComplete(FLAGS_remote_peer, recv_index);
     // if ((i + 1) % 100 == 0) {
     //   std::cout << "Completed " << (i + 1) << " iterations\n";
     // }
@@ -406,11 +406,11 @@ void bandwidth_test(RDMAEndpoint& endpoint, MemoryAllocator& allocator,
   // for (auto const& [channel_id, send_wr_id] : send_infos) {
   //   // std::cout << "channel_id:" <<channel_id<<",
   //   // send_wr_id:"<<send_wr_id<<std::endl<<std::flush;
-  //   endpoint.checkSendComplete(FLAGS_remote_rank, send_wr_id);
+  //   endpoint.checkSendComplete(FLAGS_remote_peer, send_wr_id);
   // }
   // for (int64_t recv_index : recv_indices) {
   //   // std::cout << "recv_index:" <<recv_index<<std::endl<<std::flush;
-  //   endpoint.checkRecvComplete(FLAGS_remote_rank, recv_index);
+  //   endpoint.checkRecvComplete(FLAGS_remote_peer, recv_index);
   // }
   auto phase2_end = std::chrono::high_resolution_clock::now();
   double phase2_time =
@@ -471,9 +471,9 @@ int main(int argc, char* argv[]) {
 
   std::cout << "=== RDMAEndpoint Usage Example ===\n";
   std::cout << "GPU Index: " << FLAGS_gpu_index << "\n";
-  std::cout << "Rank ID: " << FLAGS_rank_id << "\n";
+  std::cout << "Peer ID: " << FLAGS_peer_id << "\n";
   std::cout << "Port: " << FLAGS_port << "\n";
-  std::cout << "Remote Rank: " << FLAGS_remote_rank << "\n";
+  std::cout << "Remote Peer: " << FLAGS_remote_peer << "\n";
   std::cout << "Remote IP: " << FLAGS_remote_ip << "\n";
   std::cout << "Remote Port: " << FLAGS_remote_port << "\n";
   std::cout << "================================\n\n";
@@ -514,20 +514,20 @@ int main(int argc, char* argv[]) {
     // Create RDMAEndpoint with device_ids = {0}
     std::cout << "Creating RDMAEndpoint...\n";
     std::vector<size_t> device_ids = {0, 1};
-    RDMAEndpoint endpoint(FLAGS_gpu_index, FLAGS_rank_id, FLAGS_port);
+    RDMAEndpoint endpoint(FLAGS_gpu_index, FLAGS_port);
     std::cout << "RDMAEndpoint created successfully\n\n";
 
-    // Create OOBMetaData for remote rank
-    std::cout << "Setting up remote rank metadata...\n";
+    // Create OOBMetaData for remote peer
+    std::cout << "Setting up remote peer metadata...\n";
     auto remote_meta = std::make_shared<OOBMetaData>();
     remote_meta->server_ip = FLAGS_remote_ip;
     remote_meta->server_port = FLAGS_remote_port;
 
-    // Add remote rank metadata
-    std::unordered_map<uint64_t, std::shared_ptr<OOBMetaData>> rank_meta_map;
-    rank_meta_map[FLAGS_remote_rank] = remote_meta;
-    endpoint.add_rank_oob_meta(rank_meta_map);
-    std::cout << "Added remote rank " << FLAGS_remote_rank
+    // Add remote peer metadata
+    std::unordered_map<uint64_t, std::shared_ptr<OOBMetaData>> peer_meta_map;
+    peer_meta_map[FLAGS_remote_peer] = remote_meta;
+    endpoint.add_peer_oob_meta(peer_meta_map);
+    std::cout << "Added remote peer " << FLAGS_remote_peer
               << " metadata (IP: " << FLAGS_remote_ip
               << ", Port: " << FLAGS_remote_port << ")\n\n";
 
@@ -536,27 +536,27 @@ int main(int argc, char* argv[]) {
         << "Waiting for 2 seconds to ensure both endpoints are ready...\n";
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
-    // Connect to remote rank
-    std::cout << "Connecting to remote rank " << FLAGS_remote_rank << "...\n";
-    int connect_result = endpoint.build_connect(FLAGS_remote_rank);  // sync
+    // Connect to remote peer
+    std::cout << "Connecting to remote peer " << FLAGS_remote_peer << "...\n";
+    int connect_result = endpoint.build_connect(FLAGS_remote_peer);  // sync
     // mode (default)
-    // // int connect_result = endpoint.build_connect(FLAGS_remote_rank, false);
-    // // async mode endpoint.connect_check(FLAGS_remote_rank);
+    // // int connect_result = endpoint.build_connect(FLAGS_remote_peer, false);
+    // // async mode endpoint.connect_check(FLAGS_remote_peer);
     std::string remote_ip;
     int remote_dev;
     int remote_gpuidx;
-    // if(FLAGS_rank_id==0){
+    // if(FLAGS_peer_id==0){
     // endpoint.uccl_connect(0, 0, 0, 0, FLAGS_remote_ip, FLAGS_remote_port);
     // // }
     // // else{
     // endpoint.uccl_accept(0, 0, 0, remote_ip, &remote_dev, &remote_gpuidx);
     // }
     // if (connect_result>=0) {
-    //   std::cout << "Successfully connected to remote rank " <<
-    //   FLAGS_remote_rank
+    //   std::cout << "Successfully connected to remote peer " <<
+    //   FLAGS_remote_peer
     //             << "\n";
     // } else {
-    //   std::cerr << "Failed to connect to remote rank " << FLAGS_remote_rank
+    //   std::cerr << "Failed to connect to remote peer " << FLAGS_remote_peer
     //             << "\n";
     //   return 1;
     // }

--- a/p2p/uccl_engine.cc
+++ b/p2p/uccl_engine.cc
@@ -177,7 +177,7 @@ uccl_conn_t* uccl_engine_connect(uccl_engine_t* engine, char const* ip_addr,
   //   - Cross-process same-node: network (NCCL). Data still uses IPC via
   //     NIXL ipc_bufs since conn->is_local is set true.
   //     NOTE: same-GPU cross-process is unsupported with NCCL because
-  //     ncclCommInitRank rejects two ranks on the same physical GPU.
+  //     ncclCommInitPeer rejects two ranks on the same physical GPU.
   //   - Remote inter-node: network (NCCL)
   bool use_ipc;
   if (!uccl::is_nccl_transport()) {

--- a/p2p/uccl_engine.cc
+++ b/p2p/uccl_engine.cc
@@ -180,7 +180,7 @@ uccl_conn_t* uccl_engine_connect(uccl_engine_t* engine, char const* ip_addr,
   //     ncclCommInitPeer rejects two ranks on the same physical GPU.
   //   - Remote inter-node: network (NCCL)
   bool use_ipc;
-  if (!uccl::is_nccl_transport()) {
+  if (!is_nccl_transport()) {
     use_ipc = is_local && (same_process ||
                            remote_bdf != engine->endpoint->get_gpu_bus_id());
   } else {
@@ -213,7 +213,7 @@ uccl_conn_t* uccl_engine_connect(uccl_engine_t* engine, char const* ip_addr,
                                    conn_id);
     if (ok) {
       conn->sock_fd = engine->endpoint->get_sock_fd(conn_id);
-      if (!uccl::is_nccl_transport()) {
+      if (!is_nccl_transport()) {
         conn->oob_conn_key = engine->endpoint->get_oob_conn_key(conn_id);
       }
     }
@@ -235,7 +235,7 @@ uccl_conn_t* uccl_engine_connect(uccl_engine_t* engine, char const* ip_addr,
 uccl_conn_t* uccl_engine_accept(uccl_engine_t* engine, char* ip_addr_buf,
                                 size_t ip_addr_buf_len, int* remote_gpu_idx) {
   if (!engine || !ip_addr_buf || !remote_gpu_idx) return nullptr;
-  if (!uccl::is_nccl_transport()) {
+  if (!is_nccl_transport()) {
     engine->endpoint->start_passive_accept();
   }
   uccl_conn_t* conn = new uccl_conn;
@@ -251,7 +251,7 @@ uccl_conn_t* uccl_engine_accept(uccl_engine_t* engine, char* ip_addr_buf,
   *remote_gpu_idx = gpu_idx;
   conn->conn_id = conn_id;
   conn->sock_fd = engine->endpoint->get_sock_fd(conn_id);
-  if (!uccl::is_nccl_transport()) {
+  if (!is_nccl_transport()) {
     conn->oob_conn_key = engine->endpoint->get_oob_conn_key(conn_id);
   }
   conn->engine = engine;
@@ -324,7 +324,7 @@ int uccl_engine_read_vector(uccl_conn_t* conn, std::vector<uccl_mr_t> mr_ids,
                             std::vector<char*> ipc_bufs) {
   if (!conn || num_iovs <= 0) return -1;
 
-  if (uccl::is_nccl_transport()) {
+  if (is_nccl_transport()) {
     // The NIXL UCCL backend always uses the vector API, even for a single iov.
     // For the NCCL path, bypass the generic readv proxy-thread machinery in
     // that case and issue the scalar read directly.
@@ -414,7 +414,7 @@ int uccl_engine_write_vector(uccl_conn_t* conn, std::vector<uccl_mr_t> mr_ids,
                              std::vector<char*> ipc_bufs) {
   if (!conn || num_iovs <= 0) return -1;
 
-  if (uccl::is_nccl_transport()) {
+  if (is_nccl_transport()) {
     // Mirror the single-iov fast path for writes so the merged NCCL endpoint
     // does not force 1-buffer transfers through the vector proxy path.
     if (num_iovs == 1 && mr_ids.size() == 1 && dst_v.size() == 1 &&
@@ -603,7 +603,7 @@ int uccl_engine_send_notif(uccl_conn_t* conn, notify_msg_t* notify_msg) {
                : -1;
   }
 
-  if (uccl::is_nccl_transport()) {
+  if (is_nccl_transport()) {
     return conn->engine->endpoint->send_notification(conn->conn_id, oob_msg);
   }
 

--- a/p2p/util/common.cc
+++ b/p2p/util/common.cc
@@ -24,6 +24,35 @@ size_t channelIdToContextId(uint32_t channel_id) {
   return (channel_id == 0) ? 0 : (channel_id - 1) % kNICContextNumber;
 }
 
+void ImmData::set_chunk_count(uint16_t chunk_count) {
+  data_ = (static_cast<uint32_t>(chunk_count) << 16) | (data_ & 0xFFFF);
+}
+
+void ImmData::set_index(uint16_t index) {
+  data_ = (data_ & 0xFFFF0000) | (index & kIndexMask) | (data_ & kWriteMetaBit);
+}
+
+void ImmData::set_write_meta() { data_ |= kWriteMetaBit; }
+
+ImmData& ImmData::operator=(uint32_t raw) {
+  data_ = raw;
+  return *this;
+}
+
+std::ostream& operator<<(std::ostream& os, ImmData const& imm) {
+  os << "ImmData{raw: " << imm.data_ << ", chunk_count: " << imm.chunk_count()
+     << ", index: " << imm.index() << "}";
+  return os;
+}
+
+MessageChunk::MessageChunk(uint64_t off, size_t sz) : offset(off), size(sz) {}
+
+std::ostream& operator<<(std::ostream& os, MessageChunk const& chunk) {
+  os << "MessageChunk{offset: " << chunk.offset << ", size: " << chunk.size
+     << "}";
+  return os;
+}
+
 size_t ChunkSplitStrategy::getMessageChunkCount(size_t message_size) {
   constexpr size_t chunk_size_bytes = kMessageChunkSizeKB * 1024;
   if (message_size == 0) return 0;
@@ -72,6 +101,342 @@ void copyRKeysFromMRArrayToBytes(MRArray const& mr_array, char* dst,
   }
 }
 
+std::ostream& operator<<(std::ostream& os, ChannelMetaData const& meta) {
+  os << "ChannelMetaData{qpn: " << meta.qpn << ", gid: ";
+  std::ios_base::fmtflags flags = os.flags();
+  for (int i = 0; i < 16; ++i) {
+    os << std::hex << std::setw(2) << std::setfill('0')
+       << static_cast<int>(meta.gid.raw[i]);
+    if (i == 7) os << ":";
+  }
+  os.flags(flags);
+  os << "}";
+  return os;
+}
+
+OOBMetaData::OOBMetaData() : server_ip(""), server_port(0), gpu_id(0) {}
+
+OOBMetaData::OOBMetaData(std::string conn_key_, uint16_t remote_port_)
+    : server_ip(std::move(conn_key_)), server_port(remote_port_), gpu_id(0) {}
+
+std::ostream& operator<<(std::ostream& os, OOBMetaData const& meta) {
+  os << "OOBMetaData{server_ip: " << meta.server_ip
+     << ", server_port: " << meta.server_port << ", gpu_id: " << meta.gpu_id
+     << "}";
+  return os;
+}
+
+bool CQMeta::hasIMM() const { return op_code == IBV_WC_RECV_RDMA_WITH_IMM; }
+
+std::ostream& operator<<(std::ostream& os, CQMeta const& meta) {
+  os << "CQMeta{wr_id: " << meta.wr_id << ", op_code: " << meta.op_code
+     << ", len: " << meta.len << ", imm: " << meta.imm
+     << ", hasIMM: " << (meta.op_code == IBV_WC_RECV_RDMA_WITH_IMM) << "}";
+  return os;
+}
+
+RegMemBlock::RegMemBlock() : addr(nullptr), size(0), type(MemoryType::HOST) {}
+
+RegMemBlock::RegMemBlock(void* a, size_t s, MemoryType t)
+    : addr(a), size(s), type(t) {}
+
+RegMemBlock::RegMemBlock(void* a, size_t s, MRArray const& mr_array_in,
+                         MemoryType t)
+    : addr(a), size(s), type(t) {
+  mr_array.copyFrom(mr_array_in);
+}
+
+bool RegMemBlock::operator==(RegMemBlock const& other) const {
+  return addr == other.addr && size == other.size && type == other.type;
+}
+
+void RegMemBlock::setMRByContextID(uint32_t context_id, struct ibv_mr* mr) {
+  mr_array.setKeyByContextID(context_id, mr);
+}
+
+void RegMemBlock::setMRByChannelID(uint32_t channel_id, struct ibv_mr* mr) {
+  mr_array.setKeyByChannelID(channel_id, mr);
+}
+
+struct ibv_mr* RegMemBlock::getMRByChannelID(uint32_t channel_id) const {
+  return mr_array.getKeyByChannelID(channel_id);
+}
+
+struct ibv_mr* RegMemBlock::getMRByContextID(uint32_t context_id) const {
+  return mr_array.getKeyByContextID(context_id);
+}
+
+uint32_t RegMemBlock::getKeyByChannelID(uint32_t channel_id) const {
+  struct ibv_mr* mr = getMRByChannelID(channel_id);
+  return mr ? mr->rkey : 0;
+}
+
+uint32_t RegMemBlock::getKeyByContextID(uint32_t context_id) const {
+  struct ibv_mr* mr = getMRByContextID(context_id);
+  return mr ? mr->rkey : 0;
+}
+
+std::ostream& operator<<(std::ostream& os, RegMemBlock const& block) {
+  os << "RegMemBlock{addr: " << block.addr << ", size: " << block.size
+     << ", type: " << (block.type == MemoryType::HOST ? "HOST" : "GPU")
+     << block.mr_array << std::endl;
+
+  os << "}";
+  return os;
+}
+
+RemoteMemInfo::RemoteMemInfo() : addr(0), length(0), type(MemoryType::HOST) {}
+
+RemoteMemInfo::RemoteMemInfo(uint64_t a, size_t len, RKeyArray const& rkey,
+                             MemoryType t)
+    : addr(a), length(len), type(t) {
+  rkey_array.copyFrom(rkey);
+}
+
+RemoteMemInfo::RemoteMemInfo(uint64_t a, size_t len, MRArray const& mrs,
+                             MemoryType t)
+    : addr(a), length(len), type(t) {
+  copyRKeyArrayFromMRArray(mrs, rkey_array);
+}
+
+RemoteMemInfo::RemoteMemInfo(RegMemBlock const& block)
+    : addr(reinterpret_cast<uint64_t>(block.addr)),
+      length(block.size),
+      type(block.type) {
+  copyRKeyArrayFromMRArray(block.mr_array, rkey_array);
+}
+
+RemoteMemInfo::RemoteMemInfo(std::shared_ptr<RegMemBlock> const block)
+    : addr(reinterpret_cast<uint64_t>(block->addr)),
+      length(block->size),
+      type(block->type) {
+  copyRKeyArrayFromMRArray(block->mr_array, rkey_array);
+}
+
+uint32_t RemoteMemInfo::getKeyByChannelID(uint32_t channel_id) const {
+  return rkey_array.getKeyByChannelID(channel_id);
+}
+
+uint32_t RemoteMemInfo::getKeyByContextID(size_t context_id) const {
+  return rkey_array.getKeyByContextID(context_id);
+}
+
+std::ostream& operator<<(std::ostream& os, RemoteMemInfo const& info) {
+  os << "RemoteMemInfo{addr: 0x" << std::hex << info.addr << std::dec
+     << ", length: " << info.length
+     << ", type: " << (info.type == MemoryType::HOST ? "HOST" : "GPU")
+     << "rkey_array " << info.rkey_array << "}" << std::endl;
+  return os;
+}
+
+RDMARecvRequest::RDMARecvRequest(std::shared_ptr<RegMemBlock> local)
+    : local_mem(local) {}
+
+uint32_t RDMARecvRequest::getLocalKey() const {
+  return local_mem->getKeyByChannelID(channel_id);
+}
+
+uint64_t RDMARecvRequest::getLocalAddress() const {
+  return reinterpret_cast<uint64_t>(local_mem->addr);
+}
+
+uint32_t RDMARecvRequest::getLocalLen() const { return local_mem->size; }
+
+std::ostream& operator<<(std::ostream& os, RDMARecvRequest const& req) {
+  os << "RDMARecvRequest{";
+  os << "from_peer_id: " << req.from_peer_id
+     << ", to_peer_id: " << req.to_peer_id
+     << ", channel_id: " << req.channel_id;
+  if (req.local_mem) {
+    os << ", local_mem: " << *req.local_mem;
+  } else {
+    os << ", local_mem: nullptr";
+  }
+  os << "}";
+  return os;
+}
+
+SendReqMeta::SendReqMeta()
+    : peer_id(0),
+      channel_id(0),
+      remote_mem{},
+      expected_chunk_count(0),
+      received_chunk_count(0) {}
+
+SendReqMeta::SendReqMeta(uint32_t pid, uint32_t cid, RemoteMemInfo const& rmem,
+                         uint32_t expected, uint32_t received)
+    : peer_id(pid),
+      channel_id(cid),
+      remote_mem(rmem),
+      expected_chunk_count(expected),
+      received_chunk_count(received) {}
+
+SendReqMeta::SendReqMeta(std::shared_ptr<RDMARecvRequest> rev_req) {
+  peer_id = rev_req->from_peer_id;
+  channel_id = rev_req->channel_id;
+  remote_mem = rev_req->local_mem;
+  local_mem = *(rev_req->local_compression_mem ? rev_req->local_compression_mem
+                                               : rev_req->local_mem);
+  float_type = rev_req->compress_ctx ? rev_req->compress_ctx->getFloatType()
+                                     : FloatType::kUndefined;
+  expected_chunk_count =
+      ChunkSplitStrategy::getMessageChunkCount(local_mem.size);
+  received_chunk_count = 0;
+}
+
+std::ostream& operator<<(std::ostream& os, SendReqMeta const& meta) {
+  os << "SendReqMeta{peer_id: " << meta.peer_id
+     << ", channel_id: " << meta.channel_id
+     << ", remote_mem: " << meta.remote_mem
+     << ", expected_chunk_count: " << meta.expected_chunk_count
+     << ", received_chunk_count: " << meta.received_chunk_count << "}";
+  return os;
+}
+
+SendReqMetaOnRing::SendReqMetaOnRing() : meta{}, flag{ReqFlag::PENDING} {}
+
+SendReqMetaOnRing::SendReqMetaOnRing(SendReqMetaOnRing const& other)
+    : meta(other.meta), flag{other.flag.load(std::memory_order_relaxed)} {}
+
+SendReqMetaOnRing& SendReqMetaOnRing::operator=(
+    SendReqMetaOnRing const& other) {
+  meta = other.meta;
+  flag.store(other.flag.load(std::memory_order_relaxed),
+             std::memory_order_relaxed);
+  return *this;
+}
+
+SendReqMeta SendReqMetaOnRing::getSendReqMeta() const { return meta; }
+
+void SendReqMetaOnRing::setSendReqMeta(SendReqMeta const& m) { meta = m; }
+
+std::ostream& operator<<(std::ostream& os, SendReqMetaOnRing const& ring) {
+  auto flag_val = ring.flag.load(std::memory_order_relaxed);
+  os << "SendReqMetaOnRing{meta: " << ring.meta << ", flag: "
+     << (flag_val == ReqFlag::PENDING       ? "PENDING"
+         : flag_val == ReqFlag::IN_PROGRESS ? "IN_PROGRESS"
+                                            : "IS_DONE")
+     << "}";
+  return os;
+}
+
+RDMASendRequest::RDMASendRequest(std::shared_ptr<RegMemBlock> local,
+                                 std::shared_ptr<RemoteMemInfo> remote,
+                                 ImmData imm, bool signaled)
+    : local_mem(local),
+      remote_mem(remote),
+      imm_data(imm),
+      need_signaled(signaled) {}
+
+RDMASendRequest::RDMASendRequest(std::shared_ptr<RDMASendRequest> other,
+                                 std::shared_ptr<RegMemBlock> local,
+                                 ImmData imm, bool signaled)
+    : local_mem(local),
+      remote_mem(other->remote_mem),
+      imm_data(imm),
+      need_signaled(signaled) {}
+
+RDMASendRequest::RDMASendRequest(RDMASendRequest const& other,
+                                 std::shared_ptr<RegMemBlock> local,
+                                 ImmData imm, bool signaled)
+    : local_mem(local),
+      remote_mem(other.remote_mem),
+      imm_data(imm),
+      need_signaled(signaled) {}
+
+uint32_t RDMASendRequest::getLocalKey() const {
+  return local_mem->getKeyByChannelID(channel_id);
+}
+
+uint32_t RDMASendRequest::getRemoteKey() const {
+  return remote_mem->getKeyByChannelID(channel_id);
+}
+
+uint64_t RDMASendRequest::getLocalAddress() const {
+  return reinterpret_cast<uint64_t>(local_mem->addr);
+}
+
+uint64_t RDMASendRequest::getRemoteAddress() const { return remote_mem->addr; }
+
+ImmData RDMASendRequest::getImm() const { return imm_data; }
+
+uint32_t RDMASendRequest::getLocalLen() const { return local_mem->size; }
+
+std::ostream& operator<<(std::ostream& os, RDMASendRequest const& req) {
+  os << "RDMASendRequest{";
+  os << "from_peer_id: " << req.from_peer_id
+     << ", to_peer_id: " << req.to_peer_id << ", channel_id: " << req.channel_id
+     << ", imm_data: " << req.imm_data
+     << ", need_signaled: " << req.need_signaled;
+  if (req.local_mem) {
+    os << ", local_mem: " << *req.local_mem;
+  } else {
+    os << ", local_mem: nullptr";
+  }
+  if (req.remote_mem) {
+    os << ", remote_mem: " << *req.remote_mem;
+  } else {
+    os << ", remote_mem: nullptr";
+  }
+  os << "}";
+  return os;
+}
+
+MetaInfoToExchange::MetaInfoToExchange()
+    : peer_id(0),
+      channel_id(0),
+      flag(ChannelType::Normal),
+      channel_meta{},
+      mem_meta{},
+      gpu_id(0),
+      oob_port(0) {}
+
+MetaInfoToExchange::MetaInfoToExchange(
+    int32_t pid, int32_t cid, std::shared_ptr<ChannelMetaData> ch_meta,
+    std::shared_ptr<RemoteMemInfo> mem_meta_ptr, ChannelType flag_in, int gid,
+    uint16_t oob_p)
+    : peer_id(pid),
+      channel_id(cid),
+      flag(flag_in),
+      channel_meta{},
+      mem_meta{},
+      gpu_id(gid),
+      oob_port(oob_p) {
+  if (ch_meta) {
+    channel_meta = *ch_meta;
+  }
+  if (mem_meta_ptr) {
+    mem_meta = *mem_meta_ptr;
+  }
+}
+
+std::ostream& operator<<(std::ostream& os, MetaInfoToExchange const& meta) {
+  os << "=== MetaInfoToExchange ===" << std::endl;
+  os << "  peer_id: " << meta.peer_id << std::endl;
+  os << "  channel_id: " << meta.channel_id << std::endl;
+
+  os << "  channel_meta:" << std::endl;
+  os << "    qpn: " << meta.channel_meta.qpn << std::endl;
+  os << "    gid: ";
+
+  std::ios_base::fmtflags flags = os.flags();
+
+  for (int i = 0; i < 16; ++i) {
+    os << std::hex << std::setw(2) << std::setfill('0')
+       << static_cast<int>(meta.channel_meta.gid.raw[i]);
+    if (i == 7) os << ":";
+  }
+
+  os.flags(flags);
+  os << std::endl;
+
+  os << "  mem_meta:" << meta.mem_meta << std::endl;
+  os << "  gpu_id: " << meta.gpu_id << std::endl;
+  os << "=========================" << std::endl;
+
+  return os;
+}
+
 int make_socket_non_blocking(int fd) {
   int flags = fcntl(fd, F_GETFL, 0);
   if (flags == -1) return -1;
@@ -86,6 +451,50 @@ ssize_t try_send(int fd, char const* buf, size_t len) {
     return -1;
   }
   return n;
+}
+
+bool is_nic_usable(std::string const& nic_name, NicMode mode) {
+  if (mode == NicMode::EFA && strncmp(nic_name.c_str(), "rdmap", 5) != 0) {
+    return false;
+  }
+
+  int dev_count = 0;
+  ibv_device** dev_list = ibv_get_device_list(&dev_count);
+  if (!dev_list) {
+    return false;
+  }
+  bool usable = false;
+  for (int i = 0; i < dev_count; ++i) {
+    if (std::strcmp(ibv_get_device_name(dev_list[i]), nic_name.c_str()) != 0) {
+      continue;
+    }
+    ibv_context* ctx = ibv_open_device(dev_list[i]);
+    if (!ctx) break;
+
+    ibv_port_attr port_attr{};
+    if (ibv_query_port(ctx, kPortNum, &port_attr) == 0) {
+      if (mode == NicMode::EFA) {
+        if (port_attr.state == IBV_PORT_ACTIVE &&
+            (port_attr.link_layer == IBV_LINK_LAYER_UNSPECIFIED ||
+             port_attr.link_layer == IBV_LINK_LAYER_ETHERNET ||
+             port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND)) {
+          usable = true;
+        }
+      } else {
+        if (port_attr.state == IBV_PORT_ACTIVE &&
+            (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET ||
+             port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) &&
+            (port_attr.link_layer != IBV_LINK_LAYER_ETHERNET ||
+             port_attr.gid_tbl_len > 0)) {
+          usable = true;
+        }
+      }
+    }
+    ibv_close_device(ctx);
+    break;
+  }
+  ibv_free_device_list(dev_list);
+  return usable;
 }
 
 namespace std {

--- a/p2p/util/common.h
+++ b/p2p/util/common.h
@@ -38,19 +38,19 @@
 #include <sys/socket.h>
 #include <unistd.h>
 
-typedef uint64_t FlowID;
+typedef uint64_t PeerID;
 struct ConnID {
   void* context;
   int sock_fd;
   int dev;
-  FlowID flow_id;
+  PeerID peer_id;
 };
 
 typedef struct AcceptedMeta {
   std::string ip;
   uint16_t port;
   int gpu_id;
-  uint64_t rank_id;
+  uint64_t peer_id;
 } AcceptedMeta;
 
 // Notifications
@@ -174,7 +174,7 @@ static constexpr size_t kRingCapacity = 16384;  // Must be power of 2
 static constexpr size_t kInFlightMaxSizeKB =
     10240000;  // Max in-flight packets per channel
 
-static constexpr uint32_t INVALID_RANK_ID =
+static constexpr uint32_t INVALID_PEER_ID =
     std::numeric_limits<uint32_t>::max();
 static constexpr uint32_t INVALID_GPU = std::numeric_limits<uint32_t>::max();
 
@@ -508,8 +508,9 @@ typedef struct RemoteMemInfo {
 } RemoteMemInfo;
 
 typedef struct RDMARecvRequest {
-  uint32_t from_rank_id = INVALID_RANK_ID;
-  uint32_t to_rank_id = INVALID_RANK_ID;
+  // Peer id is local to this endpoint, not necessarily global.
+  uint32_t from_peer_id = INVALID_PEER_ID;
+  uint32_t to_peer_id = INVALID_PEER_ID;
   uint32_t channel_id = 0;
   int64_t wr_id = -1;
   std::shared_ptr<RegMemBlock> local_mem;
@@ -533,8 +534,8 @@ typedef struct RDMARecvRequest {
   friend std::ostream& operator<<(std::ostream& os,
                                   RDMARecvRequest const& req) {
     os << "RDMARecvRequest{";
-    os << "from_rank_id: " << req.from_rank_id
-       << ", to_rank_id: " << req.to_rank_id
+    os << "from_peer_id: " << req.from_peer_id
+       << ", to_peer_id: " << req.to_peer_id
        << ", channel_id: " << req.channel_id;
     if (req.local_mem) {
       os << ", local_mem: " << *req.local_mem;
@@ -549,7 +550,7 @@ typedef struct RDMARecvRequest {
 enum class ReqFlag : int16_t { PENDING = 2, IN_PROGRESS = 3, IS_DONE = 4 };
 
 struct alignas(64) SendReqMeta {
-  uint32_t rank_id;
+  uint32_t peer_id;
   uint32_t channel_id;
   RemoteMemInfo remote_mem;
   RegMemBlock local_mem;
@@ -558,22 +559,22 @@ struct alignas(64) SendReqMeta {
   uint32_t received_chunk_count;  // Number of chunks already received
 
   SendReqMeta()
-      : rank_id(0),
+      : peer_id(0),
         channel_id(0),
         remote_mem{},
         expected_chunk_count(0),
         received_chunk_count(0) {}
 
-  SendReqMeta(uint32_t rid, uint32_t cid, RemoteMemInfo const& rmem,
+  SendReqMeta(uint32_t pid, uint32_t cid, RemoteMemInfo const& rmem,
               uint32_t expected = 0, uint32_t received = 0)
-      : rank_id(rid),
+      : peer_id(pid),
         channel_id(cid),
         remote_mem(rmem),
         expected_chunk_count(expected),
         received_chunk_count(received) {}
 
   SendReqMeta(std::shared_ptr<RDMARecvRequest> rev_req) {
-    rank_id = rev_req->from_rank_id;
+    peer_id = rev_req->from_peer_id;
     channel_id = rev_req->channel_id;
     remote_mem = rev_req->local_mem;
     local_mem =
@@ -587,7 +588,7 @@ struct alignas(64) SendReqMeta {
   }
 
   friend std::ostream& operator<<(std::ostream& os, SendReqMeta const& meta) {
-    os << "SendReqMeta{rank_id: " << meta.rank_id
+    os << "SendReqMeta{peer_id: " << meta.peer_id
        << ", channel_id: " << meta.channel_id
        << ", remote_mem: " << meta.remote_mem
        << ", expected_chunk_count: " << meta.expected_chunk_count
@@ -704,11 +705,13 @@ inline auto from_ring_meta = [](SendReqMetaOnRing const& src,
                                 SendReqMeta& dst) { dst = src.meta; };
 
 enum class SendType { Send, Write, Read };
+
 struct RDMASendRequest {
   std::shared_ptr<RegMemBlock> local_mem;
   std::shared_ptr<RemoteMemInfo> remote_mem;
-  uint32_t from_rank_id = INVALID_RANK_ID;
-  uint32_t to_rank_id = INVALID_RANK_ID;
+  // Peer id is local to this endpoint, not necessarily global.
+  uint32_t from_peer_id = INVALID_PEER_ID;
+  uint32_t to_peer_id = INVALID_PEER_ID;
   uint32_t channel_id = 0;
   ImmData imm_data = 0;  // immediate data with chunk_count (high 16 bits) and
                          // index (low 16 bits)
@@ -765,8 +768,8 @@ struct RDMASendRequest {
   friend std::ostream& operator<<(std::ostream& os,
                                   RDMASendRequest const& req) {
     os << "RDMASendRequest{";
-    os << "from_rank_id: " << req.from_rank_id
-       << ", to_rank_id: " << req.to_rank_id
+    os << "from_peer_id: " << req.from_peer_id
+       << ", to_peer_id: " << req.to_peer_id
        << ", channel_id: " << req.channel_id << ", imm_data: " << req.imm_data
        << ", need_signaled: " << req.need_signaled;
     if (req.local_mem) {
@@ -801,7 +804,7 @@ T deserialize(std::string const& s) {
 
 // Example MetaInfo struct for metadata exchange
 struct MetaInfoToExchange {
-  int32_t rank_id;
+  int32_t peer_id;
   int32_t channel_id;
   ChannelType flag;
   ChannelMetaData channel_meta;
@@ -815,7 +818,7 @@ struct MetaInfoToExchange {
 
   // Default constructor
   MetaInfoToExchange()
-      : rank_id(0),
+      : peer_id(0),
         channel_id(0),
         flag(ChannelType::Normal),
         channel_meta{},
@@ -823,14 +826,14 @@ struct MetaInfoToExchange {
         gpu_id(0),
         oob_port(0) {}
 
-  // Constructor with required rank_id and channel_id, optional channel_meta and
+  // Constructor with required peer_id and channel_id, optional channel_meta and
   // mem_meta
-  MetaInfoToExchange(int32_t rid, int32_t cid,
+  MetaInfoToExchange(int32_t pid, int32_t cid,
                      std::shared_ptr<ChannelMetaData> ch_meta = nullptr,
                      std::shared_ptr<RemoteMemInfo> mem_meta_ptr = nullptr,
                      ChannelType flag_in = ChannelType::Normal, int gid = 0,
                      uint16_t oob_p = 0)
-      : rank_id(rid),
+      : peer_id(pid),
         channel_id(cid),
         flag(flag_in),
         channel_meta{},
@@ -849,7 +852,7 @@ struct MetaInfoToExchange {
   friend std::ostream& operator<<(std::ostream& os,
                                   MetaInfoToExchange const& meta) {
     os << "=== MetaInfoToExchange ===" << std::endl;
-    os << "  rank_id: " << meta.rank_id << std::endl;
+    os << "  peer_id: " << meta.peer_id << std::endl;
     os << "  channel_id: " << meta.channel_id << std::endl;
 
     os << "  channel_meta:" << std::endl;

--- a/p2p/util/common.h
+++ b/p2p/util/common.h
@@ -84,7 +84,6 @@ void serialize_fifo_item(FifoItem const& item, char* buf);
 void deserialize_fifo_item(char const* buf, FifoItem* item);
 enum class MemoryType { HOST, GPU };
 
-namespace uccl {
 enum class FloatType : uint32_t {
   kUndefined = 0,
   kFloat16 = 1,
@@ -93,64 +92,18 @@ enum class FloatType : uint32_t {
   kFloat8E4M3FN = 4,
   kFloat8E5M2 = 5,
 };
-}
 
 struct CompressionContext {
   virtual ~CompressionContext() = default;
-  virtual uccl::FloatType getFloatType() const = 0;
+  virtual FloatType getFloatType() const = 0;
   virtual size_t getMaxSize() const = 0;
 };
 
 using CompressCtx = std::shared_ptr<CompressionContext>;
 
-static constexpr uint8_t kPortNum = 1;
-
 enum class NicMode { EFA, IB };
 
-inline bool is_nic_usable(std::string const& nic_name, NicMode mode) {
-  if (mode == NicMode::EFA && strncmp(nic_name.c_str(), "rdmap", 5) != 0) {
-    return false;
-  }
-
-  int dev_count = 0;
-  ibv_device** dev_list = ibv_get_device_list(&dev_count);
-  if (!dev_list) {
-    return false;
-  }
-  bool usable = false;
-  for (int i = 0; i < dev_count; ++i) {
-    if (std::strcmp(ibv_get_device_name(dev_list[i]), nic_name.c_str()) != 0) {
-      continue;
-    }
-    ibv_context* ctx = ibv_open_device(dev_list[i]);
-    if (!ctx) break;
-
-    ibv_port_attr port_attr{};
-    if (ibv_query_port(ctx, kPortNum, &port_attr) == 0) {
-      if (mode == NicMode::EFA) {
-        if (port_attr.state == IBV_PORT_ACTIVE &&
-            (port_attr.link_layer == IBV_LINK_LAYER_UNSPECIFIED ||
-             port_attr.link_layer == IBV_LINK_LAYER_ETHERNET ||
-             port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND)) {
-          usable = true;
-        }
-      } else {
-        if (port_attr.state == IBV_PORT_ACTIVE &&
-            (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET ||
-             port_attr.link_layer == IBV_LINK_LAYER_INFINIBAND) &&
-            (port_attr.link_layer != IBV_LINK_LAYER_ETHERNET ||
-             port_attr.gid_tbl_len > 0)) {
-          usable = true;
-        }
-      }
-    }
-    ibv_close_device(ctx);
-    break;
-  }
-  ibv_free_device_list(dev_list);
-  return usable;
-}
-
+static constexpr uint8_t kPortNum = 1;
 static constexpr int kNumEngines = 4;
 static constexpr int kNumGpuRtStreams = 4;
 
@@ -261,15 +214,10 @@ class ImmData {
   }
 
   // Set chunk_count (preserves index)
-  void set_chunk_count(uint16_t chunk_count) {
-    data_ = (static_cast<uint32_t>(chunk_count) << 16) | (data_ & 0xFFFF);
-  }
+  void set_chunk_count(uint16_t chunk_count);
 
   // Set index (preserves chunk_count + write_meta flag)
-  void set_index(uint16_t index) {
-    data_ =
-        (data_ & 0xFFFF0000) | (index & kIndexMask) | (data_ & kWriteMetaBit);
-  }
+  void set_index(uint16_t index);
 
   // Distinguishes WriteReqMeta entries from SendReqMeta entries on the
   // control channel. kRingCapacity = 16384 only needs 14 bits, so bit 15 of
@@ -277,7 +225,7 @@ class ImmData {
   static constexpr uint32_t kWriteMetaBit = 1u << 15;
   static constexpr uint32_t kIndexMask = 0x7FFFu;
   constexpr bool is_write_meta() const { return data_ & kWriteMetaBit; }
-  void set_write_meta() { data_ |= kWriteMetaBit; }
+  void set_write_meta();
   constexpr uint16_t plain_index() const {
     return static_cast<uint16_t>(data_ & kIndexMask);
   }
@@ -286,10 +234,7 @@ class ImmData {
   constexpr operator uint32_t() const { return data_; }
 
   // Assignment from uint32_t
-  ImmData& operator=(uint32_t raw) {
-    data_ = raw;
-    return *this;
-  }
+  ImmData& operator=(uint32_t raw);
 
   // Get raw value
   constexpr uint32_t raw() const { return data_; }
@@ -304,11 +249,7 @@ class ImmData {
   constexpr bool operator==(uint32_t other) const { return data_ == other; }
   constexpr bool operator!=(uint32_t other) const { return data_ != other; }
 
-  friend std::ostream& operator<<(std::ostream& os, ImmData const& imm) {
-    os << "ImmData{raw: " << imm.data_ << ", chunk_count: " << imm.chunk_count()
-       << ", index: " << imm.index() << "}";
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, ImmData const& imm);
 
  private:
   uint32_t data_;
@@ -318,13 +259,9 @@ struct MessageChunk {
   uint64_t offset;  // Offset from the start of the message
   size_t size;      // Size of this chunk in bytes
 
-  MessageChunk(uint64_t off, size_t sz) : offset(off), size(sz) {}
+  MessageChunk(uint64_t off, size_t sz);
 
-  friend std::ostream& operator<<(std::ostream& os, MessageChunk const& chunk) {
-    os << "MessageChunk{offset: " << chunk.offset << ", size: " << chunk.size
-       << "}";
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, MessageChunk const& chunk);
 };
 
 struct ChunkSplitStrategy {
@@ -346,18 +283,7 @@ struct ChannelMetaData {
   uint16_t lid;       // Infiniband
 
   friend std::ostream& operator<<(std::ostream& os,
-                                  ChannelMetaData const& meta) {
-    os << "ChannelMetaData{qpn: " << meta.qpn << ", gid: ";
-    std::ios_base::fmtflags flags = os.flags();
-    for (int i = 0; i < 16; ++i) {
-      os << std::hex << std::setw(2) << std::setfill('0')
-         << static_cast<int>(meta.gid.raw[i]);
-      if (i == 7) os << ":";
-    }
-    os.flags(flags);
-    os << "}";
-    return os;
-  }
+                                  ChannelMetaData const& meta);
 };
 
 enum class ChannelType : int16_t { Control, Normal };
@@ -371,15 +297,9 @@ struct OOBMetaData {
   std::string server_ip;
   int64_t server_port;
   int gpu_id;
-  OOBMetaData() : server_ip(""), server_port(0), gpu_id(0) {}
-  OOBMetaData(std::string conn_key_, uint16_t remote_port_)
-      : server_ip(std::move(conn_key_)), server_port(remote_port_), gpu_id(0) {}
-  friend std::ostream& operator<<(std::ostream& os, OOBMetaData const& meta) {
-    os << "OOBMetaData{server_ip: " << meta.server_ip
-       << ", server_port: " << meta.server_port << ", gpu_id: " << meta.gpu_id
-       << "}";
-    return os;
-  }
+  OOBMetaData();
+  OOBMetaData(std::string conn_key_, uint16_t remote_port_);
+  friend std::ostream& operator<<(std::ostream& os, OOBMetaData const& meta);
 };
 
 struct CQMeta {
@@ -387,14 +307,9 @@ struct CQMeta {
   ibv_wc_opcode op_code;
   uint32_t len;
   ImmData imm;
-  inline bool hasIMM() const { return op_code == IBV_WC_RECV_RDMA_WITH_IMM; };
+  bool hasIMM() const;
 
-  friend std::ostream& operator<<(std::ostream& os, CQMeta const& meta) {
-    os << "CQMeta{wr_id: " << meta.wr_id << ", op_code: " << meta.op_code
-       << ", len: " << meta.len << ", imm: " << meta.imm
-       << ", hasIMM: " << (meta.op_code == IBV_WC_RECV_RDMA_WITH_IMM) << "}";
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, CQMeta const& meta);
 };
 
 // Registered memory region info
@@ -404,59 +319,33 @@ typedef struct RegMemBlock {
   MemoryType type;
   MRArray mr_array;  // Array of MR pointers for multiple contexts
 
-  RegMemBlock() : addr(nullptr), size(0), type(MemoryType::HOST) {}
-  RegMemBlock(void* a, size_t s, MemoryType t) : addr(a), size(s), type(t) {}
+  RegMemBlock();
+  RegMemBlock(void* a, size_t s, MemoryType t);
 
-  RegMemBlock(void* a, size_t s, MRArray const& mr_array_in, MemoryType t)
-      : addr(a), size(s), type(t) {
-    mr_array.copyFrom(mr_array_in);
-  }
+  RegMemBlock(void* a, size_t s, MRArray const& mr_array_in, MemoryType t);
 
   // Equality operator for hash support (based on size and type only)
-  bool operator==(RegMemBlock const& other) const {
-    return addr == other.addr && size == other.size && type == other.type;
-  }
+  bool operator==(RegMemBlock const& other) const;
 
   // Set MR by context ID
-  inline void setMRByContextID(uint32_t context_id, struct ibv_mr* mr) {
-    mr_array.setKeyByContextID(context_id, mr);
-  }
+  void setMRByContextID(uint32_t context_id, struct ibv_mr* mr);
 
   // Set MR by channel ID
-  inline void setMRByChannelID(uint32_t channel_id, struct ibv_mr* mr) {
-    mr_array.setKeyByChannelID(channel_id, mr);
-  }
+  void setMRByChannelID(uint32_t channel_id, struct ibv_mr* mr);
 
   // Get MR by channel ID
-  inline struct ibv_mr* getMRByChannelID(uint32_t channel_id) const {
-    return mr_array.getKeyByChannelID(channel_id);
-  }
+  struct ibv_mr* getMRByChannelID(uint32_t channel_id) const;
 
   // Get MR by context ID
-  inline struct ibv_mr* getMRByContextID(uint32_t context_id) const {
-    return mr_array.getKeyByContextID(context_id);
-  }
+  struct ibv_mr* getMRByContextID(uint32_t context_id) const;
 
   // Get rkey by channel ID (for backward compatibility)
-  inline uint32_t getKeyByChannelID(uint32_t channel_id) const {
-    struct ibv_mr* mr = getMRByChannelID(channel_id);
-    return mr ? mr->rkey : 0;
-  }
+  uint32_t getKeyByChannelID(uint32_t channel_id) const;
 
   // Get rkey by context ID (for backward compatibility)
-  inline uint32_t getKeyByContextID(uint32_t context_id) const {
-    struct ibv_mr* mr = getMRByContextID(context_id);
-    return mr ? mr->rkey : 0;
-  }
+  uint32_t getKeyByContextID(uint32_t context_id) const;
 
-  friend std::ostream& operator<<(std::ostream& os, RegMemBlock const& block) {
-    os << "RegMemBlock{addr: " << block.addr << ", size: " << block.size
-       << ", type: " << (block.type == MemoryType::HOST ? "HOST" : "GPU")
-       << block.mr_array << std::endl;
-
-    os << "}";
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, RegMemBlock const& block);
 } RegMemBlock;
 
 typedef struct RemoteMemInfo {
@@ -464,47 +353,21 @@ typedef struct RemoteMemInfo {
   RKeyArray rkey_array;  // For multiple memory regions (e.g., GPU memory)
   size_t length;
   MemoryType type;
-  RemoteMemInfo() : addr(0), length(0), type(MemoryType::HOST) {}
+  RemoteMemInfo();
 
-  RemoteMemInfo(uint64_t a, size_t len, RKeyArray const& rkey, MemoryType t)
-      : addr(a), length(len), type(t) {
-    rkey_array.copyFrom(rkey);
-  }
-  RemoteMemInfo(uint64_t a, size_t len, MRArray const& mrs, MemoryType t)
-      : addr(a), length(len), type(t) {
-    copyRKeyArrayFromMRArray(mrs, rkey_array);
-  }
+  RemoteMemInfo(uint64_t a, size_t len, RKeyArray const& rkey, MemoryType t);
+  RemoteMemInfo(uint64_t a, size_t len, MRArray const& mrs, MemoryType t);
 
-  RemoteMemInfo(RegMemBlock const& block)
-      : addr(reinterpret_cast<uint64_t>(block.addr)),
-        length(block.size),
-        type(block.type) {
-    copyRKeyArrayFromMRArray(block.mr_array, rkey_array);
-  }
+  RemoteMemInfo(RegMemBlock const& block);
 
-  RemoteMemInfo(std::shared_ptr<RegMemBlock> const block)
-      : addr(reinterpret_cast<uint64_t>(block->addr)),
-        length(block->size),
-        type(block->type) {
-    copyRKeyArrayFromMRArray(block->mr_array, rkey_array);
-  }
+  RemoteMemInfo(std::shared_ptr<RegMemBlock> const block);
 
-  inline uint32_t getKeyByChannelID(uint32_t channel_id) const {
-    return rkey_array.getKeyByChannelID(channel_id);
-  }
+  uint32_t getKeyByChannelID(uint32_t channel_id) const;
 
   // Get rkey by context ID (direct index access)
-  inline uint32_t getKeyByContextID(size_t context_id) const {
-    return rkey_array.getKeyByContextID(context_id);
-  }
+  uint32_t getKeyByContextID(size_t context_id) const;
 
-  friend std::ostream& operator<<(std::ostream& os, RemoteMemInfo const& info) {
-    os << "RemoteMemInfo{addr: 0x" << std::hex << info.addr << std::dec
-       << ", length: " << info.length
-       << ", type: " << (info.type == MemoryType::HOST ? "HOST" : "GPU")
-       << "rkey_array " << info.rkey_array << "}" << std::endl;
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, RemoteMemInfo const& info);
 } RemoteMemInfo;
 
 typedef struct RDMARecvRequest {
@@ -518,33 +381,16 @@ typedef struct RDMARecvRequest {
   CompressCtx compress_ctx;
 
   // Constructor
-  RDMARecvRequest(std::shared_ptr<RegMemBlock> local) : local_mem(local) {}
+  RDMARecvRequest(std::shared_ptr<RegMemBlock> local);
 
   // Getter methods
-  inline uint32_t getLocalKey() const {
-    return local_mem->getKeyByChannelID(channel_id);
-  }
+  uint32_t getLocalKey() const;
 
-  inline uint64_t getLocalAddress() const {
-    return reinterpret_cast<uint64_t>(local_mem->addr);
-  }
+  uint64_t getLocalAddress() const;
 
-  inline uint32_t getLocalLen() const { return local_mem->size; }
+  uint32_t getLocalLen() const;
 
-  friend std::ostream& operator<<(std::ostream& os,
-                                  RDMARecvRequest const& req) {
-    os << "RDMARecvRequest{";
-    os << "from_peer_id: " << req.from_peer_id
-       << ", to_peer_id: " << req.to_peer_id
-       << ", channel_id: " << req.channel_id;
-    if (req.local_mem) {
-      os << ", local_mem: " << *req.local_mem;
-    } else {
-      os << ", local_mem: nullptr";
-    }
-    os << "}";
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, RDMARecvRequest const& req);
 } RDMARecvRequest;
 
 enum class ReqFlag : int16_t { PENDING = 2, IN_PROGRESS = 3, IS_DONE = 4 };
@@ -554,84 +400,41 @@ struct alignas(64) SendReqMeta {
   uint32_t channel_id;
   RemoteMemInfo remote_mem;
   RegMemBlock local_mem;
-  uccl::FloatType float_type = uccl::FloatType::kUndefined;
+  FloatType float_type = FloatType::kUndefined;
   uint32_t expected_chunk_count;  // Expected number of chunks to receive
   uint32_t received_chunk_count;  // Number of chunks already received
 
-  SendReqMeta()
-      : peer_id(0),
-        channel_id(0),
-        remote_mem{},
-        expected_chunk_count(0),
-        received_chunk_count(0) {}
+  SendReqMeta();
 
   SendReqMeta(uint32_t pid, uint32_t cid, RemoteMemInfo const& rmem,
-              uint32_t expected = 0, uint32_t received = 0)
-      : peer_id(pid),
-        channel_id(cid),
-        remote_mem(rmem),
-        expected_chunk_count(expected),
-        received_chunk_count(received) {}
+              uint32_t expected = 0, uint32_t received = 0);
 
-  SendReqMeta(std::shared_ptr<RDMARecvRequest> rev_req) {
-    peer_id = rev_req->from_peer_id;
-    channel_id = rev_req->channel_id;
-    remote_mem = rev_req->local_mem;
-    local_mem =
-        *(rev_req->local_compression_mem ? rev_req->local_compression_mem
-                                         : rev_req->local_mem);
-    float_type = rev_req->compress_ctx ? rev_req->compress_ctx->getFloatType()
-                                       : uccl::FloatType::kUndefined;
-    expected_chunk_count =
-        ChunkSplitStrategy::getMessageChunkCount(local_mem.size);
-    received_chunk_count = 0;
-  }
+  SendReqMeta(std::shared_ptr<RDMARecvRequest> rev_req);
 
-  friend std::ostream& operator<<(std::ostream& os, SendReqMeta const& meta) {
-    os << "SendReqMeta{peer_id: " << meta.peer_id
-       << ", channel_id: " << meta.channel_id
-       << ", remote_mem: " << meta.remote_mem
-       << ", expected_chunk_count: " << meta.expected_chunk_count
-       << ", received_chunk_count: " << meta.received_chunk_count << "}";
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, SendReqMeta const& meta);
 };
 
 struct alignas(64) SendReqMetaOnRing {
   SendReqMeta meta;
   std::atomic<ReqFlag> flag;
 
-  SendReqMetaOnRing() : meta{}, flag{ReqFlag::PENDING} {}
+  SendReqMetaOnRing();
 
-  SendReqMetaOnRing(SendReqMetaOnRing const& other)
-      : meta(other.meta), flag{other.flag.load(std::memory_order_relaxed)} {}
+  SendReqMetaOnRing(SendReqMetaOnRing const& other);
 
-  SendReqMetaOnRing& operator=(SendReqMetaOnRing const& other) {
-    meta = other.meta;
-    flag.store(other.flag.load(std::memory_order_relaxed),
-               std::memory_order_relaxed);
-    return *this;
-  }
+  SendReqMetaOnRing& operator=(SendReqMetaOnRing const& other);
 
   // Get SendReqMeta from SendReqMetaOnRing
-  SendReqMeta getSendReqMeta() const { return meta; }
+  SendReqMeta getSendReqMeta() const;
 
   // Set SendReqMeta part
-  void setSendReqMeta(SendReqMeta const& m) { meta = m; }
+  void setSendReqMeta(SendReqMeta const& m);
 
   friend std::ostream& operator<<(std::ostream& os,
-                                  SendReqMetaOnRing const& ring) {
-    auto flag_val = ring.flag.load(std::memory_order_relaxed);
-    os << "SendReqMetaOnRing{meta: " << ring.meta << ", flag: "
-       << (flag_val == ReqFlag::PENDING       ? "PENDING"
-           : flag_val == ReqFlag::IN_PROGRESS ? "IN_PROGRESS"
-                                              : "IS_DONE")
-       << "}";
-    return os;
-  }
+                                  SendReqMetaOnRing const& ring);
 };
 
-// Ring buffer size for control channel
+// Ring buffer size for control channel.
 static constexpr size_t kRingBufferSize =
     sizeof(SendReqMetaOnRing) * kRingCapacity;
 
@@ -645,8 +448,8 @@ struct alignas(64) WriteReqMeta {
   uint32_t user_rkey;          // user-provided rkey (for logging/validation)
   uint32_t total_uncomp_size;  // original message size in bytes
   uint32_t compressed_size;    // split + encode output total bytes
-  uint32_t float_type;         // uccl::FloatType
-  uint32_t ack_slot;  // sender expects ack written here in its ack_ring
+  uint32_t float_type;         // FloatType
+  uint32_t ack_slot;           // sender expects ack written here in its ack_ring
   uint32_t _pad;
   int64_t wr_id;
 };
@@ -654,6 +457,7 @@ struct alignas(64) WriteReqMeta {
 // A small on-host ack slot. Receiver writes |wr_id| (or wr_id|kAckErrBit) once
 // decompress completes. Sender polls the value to determine completion.
 static constexpr uint64_t kAckErrBit = 1ull << 63;
+
 struct alignas(64) AckSlot {
   std::atomic<uint64_t> value;
 };
@@ -722,69 +526,32 @@ struct RDMASendRequest {
   // Constructor
   RDMASendRequest(std::shared_ptr<RegMemBlock> local,
                   std::shared_ptr<RemoteMemInfo> remote,
-                  ImmData imm = ImmData(), bool signaled = true)
-      : local_mem(local),
-        remote_mem(remote),
-        imm_data(imm),
-        need_signaled(signaled) {}
+                  ImmData imm = ImmData(), bool signaled = true);
 
   // Constructor from shared_ptr<RDMASendRequest>
   RDMASendRequest(std::shared_ptr<RDMASendRequest> other,
                   std::shared_ptr<RegMemBlock> local, ImmData imm = ImmData(),
-                  bool signaled = true)
-      : local_mem(local),
-        remote_mem(other->remote_mem),
-        imm_data(imm),
-        need_signaled(signaled) {}
+                  bool signaled = true);
 
   // Constructor from const RDMASendRequest&
   RDMASendRequest(RDMASendRequest const& other,
                   std::shared_ptr<RegMemBlock> local, ImmData imm = ImmData(),
-                  bool signaled = true)
-      : local_mem(local),
-        remote_mem(other.remote_mem),
-        imm_data(imm),
-        need_signaled(signaled) {}
+                  bool signaled = true);
 
   // Getter methods
-  inline uint32_t getLocalKey() const {
-    return local_mem->getKeyByChannelID(channel_id);
-  }
+  uint32_t getLocalKey() const;
 
-  inline uint32_t getRemoteKey() const {
-    return remote_mem->getKeyByChannelID(channel_id);
-  }
+  uint32_t getRemoteKey() const;
 
-  inline uint64_t getLocalAddress() const {
-    return reinterpret_cast<uint64_t>(local_mem->addr);
-  }
+  uint64_t getLocalAddress() const;
 
-  inline uint64_t getRemoteAddress() const { return remote_mem->addr; }
+  uint64_t getRemoteAddress() const;
 
-  inline ImmData getImm() const { return imm_data; }
+  ImmData getImm() const;
 
-  inline uint32_t getLocalLen() const { return local_mem->size; }
+  uint32_t getLocalLen() const;
 
-  friend std::ostream& operator<<(std::ostream& os,
-                                  RDMASendRequest const& req) {
-    os << "RDMASendRequest{";
-    os << "from_peer_id: " << req.from_peer_id
-       << ", to_peer_id: " << req.to_peer_id
-       << ", channel_id: " << req.channel_id << ", imm_data: " << req.imm_data
-       << ", need_signaled: " << req.need_signaled;
-    if (req.local_mem) {
-      os << ", local_mem: " << *req.local_mem;
-    } else {
-      os << ", local_mem: nullptr";
-    }
-    if (req.remote_mem) {
-      os << ", remote_mem: " << *req.remote_mem;
-    } else {
-      os << ", remote_mem: nullptr";
-    }
-    os << "}";
-    return os;
-  }
+  friend std::ostream& operator<<(std::ostream& os, RDMASendRequest const& req);
 };
 
 template <typename T>
@@ -817,14 +584,7 @@ struct MetaInfoToExchange {
   RemoteMemInfo ack_ring_meta;
 
   // Default constructor
-  MetaInfoToExchange()
-      : peer_id(0),
-        channel_id(0),
-        flag(ChannelType::Normal),
-        channel_meta{},
-        mem_meta{},
-        gpu_id(0),
-        oob_port(0) {}
+  MetaInfoToExchange();
 
   // Constructor with required peer_id and channel_id, optional channel_meta and
   // mem_meta
@@ -832,52 +592,11 @@ struct MetaInfoToExchange {
                      std::shared_ptr<ChannelMetaData> ch_meta = nullptr,
                      std::shared_ptr<RemoteMemInfo> mem_meta_ptr = nullptr,
                      ChannelType flag_in = ChannelType::Normal, int gid = 0,
-                     uint16_t oob_p = 0)
-      : peer_id(pid),
-        channel_id(cid),
-        flag(flag_in),
-        channel_meta{},
-        mem_meta{},
-        gpu_id(gid),
-        oob_port(oob_p) {
-    if (ch_meta) {
-      channel_meta = *ch_meta;
-    }
-    if (mem_meta_ptr) {
-      mem_meta = *mem_meta_ptr;
-    }
-  }
+                     uint16_t oob_p = 0);
 
   // Overload << operator for printing
   friend std::ostream& operator<<(std::ostream& os,
-                                  MetaInfoToExchange const& meta) {
-    os << "=== MetaInfoToExchange ===" << std::endl;
-    os << "  peer_id: " << meta.peer_id << std::endl;
-    os << "  channel_id: " << meta.channel_id << std::endl;
-
-    os << "  channel_meta:" << std::endl;
-    os << "    qpn: " << meta.channel_meta.qpn << std::endl;
-    os << "    gid: ";
-
-    // Save stream flags
-    std::ios_base::fmtflags flags = os.flags();
-
-    for (int i = 0; i < 16; ++i) {
-      os << std::hex << std::setw(2) << std::setfill('0')
-         << static_cast<int>(meta.channel_meta.gid.raw[i]);
-      if (i == 7) os << ":";
-    }
-
-    // Restore stream flags
-    os.flags(flags);
-    os << std::endl;
-
-    os << "  mem_meta:" << meta.mem_meta << std::endl;
-    os << "  gpu_id: " << meta.gpu_id << std::endl;
-    os << "=========================" << std::endl;
-
-    return os;
-  }
+                                  MetaInfoToExchange const& meta);
 };
 
 // Helper function: make socket non-blocking
@@ -885,6 +604,8 @@ int make_socket_non_blocking(int fd);
 
 // Helper function: try send entire buffer, return bytes_sent
 ssize_t try_send(int fd, char const* buf, size_t len);
+
+bool is_nic_usable(std::string const& nic_name, NicMode mode);
 
 // Hash support for RegMemBlock (based on size and type only)
 namespace std {

--- a/p2p/util/common.h
+++ b/p2p/util/common.h
@@ -449,7 +449,7 @@ struct alignas(64) WriteReqMeta {
   uint32_t total_uncomp_size;  // original message size in bytes
   uint32_t compressed_size;    // split + encode output total bytes
   uint32_t float_type;         // FloatType
-  uint32_t ack_slot;           // sender expects ack written here in its ack_ring
+  uint32_t ack_slot;  // sender expects ack written here in its ack_ring
   uint32_t _pad;
   int64_t wr_id;
 };

--- a/p2p/util/transport_type.h
+++ b/p2p/util/transport_type.h
@@ -5,8 +5,6 @@
 #include <cstdlib>
 #include <cstring>
 
-namespace uccl {
-
 enum class TransportType { RDMA, NCCL, EFA };
 
 inline TransportType get_transport_type() {
@@ -29,5 +27,3 @@ inline bool is_nccl_transport() {
 inline bool is_efa_transport() {
   return get_transport_type() == TransportType::EFA;
 }
-
-}  // namespace uccl


### PR DESCRIPTION
## Description

* Renaming rank_id and flow_id to peer_id, which better describes the connection identification mechanism. Rank_id is within a certain process group, but p2p actually uses local-viewed mono-increasing counters to assign peer_ids. flow_id was inherited from uccl-tran, and we should align it with its actual meaning of peer_id. 
* Separate def and impl for common.h and common.cc
* Many other small naming nits

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [x] I have run `build.sh` to verify compilation.
- [x] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
