### PR TITLE
[bugfix]: quiet all CXI proxy queues before reuse

### DIFF
--- a/ep/include/proxy_ctx.hpp
+++ b/ep/include/proxy_ctx.hpp
@@ -201,10 +201,10 @@ struct ProxyCtx {
   // Async-barrier state (single inflight assumed)
   bool barrier_inflight = false;
   uint64_t barrier_seq = 0;
-  int barrier_wr = -1;
+  int64_t barrier_wr = -1;
 
   bool quiet_inflight = false;
-  int quiet_wr = -1;
+  int64_t quiet_wr = -1;
 
   // Rank-0 bookkeeping
   std::vector<uint8_t> barrier_arrived;  // size = num_ranks; 1 if arrival seen

--- a/ep/include/uccl_ibgda.cuh
+++ b/ep/include/uccl_ibgda.cuh
@@ -325,16 +325,23 @@ __device__ static __forceinline__ void nvshmemi_ibgda_quiet(
   EP_DEVICE_ASSERT(
       num_d2h_channel_addrs % kChannelPerProxy == 0 &&
       "num_d2h_channel_addrs must be multiple of kChannelPerProxy");
-  /* NOTE(MaoZiming): This is sent to all proxy threads. Since each proxy
-   * thread manages kChannelPerProxy ring buffers, we just need to post a quiet
-   * command to one out of the kChannelPerProxy ring buffer per cpu thread. */
   EP_DEVICE_ASSERT(num_d2h_channel_addrs % kChannelPerProxy == 0);
   EP_DEVICE_ASSERT(num_d2h_channel_addrs / kChannelPerProxy == kNumProxyThs);
-  // First, atomically commit QUIET to one ring per proxy
-  uint64_t slots[kNumProxyThs];
+  // First, atomically commit QUIET to all CXI rings. Each proxy thread owns
+  // multiple D2H rings, so posting to one ring per proxy is not enough to fence
+  // sibling rings before RDMA buffer reuse.
+#if defined(USE_LIBFABRIC_CXI)
+  constexpr int kQuietStride = 1;
+  constexpr int kMaxQuietPosts = kNumProxyThs * kChannelPerProxy;
+#else
+  constexpr int kQuietStride = kChannelPerProxy;
+  constexpr int kMaxQuietPosts = kNumProxyThs;
+#endif
+  uint64_t slots[kMaxQuietPosts];
+  int posted_d2h_channel_idxs[kMaxQuietPosts];
   int num_posted = 0;
   for (int d2h_channel_idx = 0; d2h_channel_idx < num_d2h_channel_addrs;
-       d2h_channel_idx += kChannelPerProxy) {
+       d2h_channel_idx += kQuietStride) {
     auto* h = reinterpret_cast<d2hq::D2HHandle*>(
         static_cast<uintptr_t>(d2h_channel_addrs[d2h_channel_idx]));
 #ifdef USE_MSCCLPP_FIFO_BACKEND
@@ -343,7 +350,9 @@ __device__ static __forceinline__ void nvshmemi_ibgda_quiet(
       TransferCmd cmd{};
       cmd.cmd_type = CmdType::QUIET;
       h->atomic_set_and_commit(cmd, &slot);
-      slots[num_posted++] = slot;
+      slots[num_posted] = slot;
+      posted_d2h_channel_idxs[num_posted] = d2h_channel_idx;
+      ++num_posted;
     }
 #else
     while (true) {
@@ -356,6 +365,7 @@ __device__ static __forceinline__ void nvshmemi_ibgda_quiet(
         cmd.cmd_type = CmdType::QUIET;
         h->atomic_set_and_commit(cmd, &slot);
         slots[num_posted] = slot;
+        posted_d2h_channel_idxs[num_posted] = d2h_channel_idx;
         ++num_posted;
         break;
       }
@@ -366,7 +376,7 @@ __device__ static __forceinline__ void nvshmemi_ibgda_quiet(
   // Then wait for all QUIET commands to complete
   for (int i = 0; i < num_posted; ++i) {
     auto* h = reinterpret_cast<d2hq::D2HHandle*>(
-        static_cast<uintptr_t>(d2h_channel_addrs[i * kChannelPerProxy]));
+        static_cast<uintptr_t>(d2h_channel_addrs[posted_d2h_channel_idxs[i]]));
     wait_until_cmd_consumed(h, slots[i], nvl_rank, CmdType::QUIET);
   }
 }

--- a/ep/include/uccl_ibgda.cuh
+++ b/ep/include/uccl_ibgda.cuh
@@ -409,6 +409,7 @@ __forceinline__ __device__ void nvshmem_sync_with_same_gpu_idx(
       }
     }
 #endif
+    break;
   }
 
   // Then wait for each proxy’s barrier to complete

--- a/ep/include/uccl_ibgda.cuh
+++ b/ep/include/uccl_ibgda.cuh
@@ -419,8 +419,9 @@ __forceinline__ __device__ void nvshmem_sync_with_same_gpu_idx(
       }
     }
 #endif
-    // NOTE: the `break` here is intentional (only post to proxy thread 0): unlike
-    // QUIET, one proxy thread per GPU suffices since one GPU proxy thread is enough to form a complete barrier across all ranks.
+    // NOTE: the `break` here is intentional (only post to proxy thread 0):
+    // unlike QUIET, one proxy thread per GPU suffices since one GPU proxy
+    // thread is enough to form a complete barrier across all ranks.
     break;
   }
 

--- a/ep/include/uccl_ibgda.cuh
+++ b/ep/include/uccl_ibgda.cuh
@@ -419,6 +419,8 @@ __forceinline__ __device__ void nvshmem_sync_with_same_gpu_idx(
       }
     }
 #endif
+    // NOTE: the `break` here is intentional (only post to proxy thread 0): unlike
+    // QUIET, one proxy thread per GPU suffices since one GPU proxy thread is enough to form a complete barrier across all ranks.
     break;
   }
 


### PR DESCRIPTION
## Summary

Fix the UCCL-EP CXI timeout by making `QUIET` drain every CXI D2H queue, preserving full FIFO control wr ids, and keeping `BARRIER` on the existing single representative sync queue.

## Symptom
The user-visible symptom was an NVL receiver `timeout` with `UCCL_BENCH_RDMA_BUFFER_SIZE=256` when we test `test_internode.py`. Because RDMA slots are reused, stale `SourceMeta::is_token_in_nvl_rank_bits` from a previous token can still carry a valid epoch tag for the current `rdma_channel_tail`, while its low routing bits belong to the old token.

When this happens, `WarpRole::kRDMAAndNVLForwarder` can decide the token is not destined for the current `dst_nvl_rank` and skip the NVL enqueue. The matching `WarpRole::kNVLReceivers` warp still expects the advertised token count, so it keeps polling `nvl_channel_tail` until the NVL receiver timeout fires.

This is not a receiver-capacity deadlock. It is a stale-control-state race from non-quieted CXI queues overlapping RDMA/atomic buffer reset or reuse.

## Root cause

So far, I have found 3 separate control-plane issues related to the timeout problem I found earlier.

### Remove break
`nvshmemi_ibgda_quiet()` did not fence all CXI commands before RDMA/atomic buffer reuse. The original helper had an unconditional outer `break`, so it only posted one `QUIET` from one thread in one sm. See for example in https://github.com/uccl-project/uccl/blob/d59f5b6bf3f8f7739f29e80fd6d7fb6a810bb8e7/ep/src/internode.cu#L128
Removing that break made it post multiple `QUIET` to different GPU to CPU queues, instead of simply queue 0.

### Loop over all queues in `nvshmemi_ibgda_quiet`
In `nvshmemi_ibgda_quiet` previously the quiet command was only put every `kChannelPerProxy`. In the default setting, there are 4 proxy threads, and `kChannelPerProxy == 8` so quiet command will only be put on queue
```
0, 8, 16, 24
```
for example. 
Since only one cuda thread is launching `nvshmemi_ibgda_quiet`, at the end only 4 queues will have the quiet command and be drained. 

### `int` overflow
After we fix the previous two, the timeout moved to `wait_until_cmd_consumed`. When `QUIET` was expanded to all CXI queues, the FIFO completion path revealed a wr-id truncation bug. FIFO control wr ids are generated as:

```cpp
unique_wr_id = (static_cast<uint64_t>(rb_idx) << 32) |
               (fifo_seq_[rb_idx]++ & 0xFFFFFFFFULL);
```

So `rb_idx` says **which FIFO inside this proxy thread** the command came from.

When the proxy sees a `QUIET`, it records that wr id in `ctx_.quiet_wr`. Later, after the quiet work is done, `notify_gpu_completion()` checks whether the completed wr id matches the pending FIFO entry:

```
if (ctx_.quiet_wr != -1 && front_wr == (uint64_t)ctx_.quiet_wr) {
  ctx_.quiet_inflight = false;
  ctx_.quiet_wr = -1;
  fifo->pop();
}
```

The `fifo->pop()` is the important part. On the GPU side, `wait_until_cmd_consumed()` is waiting for the FIFO tail to advance:

```
if (h->fifo.poll(slot)) break;
```

If `quiet_wr` is only `int`, then a wr id from `rb_idx = 1`:

```
4294967296
```

gets truncated to:

```
0
```

So the proxy can finish the CXI quiet drain and even insert the ack, but when `notify_gpu_completion()` looks at FIFO 1’s pending entry:

```
front_wr = 4294967296
ctx_.quiet_wr = 0
```

they do not match. Therefore:

```
fifo->pop() is not called
FIFO tail does not advance
GPU h->fifo.poll(slot) stays false
GPU waits forever
timeout
```


Last point. `nvshmem_sync_with_same_gpu_idx()` should not be changed in the same way as `QUIET` for this fix. The barrier path is a proxy-thread rendezvous, while `QUIET` is the operation that must fence per-queue CXI writes/atomics before buffer reuse. This PR therefore keeps the sync/BARRIER helper on the existing single representative queue and only expands CXI `QUIET` coverage.

## Fix

This is split into three commits:

1. Keep sync/BARRIER single-queued by restoring the outer `break` in `nvshmem_sync_with_same_gpu_idx()`.
2. Preserve full FIFO control wr ids by widening `ProxyCtx::quiet_wr` and `ProxyCtx::barrier_wr` from `int` to `int64_t`.
3. For `USE_LIBFABRIC_CXI`, make `nvshmemi_ibgda_quiet()` stride every D2H queue, record the exact posted queue index, and wait on the same queue for completion. Non-CXI keeps the existing one-queue-per-proxy stride.

## Validation

On Alps/CXI, EP8 with `UCCL_BENCH_RDMA_BUFFER_SIZE=256` previously reproduced forwarder epoch/NVL receiver timeouts. The reproducer initially failed 6/6 times. With this fix, 10 serial clean runs completed successfully with no `timeout`, `wait_until_cmd_consumed`, `RuntimeError`, `Traceback`, `ChildFailedError`, `NVL receiver`, `EP epoch`, or CUDA launch-failure signatures in the node logs.

Best-result ranges across the 10 clean runs:

```text
FP8 dispatch: 37.25-40.34 GB/s RDMA, 1496-1619 us
BF16 dispatch: 41.23-43.19 GB/s RDMA, 2710-2837 us
Combine: 41.40-42.68 GB/s RDMA, 2742-2827 us
```
