### PR TITLE
[P2P] Increase kMaxInflightOps to 256 and make num-iovs > kMaxInflightOps pipelined.

### DIFF
--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -132,6 +132,14 @@ static inline void check_python_signals() {
   PyGILState_Release(gstate);
 }
 
+static inline bool raw_one_sided_batch_eligible(
+    std::vector<size_t> const& size_v, size_t num_iovs) {
+  for (size_t i = 0; i < num_iovs; ++i) {
+    if (ChunkSplitStrategy::getMessageChunkCount(size_v[i]) != 1) return false;
+  }
+  return true;
+}
+
 // ShmChannel helper function
 static inline std::string shm_ring_name(std::string const& from_bdf,
                                         std::string const& to_bdf) {
@@ -1063,48 +1071,10 @@ bool Endpoint::readv(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
   SendConnection* send_group =
       uccl_resolve_send_group(ep_, conn->uccl_conn_id_.peer_id);
 
-  bool raw_batch_eligible = true;
-  for (size_t i = 0; i < num_iovs; ++i) {
-    if (ChunkSplitStrategy::getMessageChunkCount(size_v[i]) != 1) {
-      raw_batch_eligible = false;
-      break;
-    }
-  }
-
-  // Fastest path: RDMA, fits in one inflight window, compression/CC disabled.
-  // Post raw one-sided WRs directly by channel and skip per-iov request-object
-  // construction.
-  if (send_group != nullptr && num_iovs <= kMaxInflightOps &&
-      raw_batch_eligible &&
+  if (send_group != nullptr && raw_one_sided_batch_eligible(size_v, num_iovs) &&
       send_group->canUseRawOneSidedBatch(SendType::Read)) {
-    std::array<SendConnection::OneSidedBatchOp, kMaxInflightOps> ops{};
-    int64_t wr_ids[kMaxInflightOps] = {};
-    bool done[kMaxInflightOps] = {false};
-
-    for (size_t i = 0; i < num_iovs; ++i) {
-      ops[i].local_addr = dst_v[i];
-      ops[i].size = size_v[i];
-      ops[i].local_mr_array = &mhandle_v[i]->mr_array;
-      ops[i].slot_item = &slot_item_v[i];
-    }
-    if (!send_group->postWriteOrReadBatch(SendType::Read, ops.data(), num_iovs,
-                                          wr_ids)) {
-      return false;
-    }
-
-    size_t num_done = 0;
-    while (num_done < num_iovs) {
-      auto _ = inside_python ? (check_python_signals(), nullptr) : nullptr;
-      uccl_drive_send(ep_);
-      for (size_t i = 0; i < num_iovs; ++i) {
-        if (done[i]) continue;
-        if (uccl_check_wr_fast(send_group, wr_ids[i])) {
-          done[i] = true;
-          num_done++;
-        }
-      }
-    }
-    return true;
+    return run_raw_one_sided_pipeline(send_group, SendType::Read, mhandle_v,
+                                      dst_v, size_v, slot_item_v, num_iovs);
   }
 
   UcclRequest ureq[kMaxInflightOps] = {};
@@ -1123,8 +1093,13 @@ bool Endpoint::readv(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
       UCCL_DCHECK(slot < kMaxInflightOps);
 
       auto rc =
-          uccl_read_async(ep_, conn, mhandle_v[next_iov], dst_v[next_iov],
-                          size_v[next_iov], slot_item_v[next_iov], &ureq[slot]);
+          send_group != nullptr
+              ? uccl_read_async_on_group(send_group, conn, mhandle_v[next_iov],
+                                         dst_v[next_iov], size_v[next_iov],
+                                         slot_item_v[next_iov], &ureq[slot])
+              : uccl_read_async(ep_, conn, mhandle_v[next_iov], dst_v[next_iov],
+                                size_v[next_iov], slot_item_v[next_iov],
+                                &ureq[slot]);
       if (rc == -1) break;
       active[slot] = true;
       next_iov++;
@@ -1187,6 +1162,85 @@ bool Endpoint::readv_async(uint64_t conn_id, std::vector<uint64_t> mr_id_v,
                                nullptr) != 1) {
   }
   recv_proxy_adaptive_sleeper_.maybe_wake_proxy_thread();
+
+  return true;
+}
+
+bool Endpoint::run_raw_one_sided_pipeline(
+    SendConnection* send_group, SendType send_type,
+    std::vector<P2PMhandle*> const& mhandle_v,
+    std::vector<void*> const& local_addr_v, std::vector<size_t> const& size_v,
+    std::vector<FifoItem> const& slot_item_v, size_t num_iovs) {
+  struct PendingRawWait {
+    SendConnection::RawBatchWait wait;
+    bool active = false;
+  };
+
+  std::array<PendingRawWait, kMaxInflightOps> pending_waits{};
+  size_t next_iov = 0;
+  size_t num_completed = 0;
+  size_t num_inflight = 0;
+
+  auto post_raw_window = [&]() -> bool {
+    if (next_iov >= num_iovs || num_inflight >= kMaxInflightOps) return true;
+
+    size_t const batch_iovs =
+        std::min<size_t>(kMaxInflightOps - num_inflight, num_iovs - next_iov);
+    std::array<SendConnection::OneSidedBatchOp, kMaxInflightOps> ops{};
+    int64_t wr_ids[kMaxInflightOps] = {};
+    std::array<SendConnection::RawBatchWait, kMaxInflightOps> waits{};
+    size_t num_waits = 0;
+
+    for (size_t i = 0; i < batch_iovs; ++i) {
+      size_t const iov = next_iov + i;
+      ops[i].local_addr = local_addr_v[iov];
+      ops[i].size = size_v[iov];
+      ops[i].local_mr_array = &mhandle_v[iov]->mr_array;
+      ops[i].slot_item = &slot_item_v[iov];
+    }
+
+    if (!send_group->postWriteOrReadBatch(send_type, ops.data(), batch_iovs,
+                                          wr_ids, waits.data(), &num_waits)) {
+      return false;
+    }
+    if (unlikely(num_waits == 0)) return false;
+
+    for (size_t i = 0; i < num_waits; ++i) {
+      bool inserted = false;
+      for (auto& pending : pending_waits) {
+        if (pending.active) continue;
+        pending.wait = waits[i];
+        pending.active = true;
+        inserted = true;
+        break;
+      }
+      if (unlikely(!inserted)) return false;
+    }
+
+    next_iov += batch_iovs;
+    num_inflight += batch_iovs;
+    return true;
+  };
+
+  while (num_completed < num_iovs) {
+    while (next_iov < num_iovs && num_inflight < kMaxInflightOps) {
+      if (!post_raw_window()) return false;
+    }
+
+    auto _ = inside_python ? (check_python_signals(), nullptr) : nullptr;
+    uccl_drive_send(ep_);
+
+    for (auto& pending : pending_waits) {
+      if (!pending.active) continue;
+      if (!uccl_check_wr_fast(send_group, pending.wait.wr_id)) continue;
+
+      pending.active = false;
+      num_completed += pending.wait.iov_count;
+      UCCL_DCHECK(num_inflight >= pending.wait.iov_count);
+      num_inflight -= pending.wait.iov_count;
+      pending.wait = {};
+    }
+  }
 
   return true;
 }
@@ -1308,48 +1362,10 @@ bool Endpoint::writev(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
   SendConnection* send_group =
       uccl_resolve_send_group(ep_, conn->uccl_conn_id_.peer_id);
 
-  bool raw_batch_eligible = true;
-  for (size_t i = 0; i < num_iovs; ++i) {
-    if (ChunkSplitStrategy::getMessageChunkCount(size_v[i]) != 1) {
-      raw_batch_eligible = false;
-      break;
-    }
-  }
-
-  // Fastest path: RDMA, fits in one inflight window, compression/CC disabled.
-  // Post raw one-sided WRs directly by channel and skip per-iov request-object
-  // construction.
-  if (send_group != nullptr && num_iovs <= kMaxInflightOps &&
-      raw_batch_eligible &&
+  if (send_group != nullptr && raw_one_sided_batch_eligible(size_v, num_iovs) &&
       send_group->canUseRawOneSidedBatch(SendType::Write)) {
-    std::array<SendConnection::OneSidedBatchOp, kMaxInflightOps> ops{};
-    int64_t wr_ids[kMaxInflightOps] = {};
-    bool done[kMaxInflightOps] = {false};
-
-    for (size_t i = 0; i < num_iovs; ++i) {
-      ops[i].local_addr = src_v[i];
-      ops[i].size = size_v[i];
-      ops[i].local_mr_array = &mhandle_v[i]->mr_array;
-      ops[i].slot_item = &slot_item_v[i];
-    }
-    if (!send_group->postWriteOrReadBatch(SendType::Write, ops.data(), num_iovs,
-                                          wr_ids)) {
-      return false;
-    }
-
-    size_t num_done = 0;
-    while (num_done < num_iovs) {
-      auto _ = inside_python ? (check_python_signals(), nullptr) : nullptr;
-      uccl_drive_send(ep_);
-      for (size_t i = 0; i < num_iovs; ++i) {
-        if (done[i]) continue;
-        if (uccl_check_wr_fast(send_group, wr_ids[i])) {
-          done[i] = true;
-          num_done++;
-        }
-      }
-    }
-    return true;
+    return run_raw_one_sided_pipeline(send_group, SendType::Write, mhandle_v,
+                                      src_v, size_v, slot_item_v, num_iovs);
   }
 
   UcclRequest ureq[kMaxInflightOps] = {};
@@ -1367,7 +1383,12 @@ bool Endpoint::writev(uint64_t conn_id, std::vector<uint64_t> const& mr_id_v,
       }
       UCCL_DCHECK(slot < kMaxInflightOps);
 
-      auto rc = uccl_write_async(ep_, conn, mhandle_v[next_iov],
+      auto rc =
+          send_group != nullptr
+              ? uccl_write_async_on_group(send_group, conn, mhandle_v[next_iov],
+                                          src_v[next_iov], size_v[next_iov],
+                                          slot_item_v[next_iov], &ureq[slot])
+              : uccl_write_async(ep_, conn, mhandle_v[next_iov],
                                  src_v[next_iov], size_v[next_iov],
                                  slot_item_v[next_iov], &ureq[slot]);
       if (rc == -1) break;

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -249,7 +249,8 @@ class Endpoint {
   static constexpr int kMaxNumGPUs = 8;
   static constexpr size_t kIpcAlignment = 1ul << 20;
   static constexpr size_t kIpcSizePerEngine = 1ul << 20;
-  static constexpr int kMaxInflightOps = 128;  // Max 8 concurrent Ops
+  static constexpr int kMaxInflightOps =
+      256;  // Max 256 concurrent Ops across all channels
   static constexpr size_t ShmRingDefaultElemCnt = 16;
   static constexpr size_t kTaskRingSize = 1024;
   static constexpr size_t kDirectAsyncNetThreshold = 256 * 1024;
@@ -549,6 +550,13 @@ class Endpoint {
       uint64_t conn_id, std::vector<void*>&& data_v,
       std::vector<size_t>&& size_v, std::vector<uint64_t>&& mr_id_v,
       std::vector<FifoItem>&& slot_item_v);
+  bool run_raw_one_sided_pipeline(SendConnection* send_group,
+                                  SendType send_type,
+                                  std::vector<P2PMhandle*> const& mhandle_v,
+                                  std::vector<void*> const& local_addr_v,
+                                  std::vector<size_t> const& size_v,
+                                  std::vector<FifoItem> const& slot_item_v,
+                                  size_t num_iovs);
   std::shared_ptr<UnifiedTask> create_net_task(uint64_t conn_id, uint64_t mr_id,
                                                TaskType type, void* data,
                                                size_t size,

--- a/p2p/rdma/rdma_connection.cc
+++ b/p2p/rdma/rdma_connection.cc
@@ -333,14 +333,18 @@ bool SendConnection::canUseRawOneSidedBatch(SendType send_type) {
 
 bool SendConnection::postWriteOrReadBatch(SendType send_type,
                                           OneSidedBatchOp const* ops,
-                                          size_t num_ops, int64_t* wr_ids) {
+                                          size_t num_ops, int64_t* wr_ids,
+                                          RawBatchWait* waits,
+                                          size_t* num_waits) {
+  if (num_waits != nullptr) *num_waits = 0;
   if (unlikely(send_type != SendType::Write && send_type != SendType::Read)) {
     UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - invalid "
                        "send_type";
     return false;
   }
   if (unlikely(!canUseRawOneSidedBatch(send_type))) return false;
-  if (unlikely((num_ops > 0 && ops == nullptr) || wr_ids == nullptr)) {
+  if (unlikely((num_ops > 0 && ops == nullptr) || wr_ids == nullptr ||
+               (waits != nullptr && num_waits == nullptr))) {
     UCCL_LOG(ERROR) << "SendConnection::postWriteOrReadBatch - null input";
     return false;
   }
@@ -445,6 +449,7 @@ bool SendConnection::postWriteOrReadBatch(SendType send_type,
     channel_batches[channel_idx].push_back(raw);
   }
 
+  bool const wait_all_wr_ids = is_efa_transport();
   for (size_t i = 0; i < num_channels; ++i) {
     if (channel_batches[i].empty()) continue;
     if (unlikely(channel_ptrs[i] == nullptr ||
@@ -455,6 +460,20 @@ bool SendConnection::postWriteOrReadBatch(SendType send_type,
                       << "; raw one-sided batch post failure is "
                          "unrecoverable after tracker wr_ids are allocated";
       return false;
+    }
+    if (waits != nullptr) {
+      if (wait_all_wr_ids) {
+        for (auto const& raw : channel_batches[i]) {
+          size_t const wait_idx = (*num_waits)++;
+          waits[wait_idx].wr_id = static_cast<int64_t>(raw.wr_id);
+          waits[wait_idx].iov_count = 1;
+        }
+      } else {
+        size_t const wait_idx = (*num_waits)++;
+        waits[wait_idx].wr_id =
+            static_cast<int64_t>(channel_batches[i].back().wr_id);
+        waits[wait_idx].iov_count = channel_batches[i].size();
+      }
     }
   }
   return true;

--- a/p2p/rdma/rdma_connection.h
+++ b/p2p/rdma/rdma_connection.h
@@ -67,6 +67,11 @@ class SendConnection : public RDMAConnection {
     FifoItem const* slot_item = nullptr;
   };
 
+  struct RawBatchWait {
+    int64_t wr_id = -1;
+    size_t iov_count = 0;
+  };
+
   SendConnection(int numa_node, bool auto_start_polling = true,
                  double link_bandwidth_bps = 400.0 * 1e9 / 8.0);
 
@@ -115,7 +120,9 @@ class SendConnection : public RDMAConnection {
   bool canUseRawOneSidedBatch(SendType send_type);
 
   bool postWriteOrReadBatch(SendType send_type, OneSidedBatchOp const* ops,
-                            size_t num_ops, int64_t* wr_ids);
+                            size_t num_ops, int64_t* wr_ids,
+                            RawBatchWait* waits = nullptr,
+                            size_t* num_waits = nullptr);
 
   void setRemoteDecompressBuf(RemoteMemInfo const& m);
 


### PR DESCRIPTION
## Description

1. Increased `kMaxInflightOps` from 128 to 256.

2. Pipelined `num_iovs > 256` transfers on the raw one-sided RDMA batch fast path instead of falling back.

E.g., `--num-iovs=288`, 4 QP channels, each channel has 64 chained WRs, the last 32 messages will be sent when any channel frees its chained WRs.

QP0  [ 64 WRs ]  ─────────────── still running 
QP1  [ 64 WRs ]  ─────────────── still running                             
QP2  [ 64 WRs ]  ── done, frees 64 credits ──► [ post remaining 32 WRs ]        
QP3  [ 64 WRs ]  ─────────────── still running            

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [x] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
