### PR TITLE
[CI] fixing AMD ep test destory process

### DIFF
--- a/ep/bench/test_internode.py
+++ b/ep/bench/test_internode.py
@@ -617,8 +617,8 @@ def test_loop(
             assert current_hash == ref_hash
 
     # Destroy the buffer runtime and communication group
-    buffer.destroy()
     dist.barrier()
+    buffer.destroy()
     dist.destroy_process_group()
 
 

--- a/ep/bench/test_low_latency.py
+++ b/ep/bench/test_low_latency.py
@@ -572,8 +572,8 @@ def test_loop(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                 # assert current_hash == ref_hash, f"Error: seed={seed}"
 
     # Destroy the buffer runtime and communication group
-    buffer.destroy()
     dist.barrier()
+    buffer.destroy()
     dist.destroy_process_group()
 
 


### PR DESCRIPTION
## Description

Sometimes, we will hit SEGV fault for EP LL on AMD servers, like https://github.com/uccl-project/uccl/actions/runs/26493808368/job/78018572164. 

I suspect it is because some buffer gets destroyed too early. Thus I put the barrier before the buffer destroy. 

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
