### PR TITLE
[EP] Support distinct HT barrier local ranks

### DIFF
--- a/ep/bench/utils.py
+++ b/ep/bench/utils.py
@@ -573,15 +573,6 @@ def initialize_uccl(
         num_nodes,
         detected_is_intranode,
     ) = detect_group_topology(group)
-    if os.environ.get("UCCL_DEBUG_RANK_SPLIT") == "1":
-        print(
-            "[UCCL_RANK_SPLIT] "
-            f"rank={rank} local_rank={local_rank} "
-            f"barrier_local_rank={barrier_local_rank} "
-            f"node_idx={node_idx} num_nodes={num_nodes} "
-            f"is_intranode={detected_is_intranode}",
-            flush=True,
-        )
     if is_intranode is None:
         is_intranode = detected_is_intranode
     elif is_intranode and not detected_is_intranode:

--- a/ep/bench/utils.py
+++ b/ep/bench/utils.py
@@ -99,12 +99,13 @@ def _gather_peer_ips(group):
     return ips
 
 
-def detect_group_topology(group: dist.ProcessGroup) -> Tuple[int, int, int, bool]:
+def detect_group_topology(group: dist.ProcessGroup) -> Tuple[int, int, int, int, bool]:
     """
-    Infer local rank and node topology for a process group.
+    Infer CUDA-local rank, barrier-local rank, and node topology.
 
     Returns:
-        local_rank: rank index within the current node.
+        local_rank: CUDA-visible device index for the current process.
+        barrier_local_rank: rank slot within the current node.
         node_idx: compact node index within the given group.
         num_nodes: number of distinct nodes spanned by the group.
         is_intranode: whether all ranks in the group are on the same node.
@@ -114,16 +115,14 @@ def detect_group_topology(group: dist.ProcessGroup) -> Tuple[int, int, int, bool
     else:
         local_rank = torch.cuda.current_device()
 
-    node_token = (
-        os.environ.get("NODE_RANK")
-        or os.environ.get("GROUP_RANK")
-        or os.environ.get("SLURM_NODEID")
-        or socket.gethostname()
-    )
+    node_token = ep.get_oob_ip() or socket.gethostname()
 
     world = dist.get_world_size(group)
     node_tokens = [None] * world
     dist.all_gather_object(node_tokens, node_token, group=group)
+    rank = dist.get_rank(group)
+    local_ranks = [idx for idx, token in enumerate(node_tokens) if token == node_token]
+    barrier_local_rank = local_ranks.index(rank)
 
     token_to_idx = {}
     for token in node_tokens:
@@ -133,7 +132,7 @@ def detect_group_topology(group: dist.ProcessGroup) -> Tuple[int, int, int, bool
     node_idx = token_to_idx[node_token]
     num_nodes = len(token_to_idx)
     is_intranode = num_nodes == 1
-    return local_rank, node_idx, num_nodes, is_intranode
+    return local_rank, barrier_local_rank, node_idx, num_nodes, is_intranode
 
 
 def get_peer_ip(rank: int, num_ranks: int, group: dist.ProcessGroup):
@@ -567,9 +566,22 @@ def initialize_uccl(
     except Exception:
         pass
 
-    local_rank, node_idx, num_nodes, detected_is_intranode = detect_group_topology(
-        group
-    )
+    (
+        local_rank,
+        barrier_local_rank,
+        node_idx,
+        num_nodes,
+        detected_is_intranode,
+    ) = detect_group_topology(group)
+    if os.environ.get("UCCL_DEBUG_RANK_SPLIT") == "1":
+        print(
+            "[UCCL_RANK_SPLIT] "
+            f"rank={rank} local_rank={local_rank} "
+            f"barrier_local_rank={barrier_local_rank} "
+            f"node_idx={node_idx} num_nodes={num_nodes} "
+            f"is_intranode={detected_is_intranode}",
+            flush=True,
+        )
     if is_intranode is None:
         is_intranode = detected_is_intranode
     elif is_intranode and not detected_is_intranode:
@@ -593,6 +605,7 @@ def initialize_uccl(
             use_normal_mode=use_normal_mode,
             is_intranode=is_intranode,
             gpu_buffer_is_host_allocated=rdma_buffer_is_host_allocated,
+            barrier_local_rank=barrier_local_rank,
         )
         proxies.append(proxy)
 

--- a/ep/include/proxy.hpp
+++ b/ep/include/proxy.hpp
@@ -44,7 +44,10 @@ class Proxy {
     size_t total_size = 0;
     int rank = 0;
     int node_idx = -1;
+    // CUDA/NIC local device rank and HT local-barrier slot can differ when
+    // each process sees a single GPU, e.g. vLLM's Ray worker actors.
     int local_rank = -1;
+    int barrier_local_rank = -1;
     bool pin_thread = true;
     int num_experts = 0;
     int num_ranks = 0;

--- a/ep/include/uccl_proxy.hpp
+++ b/ep/include/uccl_proxy.hpp
@@ -16,7 +16,8 @@ class UcclProxy {
             int rank, int node_idx, int local_rank, int num_experts = 0,
             int num_ranks = 0, int num_nodes = 0, bool use_normal_mode = false,
             bool is_intranode = false,
-            bool gpu_buffer_is_host_allocated = false);
+            bool gpu_buffer_is_host_allocated = false,
+            int barrier_local_rank = -1);
   ~UcclProxy();
 
   void start_sender();

--- a/ep/src/proxy.cpp
+++ b/ep/src/proxy.cpp
@@ -458,8 +458,8 @@ void Proxy::init_common() {
     }
     ctx_.num_local_ranks = (int)local_ranks.size();
     ctx_.node_leader_rank = leader_rank;
-    ctx_.local_rank =
-        cfg_.barrier_local_rank >= 0 ? cfg_.barrier_local_rank : cfg_.local_rank;
+    ctx_.local_rank = cfg_.barrier_local_rank >= 0 ? cfg_.barrier_local_rank
+                                                   : cfg_.local_rank;
     ctx_.thread_idx = cfg_.thread_idx;
 
     if (ctx_.num_local_ranks > UCCL_MAX_LOCAL_RANKS) {

--- a/ep/src/proxy.cpp
+++ b/ep/src/proxy.cpp
@@ -458,12 +458,21 @@ void Proxy::init_common() {
     }
     ctx_.num_local_ranks = (int)local_ranks.size();
     ctx_.node_leader_rank = leader_rank;
-    ctx_.local_rank = cfg_.local_rank;
+    ctx_.local_rank =
+        cfg_.barrier_local_rank >= 0 ? cfg_.barrier_local_rank : cfg_.local_rank;
     ctx_.thread_idx = cfg_.thread_idx;
 
     if (ctx_.num_local_ranks > UCCL_MAX_LOCAL_RANKS) {
       fprintf(stderr, "num_local_ranks=%d exceeds UCCL_MAX_LOCAL_RANKS=%d\n",
               ctx_.num_local_ranks, (int)UCCL_MAX_LOCAL_RANKS);
+      std::abort();
+    }
+    if (ctx_.local_rank < 0 || ctx_.local_rank >= ctx_.num_local_ranks) {
+      fprintf(stderr,
+              "barrier_local_rank=%d invalid for num_local_ranks=%d "
+              "(rank=%d, local_rank=%d)\n",
+              ctx_.local_rank, ctx_.num_local_ranks, cfg_.rank,
+              cfg_.local_rank);
       std::abort();
     }
 #ifndef USE_SUBSET_BARRIER

--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -2363,13 +2363,14 @@ NB_MODULE(ep, m) {
   nb::class_<Stats>(m, "Stats");
   nb::class_<UcclProxy>(m, "Proxy")
       .def(nb::init<int, uintptr_t, size_t, int, int, int, int, int, int, bool,
-                    bool, bool>(),
+                    bool, bool, int>(),
            nb::arg("thread_idx"), nb::arg("gpu_buffer_addr"),
            nb::arg("total_size"), nb::arg("rank") = 0, nb::arg("node_idx") = -1,
            nb::arg("local_rank") = 0, nb::arg("num_experts") = -1,
            nb::arg("num_ranks") = -1, nb::arg("num_nodes") = 0,
            nb::arg("use_normal_mode") = false, nb::arg("is_intranode") = false,
-           nb::arg("gpu_buffer_is_host_allocated") = false)
+           nb::arg("gpu_buffer_is_host_allocated") = false,
+           nb::arg("barrier_local_rank") = -1)
       .def("start_sender", &UcclProxy::start_sender)
       .def("start_remote", &UcclProxy::start_remote)
       .def("start_local", &UcclProxy::start_local)

--- a/ep/src/uccl_proxy.cpp
+++ b/ep/src/uccl_proxy.cpp
@@ -14,7 +14,7 @@ UcclProxy::UcclProxy(int thread_idx, uintptr_t gpu_buffer_addr,
                      size_t total_size, int rank, int node_idx, int local_rank,
                      int num_experts, int num_ranks, int num_nodes,
                      bool use_normal_mode, bool is_intranode,
-                     bool gpu_buffer_is_host_allocated)
+                     bool gpu_buffer_is_host_allocated, int barrier_local_rank)
     : thread_{},
       mode_{Mode::None},
       running_{false},
@@ -46,6 +46,8 @@ UcclProxy::UcclProxy(int thread_idx, uintptr_t gpu_buffer_addr,
   cfg.rank = rank;
   cfg.node_idx = node_idx;
   cfg.local_rank = local_rank;
+  cfg.barrier_local_rank =
+      barrier_local_rank >= 0 ? barrier_local_rank : local_rank;
   cfg.num_experts = num_experts;
   cfg.num_ranks = num_ranks;
   cfg.num_nodes = num_nodes;


### PR DESCRIPTION
## Summary

This draft separates the CUDA/NIC-facing local rank from the node-local slot used by the high-throughput local barrier.

In launchers such as vLLM Ray data-parallel serving, each worker actor can see exactly one GPU. In that topology `torch.cuda.current_device()` is `0` for every actor on a node, while UCCL high-throughput still needs unique local barrier slots `0..N-1`. Reusing the CUDA-visible local rank for the HT barrier causes all local actors to write slot `0`, leaving the node leader waiting for the remaining slots.

The patch adds an optional `barrier_local_rank` to the Python-facing `uccl.ep.Proxy` constructor and threads it to `Proxy::Config`. The existing `local_rank` remains the CUDA/NIC/affinity rank; only the HT local-barrier context uses `barrier_local_rank` when provided.

## Validation

Validated on an Anyscale workspace with two 8x H100 nodes using SkyRL/vLLM 0.20.2 and DeepSeek-V3-0324 dummy weights.

- Built UCCL EP against Torch 2.11.0+cu128.
- Verified imports on both GPU workers.
- Low-latency control: `deepep_low_latency`, DP=16, local DP=8, TP=1 reached readiness and returned a dummy completion.
- High-throughput test: `deepep_high_throughput`, DP=16, local DP=8, TP=1 reached readiness and returned a dummy completion.
- Prior to this split, the same HT configuration failed with `RuntimeError: DeepEP error: timeout (dispatch CPU)`.

Example debug line from the Ray/vLLM topology:

```text
[UCCL_RANK_SPLIT] rank=11 local_rank=0 barrier_local_rank=3 node_idx=1 num_nodes=2 is_intranode=False
```

## Notes

This is intentionally opened as a draft. The API shape is small and backward-compatible, but I expect maintainers may want a different naming/API boundary for the barrier slot before this is ready to merge.