### PR TITLE
[CI] enable bot reply when run-benchmark

### DIFF
--- a/.github/workflows/benchmark_comment.py
+++ b/.github/workflows/benchmark_comment.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Create and update PR benchmark status comments from GitHub Actions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+
+
+def request(method: str, path: str, payload: dict | None = None) -> dict:
+    token = os.environ["GITHUB_TOKEN"]
+    api_url = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    data = json.dumps(payload).encode() if payload is not None else None
+    req = urllib.request.Request(
+        f"{api_url}{path}",
+        data=data,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = resp.read()
+    except urllib.error.HTTPError as exc:
+        details = exc.read().decode(errors="replace")
+        raise RuntimeError(f"GitHub API {method} {path} failed: {exc.code} {details}") from exc
+    return json.loads(body.decode()) if body else {}
+
+
+def write_output(name: str, value: str) -> None:
+    output = os.environ.get("GITHUB_OUTPUT")
+    if not output:
+        return
+    with open(output, "a", encoding="utf-8") as f:
+        f.write(f"{name}={value}\n")
+
+
+def status_label(status: str) -> str:
+    labels = {
+        "queued": "queued",
+        "running": "running",
+        "success": "passed",
+        "failure": "failed",
+        "cancelled": "cancelled",
+        "skipped": "skipped",
+        "dispatch-failed": "failed to dispatch",
+    }
+    return labels.get(status, status)
+
+
+def build_body(args: argparse.Namespace) -> str:
+    marker = args.marker or f"run-benchmark-{args.benchmark}-{args.pr}-{int(time.time())}"
+    lines = [
+        f"<!-- {marker} -->",
+        f"### Benchmark `{args.benchmark}` {status_label(args.status)}",
+        "",
+        f"PR: #{args.pr}",
+        f"Commit: `{args.sha}`",
+    ]
+
+    if args.requester:
+        lines.append(f"Requested by: @{args.requester}")
+    if args.result:
+        lines.append(f"Result: `{args.result}`")
+    if args.workflow_url:
+        lines.append(f"Workflow run: {args.workflow_url}")
+    elif args.workflow:
+        repo_url = f"{os.environ.get('GITHUB_SERVER_URL', 'https://github.com')}/{args.repo}"
+        lines.append(f"Workflow: {repo_url}/actions/workflows/{args.workflow}")
+    if args.error:
+        lines.extend(["", f"Error: {args.error}"])
+    elif args.status in {"queued", "running"}:
+        lines.extend(["", "Results will be posted here when it finishes."])
+
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["create", "update"], required=True)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    parser.add_argument("--pr", required=True)
+    parser.add_argument("--sha", required=True)
+    parser.add_argument("--benchmark", required=True)
+    parser.add_argument("--status", required=True)
+    parser.add_argument("--comment-id", default="")
+    parser.add_argument("--marker", default="")
+    parser.add_argument("--requester", default="")
+    parser.add_argument("--workflow", default="")
+    parser.add_argument("--workflow-url", default="")
+    parser.add_argument("--result", default="")
+    parser.add_argument("--error", default="")
+    args = parser.parse_args()
+
+    if not args.repo:
+        raise SystemExit("--repo or GITHUB_REPOSITORY is required")
+
+    owner_repo = args.repo
+    marker = args.marker or f"run-benchmark-{args.benchmark}-{args.pr}-{int(time.time())}"
+    args.marker = marker
+    body = build_body(args)
+
+    if args.mode == "create":
+        comment = request(
+            "POST",
+            f"/repos/{owner_repo}/issues/{args.pr}/comments",
+            {"body": body},
+        )
+        write_output("comment_id", str(comment["id"]))
+        write_output("reply_marker", marker)
+        return
+
+    if not args.comment_id:
+        raise SystemExit("--comment-id is required for update mode")
+    request(
+        "PATCH",
+        f"/repos/{owner_repo}/issues/comments/{args.comment_id}",
+        {"body": body},
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/run-benchmark.yml
+++ b/.github/workflows/run-benchmark.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Resolve benchmark request
         id: request
@@ -72,20 +74,33 @@ jobs:
         id: benchmark-comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BENCHMARK_PR: ${{ steps.request.outputs.pr }}
+          BENCHMARK_SHA: ${{ steps.request.outputs.sha }}
+          BENCHMARK_NAME: ${{ steps.request.outputs.benchmark }}
+          BENCHMARK_REQUESTER: ${{ steps.request.outputs.requester }}
+          BENCHMARK_WORKFLOW: ${{ steps.request.outputs.workflow }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode create \
-            --pr "${{ steps.request.outputs.pr }}" \
-            --sha "${{ steps.request.outputs.sha }}" \
-            --benchmark "${{ steps.request.outputs.benchmark }}" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
             --status queued \
-            --requester "${{ steps.request.outputs.requester }}" \
-            --workflow "${{ steps.request.outputs.workflow }}"
+            --requester "$BENCHMARK_REQUESTER" \
+            --workflow "$BENCHMARK_WORKFLOW"
 
       - name: Dispatch requested benchmark
         id: dispatch
         uses: actions/github-script@v7
         continue-on-error: true
+        env:
+          BENCHMARK_WORKFLOW: ${{ steps.request.outputs.workflow }}
+          BENCHMARK_PR: ${{ steps.request.outputs.pr }}
+          BENCHMARK_SHA: ${{ steps.request.outputs.sha }}
+          BENCHMARK_HEAD_REPO: ${{ steps.request.outputs.head_repo }}
+          BENCHMARK_NAME: ${{ steps.request.outputs.benchmark }}
+          REPLY_COMMENT_ID: ${{ steps.benchmark-comment.outputs.comment_id }}
+          REPLY_MARKER: ${{ steps.benchmark-comment.outputs.reply_marker }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -93,15 +108,15 @@ jobs:
               await github.rest.actions.createWorkflowDispatch({
                 owner,
                 repo,
-                workflow_id: '${{ steps.request.outputs.workflow }}',
+                workflow_id: process.env.BENCHMARK_WORKFLOW,
                 ref: context.payload.repository.default_branch,
                 inputs: {
-                  pr: '${{ steps.request.outputs.pr }}',
-                  sha: '${{ steps.request.outputs.sha }}',
-                  head_repo: '${{ steps.request.outputs.head_repo }}',
-                  benchmark: '${{ steps.request.outputs.benchmark }}',
-                  reply_comment_id: '${{ steps.benchmark-comment.outputs.comment_id }}',
-                  reply_marker: '${{ steps.benchmark-comment.outputs.reply_marker }}',
+                  pr: process.env.BENCHMARK_PR,
+                  sha: process.env.BENCHMARK_SHA,
+                  head_repo: process.env.BENCHMARK_HEAD_REPO,
+                  benchmark: process.env.BENCHMARK_NAME,
+                  reply_comment_id: process.env.REPLY_COMMENT_ID,
+                  reply_marker: process.env.REPLY_MARKER,
                 },
               });
             } catch (error) {
@@ -109,23 +124,30 @@ jobs:
               core.setFailed(error.message);
             }
 
-            core.info(`Dispatched ${{ steps.request.outputs.benchmark }} benchmark for PR #${{ steps.request.outputs.pr }} at ${{ steps.request.outputs.sha }}; reply comment ${{ steps.benchmark-comment.outputs.comment_id }}`);
+            core.info(`Dispatched ${process.env.BENCHMARK_NAME} benchmark for PR #${process.env.BENCHMARK_PR} at ${process.env.BENCHMARK_SHA}; reply comment ${process.env.REPLY_COMMENT_ID}`);
 
       - name: Mark dispatch failed
         if: steps.dispatch.outcome == 'failure'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ steps.benchmark-comment.outputs.comment_id }}
+          REPLY_MARKER: ${{ steps.benchmark-comment.outputs.reply_marker }}
+          BENCHMARK_PR: ${{ steps.request.outputs.pr }}
+          BENCHMARK_SHA: ${{ steps.request.outputs.sha }}
+          BENCHMARK_NAME: ${{ steps.request.outputs.benchmark }}
+          BENCHMARK_REQUESTER: ${{ steps.request.outputs.requester }}
+          DISPATCH_ERROR: ${{ steps.dispatch.outputs.error }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ steps.benchmark-comment.outputs.comment_id }}" \
-            --marker "${{ steps.benchmark-comment.outputs.reply_marker }}" \
-            --pr "${{ steps.request.outputs.pr }}" \
-            --sha "${{ steps.request.outputs.sha }}" \
-            --benchmark "${{ steps.request.outputs.benchmark }}" \
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
             --status dispatch-failed \
-            --requester "${{ steps.request.outputs.requester }}" \
-            --error "${{ steps.dispatch.outputs.error }}"
+            --requester "$BENCHMARK_REQUESTER" \
+            --error "$DISPATCH_ERROR"
 
       - name: Fail dispatcher after dispatch error
         if: steps.dispatch.outcome == 'failure'

--- a/.github/workflows/run-benchmark.yml
+++ b/.github/workflows/run-benchmark.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   actions: write
   contents: read
+  issues: write
   pull-requests: read
 
 jobs:
@@ -15,7 +16,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Dispatch requested benchmark
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Resolve benchmark request
+        id: request
         uses: actions/github-script@v7
         with:
           script: |
@@ -56,16 +61,72 @@ jobs:
             };
             const target = match[1];
 
-            await github.rest.actions.createWorkflowDispatch({
-              owner,
-              repo,
-              workflow_id: workflows[target],
-              ref: context.payload.repository.default_branch,
-              inputs: {
-                pr: String(pull_number),
-                sha: pr.head.sha,
-                head_repo: pr.head.repo.full_name,
-              },
-            });
+            core.setOutput('benchmark', target);
+            core.setOutput('workflow', workflows[target]);
+            core.setOutput('pr', String(pull_number));
+            core.setOutput('sha', pr.head.sha);
+            core.setOutput('head_repo', pr.head.repo.full_name);
+            core.setOutput('requester', commenter);
 
-            core.info(`Dispatched ${target} benchmark for PR #${pull_number} at ${pr.head.sha}`);
+      - name: Create queued benchmark comment
+        id: benchmark-comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode create \
+            --pr "${{ steps.request.outputs.pr }}" \
+            --sha "${{ steps.request.outputs.sha }}" \
+            --benchmark "${{ steps.request.outputs.benchmark }}" \
+            --status queued \
+            --requester "${{ steps.request.outputs.requester }}" \
+            --workflow "${{ steps.request.outputs.workflow }}"
+
+      - name: Dispatch requested benchmark
+        id: dispatch
+        uses: actions/github-script@v7
+        continue-on-error: true
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: '${{ steps.request.outputs.workflow }}',
+                ref: context.payload.repository.default_branch,
+                inputs: {
+                  pr: '${{ steps.request.outputs.pr }}',
+                  sha: '${{ steps.request.outputs.sha }}',
+                  head_repo: '${{ steps.request.outputs.head_repo }}',
+                  benchmark: '${{ steps.request.outputs.benchmark }}',
+                  reply_comment_id: '${{ steps.benchmark-comment.outputs.comment_id }}',
+                  reply_marker: '${{ steps.benchmark-comment.outputs.reply_marker }}',
+                },
+              });
+            } catch (error) {
+              core.setOutput('error', error.message);
+              core.setFailed(error.message);
+            }
+
+            core.info(`Dispatched ${{ steps.request.outputs.benchmark }} benchmark for PR #${{ steps.request.outputs.pr }} at ${{ steps.request.outputs.sha }}; reply comment ${{ steps.benchmark-comment.outputs.comment_id }}`);
+
+      - name: Mark dispatch failed
+        if: steps.dispatch.outcome == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ steps.benchmark-comment.outputs.comment_id }}" \
+            --marker "${{ steps.benchmark-comment.outputs.reply_marker }}" \
+            --pr "${{ steps.request.outputs.pr }}" \
+            --sha "${{ steps.request.outputs.sha }}" \
+            --benchmark "${{ steps.request.outputs.benchmark }}" \
+            --status dispatch-failed \
+            --requester "${{ steps.request.outputs.requester }}" \
+            --error "${{ steps.dispatch.outputs.error }}"
+
+      - name: Fail dispatcher after dispatch error
+        if: steps.dispatch.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/uccl-build-l4.yml
+++ b/.github/workflows/uccl-build-l4.yml
@@ -43,20 +43,28 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment with run URL
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
             --status running \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --workflow-url "$WORKFLOW_URL"
 
   build-on-l4:
     if: >
@@ -144,7 +152,7 @@ jobs:
           path: build.log
 
   write-back-result:
-    needs: [build-on-l4]
+    needs: [mark-running, build-on-l4]
     if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
     runs-on: ubuntu-latest
     permissions:
@@ -153,18 +161,27 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          BENCHMARK_RESULT: ${{ needs.build-on-l4.result }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
-            --status "${{ needs.build-on-l4.result }}" \
-            --result "${{ needs.build-on-l4.result }}" \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
+            --status "$BENCHMARK_RESULT" \
+            --result "$BENCHMARK_RESULT" \
+            --workflow-url "$WORKFLOW_URL"

--- a/.github/workflows/uccl-build-l4.yml
+++ b/.github/workflows/uccl-build-l4.yml
@@ -16,12 +16,48 @@ on:
       head_repo:
         description: PR head repository, for example owner/repo
         required: true
+      benchmark:
+        description: Benchmark target name for PR comment write-back
+        required: false
+        default: l4
+      reply_comment_id:
+        description: PR comment ID to update with benchmark result
+        required: false
+        default: ""
+      reply_marker:
+        description: Marker used to identify the benchmark reply comment
+        required: false
+        default: ""
 
 concurrency:
   group: l4-uccl-build
   cancel-in-progress: false
 
 jobs:
+  mark-running:
+    if: github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment with run URL
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status running \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   build-on-l4:
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -106,3 +142,29 @@ jobs:
         with:
           name: build-log-l4
           path: build.log
+
+  write-back-result:
+    needs: [build-on-l4]
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status "${{ needs.build-on-l4.result }}" \
+            --result "${{ needs.build-on-l4.result }}" \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/uccl-build-test-amd-zip.yml
+++ b/.github/workflows/uccl-build-test-amd-zip.yml
@@ -16,6 +16,18 @@ on:
       head_repo:
         description: PR head repository, for example owner/repo
         required: true
+      benchmark:
+        description: Benchmark target name for PR comment write-back
+        required: false
+        default: amd-zip
+      reply_comment_id:
+        description: PR comment ID to update with benchmark result
+        required: false
+        default: ""
+      reply_marker:
+        description: Marker used to identify the benchmark reply comment
+        required: false
+        default: ""
 
 # Share the concurrency group with uccl-build-test-amd.yml so only one AMD
 # workflow uses the hosts at a time.
@@ -24,6 +36,30 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  mark-running:
+    if: github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment with run URL
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status running \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   build-with-dietgpu-on-amd:
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -218,3 +254,29 @@ jobs:
             amd0-*.log
             amd1-*.log
           if-no-files-found: warn
+
+  write-back-result:
+    needs: [build-with-dietgpu-on-amd]
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status "${{ needs.build-with-dietgpu-on-amd.result }}" \
+            --result "${{ needs.build-with-dietgpu-on-amd.result }}" \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/uccl-build-test-amd-zip.yml
+++ b/.github/workflows/uccl-build-test-amd-zip.yml
@@ -45,20 +45,28 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment with run URL
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
             --status running \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --workflow-url "$WORKFLOW_URL"
 
   build-with-dietgpu-on-amd:
     if: >
@@ -256,7 +264,7 @@ jobs:
           if-no-files-found: warn
 
   write-back-result:
-    needs: [build-with-dietgpu-on-amd]
+    needs: [mark-running, build-with-dietgpu-on-amd]
     if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
     runs-on: ubuntu-latest
     permissions:
@@ -265,18 +273,27 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          BENCHMARK_RESULT: ${{ needs.build-with-dietgpu-on-amd.result }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
-            --status "${{ needs.build-with-dietgpu-on-amd.result }}" \
-            --result "${{ needs.build-with-dietgpu-on-amd.result }}" \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
+            --status "$BENCHMARK_RESULT" \
+            --result "$BENCHMARK_RESULT" \
+            --workflow-url "$WORKFLOW_URL"

--- a/.github/workflows/uccl-build-test-amd.yml
+++ b/.github/workflows/uccl-build-test-amd.yml
@@ -16,12 +16,48 @@ on:
       head_repo:
         description: PR head repository, for example owner/repo
         required: true
+      benchmark:
+        description: Benchmark target name for PR comment write-back
+        required: false
+        default: amd
+      reply_comment_id:
+        description: PR comment ID to update with benchmark result
+        required: false
+        default: ""
+      reply_marker:
+        description: Marker used to identify the benchmark reply comment
+        required: false
+        default: ""
 
 concurrency:
   group: amd-uccl-build-test
   cancel-in-progress: false
 
 jobs:
+  mark-running:
+    if: github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment with run URL
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status running \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   build-and-test-on-amd:
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -344,3 +380,29 @@ jobs:
             amd0-*.log
             amd1-*.log
           if-no-files-found: warn
+
+  write-back-result:
+    needs: [build-and-test-on-amd]
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status "${{ needs.build-and-test-on-amd.result }}" \
+            --result "${{ needs.build-and-test-on-amd.result }}" \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/uccl-build-test-amd.yml
+++ b/.github/workflows/uccl-build-test-amd.yml
@@ -43,20 +43,28 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment with run URL
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
             --status running \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --workflow-url "$WORKFLOW_URL"
 
   build-and-test-on-amd:
     if: >
@@ -382,7 +390,7 @@ jobs:
           if-no-files-found: warn
 
   write-back-result:
-    needs: [build-and-test-on-amd]
+    needs: [mark-running, build-and-test-on-amd]
     if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
     runs-on: ubuntu-latest
     permissions:
@@ -391,18 +399,27 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          BENCHMARK_RESULT: ${{ needs.build-and-test-on-amd.result }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
-            --status "${{ needs.build-and-test-on-amd.result }}" \
-            --result "${{ needs.build-and-test-on-amd.result }}" \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
+            --status "$BENCHMARK_RESULT" \
+            --result "$BENCHMARK_RESULT" \
+            --workflow-url "$WORKFLOW_URL"

--- a/.github/workflows/uccl-build-test-gb10.yml
+++ b/.github/workflows/uccl-build-test-gb10.yml
@@ -43,20 +43,28 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment with run URL
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
             --status running \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --workflow-url "$WORKFLOW_URL"
 
   build-and-test-on-gb10:
     if: >
@@ -306,7 +314,7 @@ jobs:
           if-no-files-found: warn
 
   write-back-result:
-    needs: [build-and-test-on-gb10]
+    needs: [mark-running, build-and-test-on-gb10]
     if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
     runs-on: ubuntu-latest
     permissions:
@@ -315,18 +323,27 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          BENCHMARK_RESULT: ${{ needs.build-and-test-on-gb10.result }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
-            --status "${{ needs.build-and-test-on-gb10.result }}" \
-            --result "${{ needs.build-and-test-on-gb10.result }}" \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
+            --status "$BENCHMARK_RESULT" \
+            --result "$BENCHMARK_RESULT" \
+            --workflow-url "$WORKFLOW_URL"

--- a/.github/workflows/uccl-build-test-gb10.yml
+++ b/.github/workflows/uccl-build-test-gb10.yml
@@ -16,12 +16,48 @@ on:
       head_repo:
         description: PR head repository, for example owner/repo
         required: true
+      benchmark:
+        description: Benchmark target name for PR comment write-back
+        required: false
+        default: gb10
+      reply_comment_id:
+        description: PR comment ID to update with benchmark result
+        required: false
+        default: ""
+      reply_marker:
+        description: Marker used to identify the benchmark reply comment
+        required: false
+        default: ""
 
 concurrency:
   group: gb10-uccl-build-test
   cancel-in-progress: false
 
 jobs:
+  mark-running:
+    if: github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment with run URL
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status running \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   build-and-test-on-gb10:
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -268,3 +304,29 @@ jobs:
             gb10-nixlbench-internode-spark0.log
             gb10-nixlbench-internode-spark1.log
           if-no-files-found: warn
+
+  write-back-result:
+    needs: [build-and-test-on-gb10]
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status "${{ needs.build-and-test-on-gb10.result }}" \
+            --result "${{ needs.build-and-test-on-gb10.result }}" \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/uccl-build-test-gh200.yml
+++ b/.github/workflows/uccl-build-test-gh200.yml
@@ -16,12 +16,48 @@ on:
       head_repo:
         description: PR head repository, for example owner/repo
         required: true
+      benchmark:
+        description: Benchmark target name for PR comment write-back
+        required: false
+        default: gh200
+      reply_comment_id:
+        description: PR comment ID to update with benchmark result
+        required: false
+        default: ""
+      reply_marker:
+        description: Marker used to identify the benchmark reply comment
+        required: false
+        default: ""
 
 concurrency:
   group: gh200-uccl-build-test
   cancel-in-progress: false
 
 jobs:
+  mark-running:
+    if: github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment with run URL
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status running \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
   build-and-test-on-gh200:
     if: >
       github.event_name == 'workflow_dispatch' ||
@@ -311,3 +347,29 @@ jobs:
             gh200-nixlbench-internode-gh0.log
             gh200-nixlbench-internode-gh1.log
           if-no-files-found: warn
+
+  write-back-result:
+    needs: [build-and-test-on-gh200]
+    if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout workflow helpers
+        uses: actions/checkout@v4
+
+      - name: Update benchmark comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/workflows/benchmark_comment.py \
+            --mode update \
+            --comment-id "${{ inputs.reply_comment_id }}" \
+            --marker "${{ inputs.reply_marker }}" \
+            --pr "${{ inputs.pr }}" \
+            --sha "${{ inputs.sha }}" \
+            --benchmark "${{ inputs.benchmark }}" \
+            --status "${{ needs.build-and-test-on-gh200.result }}" \
+            --result "${{ needs.build-and-test-on-gh200.result }}" \
+            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/uccl-build-test-gh200.yml
+++ b/.github/workflows/uccl-build-test-gh200.yml
@@ -43,20 +43,28 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment with run URL
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
             --status running \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --workflow-url "$WORKFLOW_URL"
 
   build-and-test-on-gh200:
     if: >
@@ -349,7 +357,7 @@ jobs:
           if-no-files-found: warn
 
   write-back-result:
-    needs: [build-and-test-on-gh200]
+    needs: [mark-running, build-and-test-on-gh200]
     if: always() && github.event_name == 'workflow_dispatch' && inputs.reply_comment_id != ''
     runs-on: ubuntu-latest
     permissions:
@@ -358,18 +366,27 @@ jobs:
     steps:
       - name: Checkout workflow helpers
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Update benchmark comment
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPLY_COMMENT_ID: ${{ inputs.reply_comment_id }}
+          REPLY_MARKER: ${{ inputs.reply_marker }}
+          BENCHMARK_PR: ${{ inputs.pr }}
+          BENCHMARK_SHA: ${{ inputs.sha }}
+          BENCHMARK_NAME: ${{ inputs.benchmark }}
+          BENCHMARK_RESULT: ${{ needs.build-and-test-on-gh200.result }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           python3 .github/workflows/benchmark_comment.py \
             --mode update \
-            --comment-id "${{ inputs.reply_comment_id }}" \
-            --marker "${{ inputs.reply_marker }}" \
-            --pr "${{ inputs.pr }}" \
-            --sha "${{ inputs.sha }}" \
-            --benchmark "${{ inputs.benchmark }}" \
-            --status "${{ needs.build-and-test-on-gh200.result }}" \
-            --result "${{ needs.build-and-test-on-gh200.result }}" \
-            --workflow-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --comment-id "$REPLY_COMMENT_ID" \
+            --marker "$REPLY_MARKER" \
+            --pr "$BENCHMARK_PR" \
+            --sha "$BENCHMARK_SHA" \
+            --benchmark "$BENCHMARK_NAME" \
+            --status "$BENCHMARK_RESULT" \
+            --result "$BENCHMARK_RESULT" \
+            --workflow-url "$WORKFLOW_URL"


### PR DESCRIPTION
## Description

This allows a github bot to update workflow running status after we comment `/run-benchmark amd`

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
