### PR TITLE
p2p/cxi: default threading hint to FI_THREAD_SAFE

### DIFF
--- a/p2p/README.md
+++ b/p2p/README.md
@@ -117,7 +117,7 @@ Notes:
 | UCCL_P2P_TRANSPORT | Network backend to use at runtime | ib (others: efa/nccl/tcp/tcpx/cxi) |
 | UCCL_CXI_DOMAIN | CXI/libfabric domain to use when `UCCL_P2P_TRANSPORT=cxi` | auto from GPU index, eg `cxi0` |
 | UCCL_CXI_DEVICE_INDEX | CXI device index used for automatic domain selection | GPU index modulo 4 |
-| UCCL_CXI_THREADING | libfabric threading hint for the CXI domain | endpoint |
+| UCCL_CXI_THREADING | libfabric threading hint for the CXI domain (`endpoint` is rejected by libfabric >= 2.x CXI) | safe |
 | UCCL_CXI_TX_QUEUE_SIZE | CXI transmit queue size | 4096 |
 | UCCL_CXI_RX_QUEUE_SIZE | CXI receive queue size | 4096 |
 | UCCL_CXI_CQ_SIZE | CXI completion queue size | 8192 |

--- a/p2p/cxi/cxi_endpoint.cc
+++ b/p2p/cxi/cxi_endpoint.cc
@@ -42,7 +42,9 @@ fi_threading threading_hint() {
   if (std::strcmp(value, "domain") == 0) return FI_THREAD_DOMAIN;
   if (std::strcmp(value, "fid") == 0) return FI_THREAD_FID;
   if (std::strcmp(value, "unspec") == 0) return FI_THREAD_UNSPEC;
-  throw std::runtime_error(std::string("Invalid UCCL_CXI_THREADING=") + value);
+  throw std::runtime_error(
+      std::string("Invalid UCCL_CXI_THREADING=") + value +
+      " (expected one of: safe, endpoint, completion, domain, fid, unspec)");
 }
 
 int cxi_device_index_for_gpu(int gpu_index) {

--- a/p2p/cxi/cxi_endpoint.cc
+++ b/p2p/cxi/cxi_endpoint.cc
@@ -32,12 +32,15 @@ void check_fi(char const* what, int ret) {
 }
 
 fi_threading threading_hint() {
+  // Default to FI_THREAD_SAFE: libfabric >= 2.x rejects FI_THREAD_ENDPOINT in
+  // the CXI provider's domain-attr check, failing fi_getinfo with ENODATA.
+  // FI_THREAD_SAFE is accepted by both libfabric 1.x and 2.x.
   char const* value = std::getenv("UCCL_CXI_THREADING");
-  if (!value || std::strcmp(value, "endpoint") == 0) return FI_THREAD_ENDPOINT;
+  if (!value || std::strcmp(value, "safe") == 0) return FI_THREAD_SAFE;
+  if (std::strcmp(value, "endpoint") == 0) return FI_THREAD_ENDPOINT;
   if (std::strcmp(value, "completion") == 0) return FI_THREAD_COMPLETION;
   if (std::strcmp(value, "domain") == 0) return FI_THREAD_DOMAIN;
   if (std::strcmp(value, "fid") == 0) return FI_THREAD_FID;
-  if (std::strcmp(value, "safe") == 0) return FI_THREAD_SAFE;
   if (std::strcmp(value, "unspec") == 0) return FI_THREAD_UNSPEC;
   throw std::runtime_error(std::string("Invalid UCCL_CXI_THREADING=") + value);
 }


### PR DESCRIPTION
Fixes the new CXI P2P backends on newer libfabrics. 

libfabric >= 2.x's CXI provider rejects `FI_THREAD_ENDPOINT` in its domain-attr check, so `fi_getinfo` fails with ENODATA and UCCL-P2P cannot initialize on any modern libfabric (found while chasing the #956 large-MR cliff: upgrading libfabric to 2.5.1 made every endpoint fail init with `fi_getinfo(cxi): No data available`; `FI_LOG_LEVEL=debug` shows `ofi_check_domain_attr(): Invalid threading model`).

`FI_THREAD_SAFE` is accepted by both 1.x and 2.x, and is the conservative choice given multiple threads (worker + proxies) touch the fabric. The `UCCL_CXI_THREADING` env override keeps all previous values available, including `endpoint`.