### PR TITLE
[P2P] Fix segfault when loaded as NIXL plugin by adding -Bsymbolic-fu…

### DIFF
--- a/p2p/Makefile
+++ b/p2p/Makefile
@@ -87,7 +87,8 @@ IBV_WRAP_FLAGS := -Wl,--wrap=ibv_get_device_list \
                   -Wl,--wrap=ibv_create_qp \
                   -Wl,--wrap=ibv_qp_to_qp_ex
 LDFLAGS = -L$(CUDA_LIB) -lcudart -lcuda -Wl,-rpath,$(CUDA_LIB) \
-          -lz -lelf -lpthread -ldl $(IBV_WRAP_FLAGS) $(DIETGPU_LIBS)
+          -lz -lelf -lpthread -ldl -Wl,-Bsymbolic-functions \
+          $(IBV_WRAP_FLAGS) $(DIETGPU_LIBS)
 
 # Target and source files - always compile ALL sources
 P2P_PYTHON_EXT := p2p$(PYEXT)

--- a/p2p/Makefile.rocm
+++ b/p2p/Makefile.rocm
@@ -84,7 +84,8 @@ IBV_WRAP_FLAGS := -Wl,--wrap=ibv_get_device_list \
                   -Wl,--wrap=ibv_qp_to_qp_ex
 LDFLAGS = -L$(HIP_LIB) -lamdhip64 -Wl,-rpath,$(HIP_LIB) \
           -L${CONDA_LIB_HOME} \
-          -lz -lelf -lpthread -ldl $(IBV_WRAP_FLAGS) $(DIETGPU_LIBS)
+          -lz -lelf -lpthread -ldl -Wl,-Bsymbolic-functions \
+          $(IBV_WRAP_FLAGS) $(DIETGPU_LIBS)
 
 # Target and source files - always compile ALL sources
 P2P_PYTHON_EXT := p2p$(PYEXT)


### PR DESCRIPTION
…nctions

Crash:
  Signal 11 (SIGSEGV) in RdmaDeviceManager::initialize()
  #0 __strlen_evex () — ibv_get_device_name() called on corrupted device ptr
  #1 __ibv_open_device_1_0 () — 1.0 compat layer receives 1.1 device pointer
  #2 __ibv_free_device_list_1_0 () — frees wrong struct layout

Root cause:
  PR #879 ("Multi-transport Build and Dispatcher") switched from linking
  -libverbs to using dlsym wrappers (ibverbs_dl.cc). This made ibv_*
  symbols local definitions resolved via PLT at runtime. When NIXL loads
  libuccl_p2p.so as a plugin, NIXL's own libibverbs (with 1.0 compat
  symbols like __ibv_open_device_1_0) is already in the global symbol
  table. The dynamic linker resolves libuccl_p2p.so's PLT entries to
  NIXL's 1.0 compat wrappers instead of libuccl_p2p.so's own IBV_DL_FUNC
  definitions. The 1.0 compat layer wraps ibv_device* in shim structs
  incompatible with 1.1, causing the segfault.

Fix:
  Add -Wl,-Bsymbolic-functions to LDFLAGS in both Makefile (CUDA) and
  Makefile.rocm (ROCm). This binds internal function calls to the
  library's own definitions at link time, preventing external symbol
  interposition through PLT.

  Makefile.therock is unaffected — it links -libverbs directly (no dlsym
  wrappers), so PLT interposition cannot occur.

  The existing --wrap flags remain necessary for verbs.h compat macros
  that redirect at compile time (ibv_reg_mr, ibv_create_qp, etc.).
  -Bsymbolic-functions handles the runtime interposition case.

Reproducer: vLLM EP+PD with NIXL UCCL backend on Intel RDMA NICs.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
