### PR TITLE
[EP] Close residual zero-token assertion gaps in intranode + LL paths

### DIFF
--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -438,10 +438,8 @@ class Buffer:
             packed_recv_x_scales_storage,
             cumulative_local_expert_recv_stats,
         )
-        # When the runtime takes the zero-token early-return path it returns
-        # hook=None. SGLang's caller does `hook() if return_recv_hook` and
-        # crashes on None, so substitute a no-op so idle DP-attention ranks
-        # participate in the collective without raising.
+        # The zero-token early-return path returns hook=None; substitute a
+        # no-op so callers can unconditionally invoke hook().
         if return_recv_hook and hook is None:
             hook = lambda: None
         return (

--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -438,6 +438,12 @@ class Buffer:
             packed_recv_x_scales_storage,
             cumulative_local_expert_recv_stats,
         )
+        # When the runtime takes the zero-token early-return path it returns
+        # hook=None. SGLang's caller does `hook() if return_recv_hook` and
+        # crashes on None, so substitute a no-op so idle DP-attention ranks
+        # participate in the collective without raising.
+        if return_recv_hook and hook is None:
+            hook = lambda: None
         return (
             (packed_recv_x, packed_recv_x_scales) if use_fp8 else packed_recv_x,
             packed_recv_count,
@@ -583,6 +589,9 @@ class Buffer:
             layout_range,
             combined_x,
         )
+        # See low_latency_dispatch — same zero-token hook=None no-op fix.
+        if return_recv_hook and hook is None:
+            hook = lambda: None
         return (
             combined_x,
             EventOverlap(event, tensors_to_record if async_finish else None),

--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -674,10 +674,16 @@ class Buffer {
                     std::optional<EventHandle>& previous_event, bool async,
                     bool allocate_on_comm_stream,
                     std::uintptr_t compute_stream_ptr) {
-    EP_HOST_ASSERT(num_tokens > 0);
+    // Allow num_tokens == 0: DP-attention ranks may have no tokens to
+    // dispatch but must still participate in the collective notification.
+    // PyTorch zero-element tensors have data_ptr() == 0, so only require a
+    // real is_token_in_rank buffer when there are tokens to route.
+    EP_HOST_ASSERT(num_tokens >= 0);
     EP_HOST_ASSERT(num_experts > 0);
     EP_HOST_ASSERT(num_tokens_per_rank_ptr != 0);
-    EP_HOST_ASSERT(is_token_in_rank_ptr != 0);
+    if (num_tokens > 0) {
+      EP_HOST_ASSERT(is_token_in_rank_ptr != 0);
+    }
     EP_HOST_ASSERT(num_tokens_per_expert_ptr != 0);
     EP_HOST_ASSERT(rank_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(channel_prefix_matrix_ptr != 0);
@@ -762,11 +768,21 @@ class Buffer {
       std::uintptr_t recv_src_idx_ptr, std::uintptr_t send_head_ptr,
       std::optional<EventHandle>& previous_event, bool async,
       bool allocate_on_comm_stream, std::uintptr_t compute_stream_ptr) {
-    EP_HOST_ASSERT(x_ptr != 0 && is_token_in_rank_ptr != 0);
+    // Allow num_tokens == 0: DP-attention ranks may have no tokens to
+    // dispatch but must still participate in the collective cached_notify
+    // and dispatch so that remote ranks are not left spinning. Send-side
+    // pointers (x, is_token_in_rank, send_head) are sized by num_tokens —
+    // PyTorch zero-element tensors have data_ptr() == 0 — so gate them on
+    // num_tokens > 0. Recv-side allocations are bumped to max(.., 1) by
+    // the Python wrapper, so their pointers stay non-zero.
+    EP_HOST_ASSERT(num_tokens >= 0 && hidden > 0 && num_recv_tokens >= 0);
+    if (num_tokens > 0) {
+      EP_HOST_ASSERT(x_ptr != 0 && is_token_in_rank_ptr != 0);
+      EP_HOST_ASSERT(send_head_ptr != 0);
+    }
     EP_HOST_ASSERT(channel_prefix_matrix_ptr != 0);
     EP_HOST_ASSERT(recv_x_ptr != 0 && recv_channel_prefix_matrix_ptr != 0);
-    EP_HOST_ASSERT(recv_src_idx_ptr != 0 && send_head_ptr != 0);
-    EP_HOST_ASSERT(num_tokens > 0 && hidden > 0 && num_recv_tokens >= 0);
+    EP_HOST_ASSERT(recv_src_idx_ptr != 0);
     EP_HOST_ASSERT((hidden * x_element_size) % static_cast<int>(sizeof(int4)) ==
                    0);
 
@@ -840,7 +856,13 @@ class Buffer {
       bool allocate_on_comm_stream, std::uintptr_t compute_stream_ptr) {
     EP_HOST_ASSERT(x_ptr != 0 && src_idx_ptr != 0 &&
                    rank_prefix_matrix_ptr != 0);
-    EP_HOST_ASSERT(channel_prefix_matrix_ptr != 0 && send_head_ptr != 0);
+    EP_HOST_ASSERT(channel_prefix_matrix_ptr != 0);
+    // send_head is sized by num_recv_tokens (the original dispatch send
+    // count). DP-attention ranks may have num_recv_tokens == 0, which
+    // makes send_head a zero-element tensor with data_ptr() == 0.
+    if (num_recv_tokens > 0) {
+      EP_HOST_ASSERT(send_head_ptr != 0);
+    }
     EP_HOST_ASSERT(recv_x_ptr != 0);
     EP_HOST_ASSERT((hidden * x_element_size) % static_cast<int>(sizeof(int4)) ==
                    0);


### PR DESCRIPTION
## Summary

After #898 (intranode zero-token wrapper + `intranode_dispatch` `num_recv_tokens` assert) and #940 (internode + LL early-returns), three crash sites and one hook-handling gap remain for DP-attention ranks with no tokens to route. This PR closes them with minimal additions.

### What still crashes today

| Path | Site | Why upstream doesn't cover it |
|---|---|---|
| `Buffer.dispatch` non-cached → `intranode_prepare` | `num_tokens > 0`, `is_token_in_rank_ptr != 0` | #898 didn't touch `intranode_prepare` |
| `Buffer.dispatch` → `intranode_dispatch` | `x_ptr`, `is_token_in_rank_ptr`, `send_head_ptr` != 0 and `num_tokens > 0` | #898 only relaxed the `num_recv_tokens` assert; send-side stays strict |
| `Buffer.combine` → `intranode_combine` | `send_head_ptr != 0` | #898 dummies `x`/`src_idx`/`topk_weights` to ≥1 row in Python, but not `send_head` (sized by `num_recv_tokens`) |
| `Buffer.low_latency_{dispatch,combine}` | `hook is None` | #940 returns `hook=None` from the runtime's zero-token early-return; SGLang's caller does `hook() if return_recv_hook` and crashes on `None` |

### Changes

**`ep/src/uccl_ep.cc`** — gate three assertion blocks on the relevant size dimension rather than relax them unconditionally, so accidental nulls still trip in the non-zero-token path:

- `intranode_prepare`: `num_tokens > 0` → `>= 0`; `is_token_in_rank_ptr != 0` only if `num_tokens > 0`.
- `intranode_dispatch`: `num_tokens > 0` → `>= 0`; `x_ptr`/`is_token_in_rank_ptr`/`send_head_ptr` only if `num_tokens > 0`.
- `intranode_combine`: `send_head_ptr != 0` only if `num_recv_tokens > 0`. Other pointers stay strict — they're already kept non-zero by #898's Python-side dummies.

**`ep/bench/buffer.py`** — substitute a no-op `hook` in `low_latency_dispatch` / `low_latency_combine` when the runtime returns `hook=None` and the caller asked for `return_recv_hook=True`.

```
ep/bench/buffer.py |  9 +++++++++
ep/src/uccl_ep.cc  | 34 ++++++++++++++++++++++++++++------
2 files changed, 37 insertions(+), 6 deletions(-)
```

### Why minimal asserts vs. wholesale relaxation

For the C++ side I gate on the size dimension that controls each pointer's allocation, mirroring how #940 handled the internode and LL paths. Pointers stay required when the size says they should be present, so a real `nullptr` bug still trips the assert in the common path.