### PR TITLE
test(ep): guard low-latency FP8 assert with `if not round_scale` (it aborts the bench at scale)

### DIFF
--- a/ep/bench/test_low_latency.py
+++ b/ep/bench/test_low_latency.py
@@ -370,9 +370,10 @@ def test_main(
                                         combined_x,
                                     )
                                     assert torch.isnan(combined_x).sum().item() == 0
-                                    assert diff < (
-                                        9e-4 if dispatch_use_fp8_case else 1e-5
-                                    ), f"Error: {diff=}, {dispatch_use_fp8_case=}, {zero_copy=}"
+                                    if not round_scale:
+                                        assert diff < (
+                                            9e-4 if dispatch_use_fp8_case else 1e-5
+                                        ), f"Error: {diff=}, {dispatch_use_fp8_case=}, {round_scale=}, {use_ue8m0=}, {zero_copy=}"
                                     tag = (
                                         f"x={'x' if current_x is x else 'rand'}"
                                         f"|hook={return_recv_hook}"


### PR DESCRIPTION
## Problem

`ep/bench/test_low_latency.py` asserts the tight FP8 similarity tolerance (`diff < 9e-4`) for **every** FP8 sub-case, including `round_scale=True`:

```python
assert diff < (
    9e-4 if dispatch_use_fp8_case else 1e-5
), f"Error: {diff=}, {dispatch_use_fp8_case=}, {zero_copy=}"
```

The loop runs `round_scale=False` first and then `round_scale=True`. At larger rank counts the `round_scale=True` (coarse, power-of-2 / UE8M0-family) sub-case exceeds `9e-4`, so the assert trips and **aborts the whole benchmark before the timed/bandwidth phase runs** — no low-latency bandwidth is reported, even though the standard `round_scale=False` FP8 path is well within tolerance.

This is a test-gate issue, not a kernel problem:

- The dispatch-side correctness check in this same file is **already** guarded with `if not round_scale:` ([`ep/bench/test_low_latency.py#L277-L282`](https://github.com/uccl-project/uccl/blob/d59f5b6bf3f8f7739f29e80fd6d7fb6a810bb8e7/ep/bench/test_low_latency.py#L277-L282)) — only the combine-side assert is unconditional, so the two checks are inconsistent.
- Upstream DeepEP guards the equivalent combine assert the same way: [`deepseek-ai/DeepEP tests/test_low_latency.py#L178`](https://github.com/deepseek-ai/DeepEP/blob/567632d/tests/test_low_latency.py#L178) — it deliberately exempts `round_scale=True`, whose larger quantization error is expected.

## Evidence

64 ranks (8 nodes × 8 GPU), `--num-tokens=128 --hidden=7168 --num-topk=8 --num-experts=256`. Logging `diff` per sub-case (256 samples each):

| dispatch_use_fp8 | round_scale | max diff | tolerance | result |
|---|---|---:|---:|---|
| False (bf16) | —     | 1.7e-6   | 1e-5 | pass |
| True         | False | **1.07e-4** | 9e-4 | **pass (8× margin)** |
| True         | True  | **1.80e-3** | 9e-4 | fail |

Only `round_scale=True` exceeds; the standard `round_scale=False` FP8 path passes with ~8× margin. (Reproduced identically across GPU generations, consistent with a quantization-recipe property rather than a kernel/arch issue.)

## Fix

Guard the combine assert with `if not round_scale:` to match both the dispatch-side check in this file and DeepEP, and add `round_scale` / `use_ue8m0` to the failure message (the current message omits `round_scale`, which obscures the failing sub-case):

```python
if not round_scale:
    assert diff < (
        9e-4 if dispatch_use_fp8_case else 1e-5
    ), f"Error: {diff=}, {dispatch_use_fp8_case=}, {round_scale=}, {use_ue8m0=}, {zero_copy=}"
```

This lets the benchmark complete and report low-latency bandwidth for all configs, while keeping the strict check on the `round_scale=False` path. Not a tolerance loosening — the `round_scale=False` path already passes.
