### PR TITLE
[EP] Remove legacy nvshmem/ibgda keywords from device comm layer

### DIFF
--- a/ep/bench/rb/test_cas_throughput.cu
+++ b/ep/bench/rb/test_cas_throughput.cu
@@ -2,7 +2,7 @@
  * CAS-based Ring Buffer Throughput Test
  * Goal: Test GPU-CPU communication throughput with CAS-based ring buffer
  * sharing Architecture: Multiple warps share ring buffers via CAS
- * (atomic_set_and_commit) Similar to production uccl_ibgda.cuh design
+ * (atomic_set_and_commit) Similar to production uccl_transfer_device.cuh design
  */
 
 #include "../include/common.hpp"

--- a/ep/include/ep_config.hpp
+++ b/ep/include/ep_config.hpp
@@ -74,11 +74,9 @@ struct Config {
         num_channels * num_nvl_ranks * (2 * num_rdma_ranks + 3) * sizeof(int);
     num_bytes += num_channels * num_nvl_ranks *
                  num_max_nvl_chunked_recv_tokens * hidden_bytes;
-#ifndef DISABLE_NVSHMEM
     num_bytes += num_channels * num_nvl_ranks *
                  num_max_nvl_chunked_recv_tokens *
                  uccl::internode::get_source_meta_bytes();
-#endif
     num_bytes += num_channels * num_nvl_ranks *
                  num_max_nvl_chunked_recv_tokens * kNumMaxTopK *
                  sizeof(int64_t);
@@ -92,7 +90,6 @@ struct Config {
   }
 
   size_t get_rdma_buffer_size_hint(int64_t hidden_bytes, int num_ranks) const {
-#ifndef DISABLE_NVSHMEM
     // Legacy mode
     if (num_ranks <= NUM_MAX_NVL_PEERS) return 0;
 
@@ -126,9 +123,6 @@ struct Config {
                  num_max_rdma_chunked_recv_tokens * sizeof(int4) * 2;
     num_bytes = ((num_bytes + 127) / 128) * 128;
     return num_bytes;
-#else
-    EP_HOST_ASSERT(false and "NVSHMEM is disable during compilation");
-#endif
   }
 };
 

--- a/ep/include/internode.cuh
+++ b/ep/include/internode.cuh
@@ -8,8 +8,6 @@
 namespace uccl {
 namespace internode {
 
-// extern nvshmem_team_t cpu_rdma_team;
-
 struct SourceMeta;
 
 int get_source_meta_bytes();

--- a/ep/include/uccl_transfer_device.cuh
+++ b/ep/include/uccl_transfer_device.cuh
@@ -136,9 +136,8 @@ __device__ __forceinline__ void put_nbi_warp(
 
       if constexpr (use_normal_mode) {
         if (atomic_offset >> 16) {
-          printf(
-              "[put_nbi_warp] atomic_offset too large: %llu\n",
-              (unsigned long long)atomic_offset);
+          printf("[put_nbi_warp] atomic_offset too large: %llu\n",
+                 (unsigned long long)atomic_offset);
           trap();
         }
         if (atomic_val >> 8) {
@@ -319,9 +318,10 @@ __device__ static __forceinline__ void wait_until_cmd_consumed(
   }
 }
 
-__device__ static __forceinline__ void quiet(
-    uint64_t const* d2h_channel_addrs, int num_d2h_channel_addrs,
-    int nvl_rank = -1, int label = -1) {
+__device__ static __forceinline__ void quiet(uint64_t const* d2h_channel_addrs,
+                                             int num_d2h_channel_addrs,
+                                             int nvl_rank = -1,
+                                             int label = -1) {
   EP_DEVICE_ASSERT(
       num_d2h_channel_addrs % kChannelPerProxy == 0 &&
       "num_d2h_channel_addrs must be multiple of kChannelPerProxy");

--- a/ep/include/uccl_transfer_device.cuh
+++ b/ep/include/uccl_transfer_device.cuh
@@ -24,7 +24,7 @@ namespace uccl {
 // to use. The total concurrent warps can be say 64 (= number of experts), while
 // the number of ring buffers is small (say 6).
 template <bool use_normal_mode = false>
-__device__ __forceinline__ void nvshmemi_ibgda_put_nbi_warp(
+__device__ __forceinline__ void put_nbi_warp(
     uint64_t req_rptr, uint64_t req_lptr, size_t bytes, int dst_rank,
     int expert_idx, int lane_id, int message_idx,
     uint64_t const* d2h_channel_addrs, int num_d2h_channel_addrs,
@@ -129,7 +129,7 @@ __device__ __forceinline__ void nvshmemi_ibgda_put_nbi_warp(
       cmd.bytes = bytes_val;
       cmd.dst_rank = dst_rank;
       if (bytes_val >> 24) {
-        printf("[nvshmemi_ibgda_put_nbi_warp] bytes too large: %llu\n",
+        printf("[put_nbi_warp] bytes too large: %llu\n",
                (unsigned long long)bytes_val);
         trap();
       }
@@ -137,12 +137,12 @@ __device__ __forceinline__ void nvshmemi_ibgda_put_nbi_warp(
       if constexpr (use_normal_mode) {
         if (atomic_offset >> 16) {
           printf(
-              "[nvshmemi_ibgda_put_nbi_warp] atomic_offset too large: %llu\n",
+              "[put_nbi_warp] atomic_offset too large: %llu\n",
               (unsigned long long)atomic_offset);
           trap();
         }
         if (atomic_val >> 8) {
-          printf("[nvshmemi_ibgda_put_nbi_warp] atomic_val too large: %llu\n",
+          printf("[put_nbi_warp] atomic_val too large: %llu\n",
                  (unsigned long long)atomic_val);
           trap();
         }
@@ -176,7 +176,7 @@ __device__ __forceinline__ void nvshmemi_ibgda_put_nbi_warp(
 // TODO(MaoZiming): Fix. This should be a non-fetch add operation. This could be
 // implemented with CPU proxy.
 template <bool use_normal_mode = false>
-__device__ __forceinline__ void nvshmemi_ibgda_amo_nonfetch_add(
+__device__ __forceinline__ void atomic_nonfetch_add(
     uint64_t rptr, uint64_t atomic_base_addr, int const& value, int dst_rank,
     int warp_id, bool is_local_copy = false,
     uint64_t const* d2h_channel_addrs = nullptr, int num_d2h_channel_addrs = 0,
@@ -242,7 +242,7 @@ __device__ __forceinline__ void nvshmemi_ibgda_amo_nonfetch_add(
         auto now = clock64();
         if (now - last_print > kPrintCycleInterval) {
           printf(
-              "[nvshmemi_ibgda_amo_nonfetch_add] %p waiting d2h_channel_idx: "
+              "[atomic_nonfetch_add] %p waiting d2h_channel_idx: "
               "%d, "
               "cur_head: "
               "%llu, cur_tail: %llu, inflight: %llu\n",
@@ -319,7 +319,7 @@ __device__ static __forceinline__ void wait_until_cmd_consumed(
   }
 }
 
-__device__ static __forceinline__ void nvshmemi_ibgda_quiet(
+__device__ static __forceinline__ void quiet(
     uint64_t const* d2h_channel_addrs, int num_d2h_channel_addrs,
     int nvl_rank = -1, int label = -1) {
   EP_DEVICE_ASSERT(
@@ -371,7 +371,7 @@ __device__ static __forceinline__ void nvshmemi_ibgda_quiet(
   }
 }
 
-__forceinline__ __device__ void nvshmem_sync_with_same_gpu_idx(
+__forceinline__ __device__ void sync_with_same_gpu_idx(
     uint64_t const* d2h_channel_addrs, int num_d2h_channel_addrs,
     int nvl_rank = -1, int label = -1) {
   EP_DEVICE_ASSERT(

--- a/ep/src/internode.cu
+++ b/ep/src/internode.cu
@@ -6,7 +6,6 @@
 #include "uccl_transfer_device.cuh"
 #include <functional>
 #include <optional>
-// #include "ibgda_device.cuh"
 #include "internode.cuh"
 
 namespace uccl {

--- a/ep/src/internode.cu
+++ b/ep/src/internode.cu
@@ -3,7 +3,7 @@
 #include "ep_launch.cuh"
 #include "ep_utils.cuh"
 #include "exception.cuh"
-#include "uccl_ibgda.cuh"
+#include "uccl_transfer_device.cuh"
 #include <functional>
 #include <optional>
 // #include "ibgda_device.cuh"
@@ -135,13 +135,13 @@ __global__ void notify_dispatch(
     // waiting for all previous inflight wrs to complete,
     // in case of rewriting cleared rdma_buffer
     if (thread_id == WARP_SIZE) {
-      uccl::nvshmemi_ibgda_quiet(d2h_channel_addrs, num_d2h_channel_addrs,
+      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs,
                                  nvl_rank);
     }
     __syncthreads();
 
     if (thread_id == WARP_SIZE) {
-      uccl::nvshmem_sync_with_same_gpu_idx(d2h_channel_addrs,
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
                                            num_d2h_channel_addrs, nvl_rank);
     }
     barrier_block<NUM_MAX_NVL_PEERS, true>(barrier_signal_ptrs, nvl_rank);
@@ -203,7 +203,7 @@ __global__ void notify_dispatch(
             rdma_recv_num_tokens_mixed.recv_buffer(rdma_rank));
         uint64_t src_ptr = reinterpret_cast<uint64_t>(
             rdma_recv_num_tokens_mixed.send_buffer(i));
-        uccl::nvshmemi_ibgda_put_nbi_warp</*use_normal_mode=*/true>(
+        uccl::put_nbi_warp</*use_normal_mode=*/true>(
             dst_ptr - reinterpret_cast<uint64_t>(original_rdma_buffer_ptr),
             src_ptr - reinterpret_cast<uint64_t>(original_rdma_buffer_ptr),
             (NUM_MAX_NVL_PEERS + num_rdma_experts + 1) * sizeof(int),
@@ -222,14 +222,14 @@ __global__ void notify_dispatch(
 
     // Wait previous operations to be finished
     if (thread_id == WARP_SIZE) {
-      uccl::nvshmemi_ibgda_quiet(d2h_channel_addrs, num_d2h_channel_addrs,
+      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs,
                                  nvl_rank);
     }
     __syncthreads();
 
     // Barrier
     if (thread_id == 0) {
-      uccl::nvshmem_sync_with_same_gpu_idx(d2h_channel_addrs,
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
                                            num_d2h_channel_addrs, nvl_rank);
     }
     __syncthreads();
@@ -341,7 +341,7 @@ __global__ void notify_dispatch(
 
     // Finally barrier
     if (thread_id == WARP_SIZE)
-      uccl::nvshmem_sync_with_same_gpu_idx(d2h_channel_addrs,
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
                                            num_d2h_channel_addrs, nvl_rank);
     barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank);
   } else {
@@ -733,7 +733,7 @@ __global__ void __launch_bounds__(
         // __threadfence_system();
         // NOTE(MaoZiming): this tells the remote rank how many tokens each
         // local nvl_rank and expert are expected to receive.
-        uccl::nvshmemi_ibgda_put_nbi_warp</*use_normal_mode=*/true>(
+        uccl::put_nbi_warp</*use_normal_mode=*/true>(
             reinterpret_cast<uint64_t>(
                 rdma_channel_meta.recv_buffer(rdma_rank)) -
                 reinterpret_cast<uint64_t>(original_rdma_buffer_ptr),
@@ -1092,7 +1092,7 @@ __global__ void __launch_bounds__(
           auto const src_ptr = reinterpret_cast<uint64_t>(
               rdma_channel_data.send_buffer(dst_rdma_rank) +
               dst_slot_idx * num_bytes_per_token);
-          uccl::nvshmemi_ibgda_put_nbi_warp</*use_normal_mode=*/true>(
+          uccl::put_nbi_warp</*use_normal_mode=*/true>(
               dst_ptr - reinterpret_cast<uint64_t>(original_rdma_buffer_ptr),
               src_ptr - reinterpret_cast<uint64_t>(original_rdma_buffer_ptr),
               num_bytes_per_msg,
@@ -1121,7 +1121,7 @@ __global__ void __launch_bounds__(
         if (lane_id == dst_rdma_rank) {
           last_issued_tail += num_tokens_to_issue;
           num_tokens_to_send -= num_tokens_to_issue;
-          uccl::nvshmemi_ibgda_amo_nonfetch_add</*use_normal_mode=*/true>(
+          uccl::atomic_nonfetch_add</*use_normal_mode=*/true>(
               reinterpret_cast<uint64_t>(rdma_channel_tail.buffer(rdma_rank)),
               reinterpret_cast<uint64_t>(original_atomic_buffer_ptr),
               num_tokens_to_issue,
@@ -1432,7 +1432,7 @@ __global__ void __launch_bounds__(
            clock64() - coordinator_stall_start > NUM_TIMEOUT_CYCLES / 100000);
       if (min_head != std::numeric_limits<int>::max() && should_advance &&
           lane_id < kNumRDMARanks) {
-        uccl::nvshmemi_ibgda_amo_nonfetch_add</*use_normal_mode=*/true>(
+        uccl::atomic_nonfetch_add</*use_normal_mode=*/true>(
             reinterpret_cast<uint64_t>(rdma_channel_head.buffer(rdma_rank)),
             reinterpret_cast<uint64_t>(original_atomic_buffer_ptr),
             min_head - last_head,
@@ -1745,13 +1745,13 @@ __global__ void cached_notify(
   // Using two SMs, which clean the RDMA/NVL buffer respectively
   if (sm_id == 0) {
     if (thread_id == WARP_SIZE)
-      uccl::nvshmemi_ibgda_quiet(d2h_channel_addrs, num_d2h_channel_addrs,
+      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs,
                                  nvl_rank, 3);
     __syncthreads();
 
     // Barrier for RDMA
     if (thread_id == WARP_SIZE)
-      uccl::nvshmem_sync_with_same_gpu_idx(d2h_channel_addrs,
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
                                            num_d2h_channel_addrs, nvl_rank);
 
     // Barrier for NVL
@@ -1789,7 +1789,7 @@ __global__ void cached_notify(
 
     // Barrier again
     if (thread_id == WARP_SIZE)
-      uccl::nvshmem_sync_with_same_gpu_idx(d2h_channel_addrs,
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
                                            num_d2h_channel_addrs, nvl_rank);
 
     barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank);
@@ -2787,7 +2787,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * WARP_SIZE, 1)
             auto const src_ptr = reinterpret_cast<uint64_t>(
                 rdma_channel_data.send_buffer(dst_rdma_rank) +
                 rdma_slot_idx * num_bytes_per_token);
-            uccl::nvshmemi_ibgda_put_nbi_warp</*use_normal_mode=*/true>(
+            uccl::put_nbi_warp</*use_normal_mode=*/true>(
                 dst_ptr - reinterpret_cast<uint64_t>(original_rdma_buffer_ptr),
                 src_ptr - reinterpret_cast<uint64_t>(original_rdma_buffer_ptr),
                 num_bytes_per_msg,
@@ -2811,7 +2811,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * WARP_SIZE, 1)
           // Write new RDMA tail
           __syncwarp();
           if (lane_id == 0) {
-            uccl::nvshmemi_ibgda_amo_nonfetch_add</*use_normal_mode=*/true>(
+            uccl::atomic_nonfetch_add</*use_normal_mode=*/true>(
                 reinterpret_cast<uint64_t>(rdma_channel_tail.buffer(rdma_rank)),
                 reinterpret_cast<uint64_t>(original_atomic_buffer_ptr),
                 num_chunked_tokens,
@@ -2853,7 +2853,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * WARP_SIZE, 1)
         if (min_head != std::numeric_limits<int>::max() and
             min_head >= last_rdma_head + num_max_rdma_chunked_send_tokens and
             lane_id < kNumRDMARanks) {
-          uccl::nvshmemi_ibgda_amo_nonfetch_add</*use_normal_mode=*/true>(
+          uccl::atomic_nonfetch_add</*use_normal_mode=*/true>(
               reinterpret_cast<uint64_t>(rdma_channel_head.buffer(rdma_rank)),
               reinterpret_cast<uint64_t>(original_atomic_buffer_ptr),
               min_head - last_rdma_head,
@@ -2982,7 +2982,7 @@ __global__ void __launch_bounds__((kNumForwarders + 1) * WARP_SIZE, 1)
           if (min_head != std::numeric_limits<int>::max() and
               min_head >= last_rdma_head + num_max_rdma_chunked_send_tokens and
               lane_id < kNumRDMARanks) {
-            uccl::nvshmemi_ibgda_amo_nonfetch_add</*use_normal_mode=*/true>(
+            uccl::atomic_nonfetch_add</*use_normal_mode=*/true>(
                 reinterpret_cast<uint64_t>(rdma_channel_head.buffer(rdma_rank)),
                 reinterpret_cast<uint64_t>(original_atomic_buffer_ptr),
                 min_head - last_rdma_head,

--- a/ep/src/internode.cu
+++ b/ep/src/internode.cu
@@ -3,10 +3,10 @@
 #include "ep_launch.cuh"
 #include "ep_utils.cuh"
 #include "exception.cuh"
+#include "internode.cuh"
 #include "uccl_transfer_device.cuh"
 #include <functional>
 #include <optional>
-#include "internode.cuh"
 
 namespace uccl {
 
@@ -134,14 +134,13 @@ __global__ void notify_dispatch(
     // waiting for all previous inflight wrs to complete,
     // in case of rewriting cleared rdma_buffer
     if (thread_id == WARP_SIZE) {
-      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs,
-                                 nvl_rank);
+      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs, nvl_rank);
     }
     __syncthreads();
 
     if (thread_id == WARP_SIZE) {
-      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
-                                           num_d2h_channel_addrs, nvl_rank);
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs, num_d2h_channel_addrs,
+                                   nvl_rank);
     }
     barrier_block<NUM_MAX_NVL_PEERS, true>(barrier_signal_ptrs, nvl_rank);
 
@@ -221,15 +220,14 @@ __global__ void notify_dispatch(
 
     // Wait previous operations to be finished
     if (thread_id == WARP_SIZE) {
-      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs,
-                                 nvl_rank);
+      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs, nvl_rank);
     }
     __syncthreads();
 
     // Barrier
     if (thread_id == 0) {
-      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
-                                           num_d2h_channel_addrs, nvl_rank);
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs, num_d2h_channel_addrs,
+                                   nvl_rank);
     }
     __syncthreads();
 
@@ -340,8 +338,8 @@ __global__ void notify_dispatch(
 
     // Finally barrier
     if (thread_id == WARP_SIZE)
-      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
-                                           num_d2h_channel_addrs, nvl_rank);
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs, num_d2h_channel_addrs,
+                                   nvl_rank);
     barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank);
   } else {
     // Calculate meta data
@@ -1744,14 +1742,13 @@ __global__ void cached_notify(
   // Using two SMs, which clean the RDMA/NVL buffer respectively
   if (sm_id == 0) {
     if (thread_id == WARP_SIZE)
-      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs,
-                                 nvl_rank, 3);
+      uccl::quiet(d2h_channel_addrs, num_d2h_channel_addrs, nvl_rank, 3);
     __syncthreads();
 
     // Barrier for RDMA
     if (thread_id == WARP_SIZE)
-      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
-                                           num_d2h_channel_addrs, nvl_rank);
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs, num_d2h_channel_addrs,
+                                   nvl_rank);
 
     // Barrier for NVL
     barrier_block<NUM_MAX_NVL_PEERS, true>(barrier_signal_ptrs, nvl_rank);
@@ -1788,8 +1785,8 @@ __global__ void cached_notify(
 
     // Barrier again
     if (thread_id == WARP_SIZE)
-      uccl::sync_with_same_gpu_idx(d2h_channel_addrs,
-                                           num_d2h_channel_addrs, nvl_rank);
+      uccl::sync_with_same_gpu_idx(d2h_channel_addrs, num_d2h_channel_addrs,
+                                   nvl_rank);
 
     barrier_block<NUM_MAX_NVL_PEERS>(barrier_signal_ptrs, nvl_rank);
   } else if (sm_id == 1) {

--- a/ep/src/internode_ll.cu
+++ b/ep/src/internode_ll.cu
@@ -236,7 +236,7 @@ __global__ __launch_bounds__(1024, 1) void dispatch(
       }
       sync_barrier_1(num_threads);
 
-      // Issue IBGDA sends
+      // Issue RDMA sends
       if (dst_expert_idx >= 0) {
         int slot_idx =
             lane_id == 0
@@ -302,7 +302,7 @@ __global__ __launch_bounds__(1024, 1) void dispatch(
       }
     }
   } else if (warp_id == num_warps - 1) {
-    // NOTE(MaoZiming): These checks are ibgda specific.
+    // NOTE(MaoZiming): These checks are RDMA specific.
     EP_DEVICE_ASSERT(num_sms > 1);
     if (sm_id == 0) {
       // The first SM is also responsible for cleaning the next buffer
@@ -356,14 +356,14 @@ __global__ __launch_bounds__(1024, 1) void dispatch(
   cg::this_grid().sync();
 #endif
 
-  // Batch RDMA send phase - send entire expert buffer in ONE IBGDA call
+  // Batch RDMA send phase - send entire expert buffer in ONE RDMA call
   // Each warp group handles one expert (only first sub_warp does the send)
   if (responsible_expert_idx < num_experts && sub_warp_id == 0) {
     auto const dst_rank = responsible_expert_idx / num_local_experts;
     auto const dst_expert_local_idx =
         responsible_expert_idx % num_local_experts;
 
-    // Check if this destination is inter-node (needs IBGDA batch send)
+    // Check if this destination is inter-node (needs RDMA batch send)
     // IPC destinations were already sent in the token loop
     auto const test_dst_ptr = reinterpret_cast<uint64_t>(rdma_recv_x);
     auto const dst_p2p_ptr =
@@ -442,7 +442,7 @@ __global__ __launch_bounds__(1024, 1) void dispatch(
                                     max_nvl_peers, 0)
             : 0;
     if (dst_p2p_ptr == 0) {
-      // Inter-node or no IPC: use IBGDA atomic
+      // Inter-node or no IPC: use RDMA atomic
       uccl::atomic_nonfetch_add(
           dst_ptr_internode, reinterpret_cast<uint64_t>(atomic_buffer_ptr),
           -num_tokens_sent - 1, dst_rank,
@@ -801,7 +801,7 @@ __global__ __launch_bounds__(1024, 1) void combine(
                                                       num_experts);
   }
 
-  // Issue IBGDA sends
+  // Issue RDMA sends
   if (responsible_expert_idx < num_experts) {
     auto const dst_rank = responsible_expert_idx / num_local_experts;
     auto const local_expert_idx = responsible_expert_idx % num_local_experts;
@@ -866,7 +866,7 @@ __global__ __launch_bounds__(1024, 1) void combine(
     };
 #endif
 
-    // Issue IBGDA send
+    // Issue RDMA send
     for (int token_idx = offset + sub_warp_id;
          token_idx < offset + num_tokens_to_send;
          token_idx += num_warps_per_group) {
@@ -1074,8 +1074,9 @@ __global__ __launch_bounds__(1024, 1) void combine(
         st_release_sys_global<kUseAggressiveAtomic>(
             reinterpret_cast<int*>(dst_p2p_ptr), 1);
       } else {
-        // Inter-node or no IPC: use IBGDA atomic
-        // NOTE(MaoZiming): Without ibgda, we can only use atomic add
+        // Inter-node or no IPC: use RDMA atomic
+        // NOTE(MaoZiming): Without GPU-initiated RDMA, we can only use atomic
+        // add
         // Pass offset to CPU proxy for atomic operation (similar to dispatch
         // phase)
         uccl::atomic_nonfetch_add(

--- a/ep/src/internode_ll.cu
+++ b/ep/src/internode_ll.cu
@@ -5,7 +5,7 @@
 #include "ep_util.hpp"
 #include "ep_utils.cuh"
 #include "internode_ll.cuh"
-#include "uccl_ibgda.cuh"
+#include "uccl_transfer_device.cuh"
 #include <iostream>
 #include <vector>
 #include <cooperative_groups.h>
@@ -278,7 +278,7 @@ __global__ __launch_bounds__(1024, 1) void dispatch(
 #else
           // Legacy path: directly issue one RDMA send per token.
           __threadfence_system();
-          uccl::nvshmemi_ibgda_put_nbi_warp(
+          uccl::put_nbi_warp(
               dst_ptr - reinterpret_cast<uint64_t>(rdma_buffer_ptr),
               src_ptr - reinterpret_cast<uint64_t>(rdma_buffer_ptr),
               num_bytes_per_msg, dst_rank,
@@ -397,7 +397,7 @@ __global__ __launch_bounds__(1024, 1) void dispatch(
 
         __threadfence_system();
 
-        uccl::nvshmemi_ibgda_put_nbi_warp(
+        uccl::put_nbi_warp(
             dst_ptr - reinterpret_cast<uint64_t>(rdma_buffer_ptr),
             src_ptr - reinterpret_cast<uint64_t>(rdma_buffer_ptr), total_bytes,
             dst_rank,
@@ -443,7 +443,7 @@ __global__ __launch_bounds__(1024, 1) void dispatch(
             : 0;
     if (dst_p2p_ptr == 0) {
       // Inter-node or no IPC: use IBGDA atomic
-      uccl::nvshmemi_ibgda_amo_nonfetch_add(
+      uccl::atomic_nonfetch_add(
           dst_ptr_internode, reinterpret_cast<uint64_t>(atomic_buffer_ptr),
           -num_tokens_sent - 1, dst_rank,
           /*warp_id=*/dst_expert_local_idx,  // NOTE(Yang): for selecting rb.
@@ -1033,7 +1033,7 @@ __global__ __launch_bounds__(1024, 1) void combine(
       // buffer
       if (dst_p2p_ptr == 0) {
         __threadfence_system();
-        nvshmemi_ibgda_put_nbi_warp(
+        put_nbi_warp(
             dst_ptr - reinterpret_cast<uint64_t>(rdma_buffer_ptr),
             buf_ptr - reinterpret_cast<uint64_t>(rdma_buffer_ptr),
             hidden * sizeof(nv_bfloat16), dst_rank,
@@ -1078,7 +1078,7 @@ __global__ __launch_bounds__(1024, 1) void combine(
         // NOTE(MaoZiming): Without ibgda, we can only use atomic add
         // Pass offset to CPU proxy for atomic operation (similar to dispatch
         // phase)
-        uccl::nvshmemi_ibgda_amo_nonfetch_add(
+        uccl::atomic_nonfetch_add(
             dst_ptr_internode, reinterpret_cast<uint64_t>(atomic_buffer_ptr),
             num_tokens_to_send /* Will be changed to 1 in the proxy */,
             dst_rank,

--- a/ep/src/uccl_ep.cc
+++ b/ep/src/uccl_ep.cc
@@ -1622,8 +1622,7 @@ class Buffer {
       CUDA_CHECK(cudaDeviceSynchronize());
     }
 
-    // Sync NVSHMEM handles and allocate memory
-    // NOTE(MaoZiming): drop nvshmem. we directly allocate rdma_buffer_ptr.
+    // Reset the local RDMA buffer and map peer RDMA IPC handles.
     if (num_rdma_bytes > 0) {
       // TODO(MaoZiming): this needs to be allocated by proxy.
       if (!rdma_buffer_ptr) {


### PR DESCRIPTION
Issue #787

### Part 1 — `uccl_ibgda.cuh`

The header defined 4 device functions that carried NVSHMEM/IBGDA names but contain pure UCCL proxy + ring-buffer code (no NVSHMEM/IBGDA dependency).

1. Renamed the header `uccl_ibgda.cuh` → `uccl_transfer_device.cuh`.
2. Dropped the misleading library prefix from the 4 functions, keeping the operation semantics (and updating all call sites / `#include`s / `printf` labels):

| old name                          | new name                 | CmdType            |
| --------------------------------- | ------------------------ | ------------------ |
| `nvshmemi_ibgda_put_nbi_warp`     | `put_nbi_warp`           | `CmdType::WRITE`   |
| `nvshmemi_ibgda_amo_nonfetch_add` | `atomic_nonfetch_add`    | `CmdType::ATOMIC`  |
| `nvshmemi_ibgda_quiet`            | `quiet`                  | `CmdType::QUIET`   |
| `nvshmem_sync_with_same_gpu_idx`  | `sync_with_same_gpu_idx` | `CmdType::BARRIER` |
### Part 2 — `DISABLE_NVSHMEM` in `ep_config.hpp`

`DISABLE_NVSHMEM` is a build flag inherited from upstream DeepEP, where it gates the no-NVSHMEM build path (DeepEP's internode kernels require NVSHMEM). **UCCL-EP never defines it** (`ep/setup.py` passes no `-DDISABLE_NVSHMEM`), so `#ifndef DISABLE_NVSHMEM` is always true and the `#else` assert is dead code. UCCL's internode also runs over the CPU proxy and doesn't need NVSHMEM at all, so the macro's premise no longer holds. Removed the `#ifndef/#else` guards, keeping the always-active branch (behavior-preserving).

### Part 3 — stale ibgda/nvshmem comments

Comments in `internode.cu` / `internode_ll.cu` / `internode.cuh` still used the
old terms:

- Removed dead commented-out leftovers: the `// #include "ibgda_device.cuh"`,
  two `// nvshmemx_barrier_all_block();` placeholders, and a vestigial
  `// extern nvshmem_team_t cpu_rdma_team;` declaration.
- Reworded "IBGDA" mentions in code comments to "RDMA" (e.g. "Issue IBGDA
  sends" → "Issue RDMA sends"), since these paths run over UCCL's CPU proxy
  rather than IBGDA.



### What stays unchanged

1. **NCCL — all kept.** Every occurrence is real, not a stale name: the PyTorch `nccl` backend, the `NCCL_IB_HCA` env var UCCL honors for NIC selection, GID-selection helpers ported from NCCL (`ncclIb*`, prefix = provenance), and comments citing NCCL's tuned defaults to justify buffer/FIFO sizes. Removing any would break functionality or lose traceability/rationale.
2. **`nvshmem` in `bench/baseline/` and `bench/sglang/`** — these genuinely `import nvshmem.core` to benchmark _against_ real NVSHMEM; removing them deletes the baseline itself.
3. **Docs** (README / baseline README) describing the NVSHMEM comparison.
4. **Comments** that explain history/rationale (e.g. why we replaced NVSHMEM's path).



## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

This is a cosmetic / no-op change: the hardcoded `"nccl"` backend in
`init_dist()` / `init_dist_under_torchrun()` is replaced by
`os.getenv("DIST_BACKEND", "nccl")`, so default behavior is unchanged.

Verified: Python syntax checks (`ast.parse`).


## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [x] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
