### PR TITLE
p2p/cxi: log libfabric runtime version, warn on <2.0 large-MR cliff

### DIFF
--- a/p2p/cxi/cxi_endpoint.cc
+++ b/p2p/cxi/cxi_endpoint.cc
@@ -196,11 +196,8 @@ void CxiEndpoint::init_fabric(int gpu_index) {
     if (lf_ver < FI_VERSION(2, 0)) {
       UCCL_LOG(WARN)
           << "libfabric " << FI_MAJOR(lf_ver) << "." << FI_MINOR(lf_ver)
-          << " detected: CXI RMA throughput collapses (>10x) once a "
-             "registered region exceeds ~1.5 GiB (uccl-project/uccl#956, "
-             "measured on 1.22, fixed by 2.5.x). Large registered pools "
-             "(e.g. KV caches) will be severely degraded; upgrade libfabric "
-             "to >= 2.5.";
+          << " detected: performance may be poor for large KV pools; see "
+             "uccl-project/uccl#956. Consider upgrading to libfabric >= 2.5.";
     }
     info_->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
     UCCL_LOG(INFO) << "CXI FI_DELIVERY_COMPLETE enabled";

--- a/p2p/cxi/cxi_endpoint.cc
+++ b/p2p/cxi/cxi_endpoint.cc
@@ -189,6 +189,19 @@ void CxiEndpoint::init_fabric(int gpu_index) {
   try {
     check_fi("fi_getinfo(cxi)",
              fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0, hints, &info_));
+
+    uint32_t const lf_ver = fi_version();
+    UCCL_LOG(INFO) << "libfabric runtime version " << FI_MAJOR(lf_ver) << "."
+                   << FI_MINOR(lf_ver);
+    if (lf_ver < FI_VERSION(2, 0)) {
+      UCCL_LOG(WARN)
+          << "libfabric " << FI_MAJOR(lf_ver) << "." << FI_MINOR(lf_ver)
+          << " detected: CXI RMA throughput collapses (>10x) once a "
+             "registered region exceeds ~1.5 GiB (uccl-project/uccl#956, "
+             "measured on 1.22, fixed by 2.5.x). Large registered pools "
+             "(e.g. KV caches) will be severely degraded; upgrade libfabric "
+             "to >= 2.5.";
+    }
     info_->tx_attr->op_flags |= FI_DELIVERY_COMPLETE;
     UCCL_LOG(INFO) << "CXI FI_DELIVERY_COMPLETE enabled";
 

--- a/p2p/cxi/fabric_dl.cc
+++ b/p2p/cxi/fabric_dl.cc
@@ -41,4 +41,10 @@ char const* fi_strerror(int errnum) {
   return fn(errnum);
 }
 
+uint32_t fi_version(void) {
+  using FnType = uint32_t (*)(void);
+  static FnType fn = reinterpret_cast<FnType>(fabric_resolve("fi_version"));
+  return fn();
+}
+
 }  // extern "C"


### PR DESCRIPTION
On libfabric 1.22, CXI RMA throughput collapses from ~20 GB/s to ~1.7 GB/s once a registered region exceeds ~1.5 GiB — measured in uccl-project/uccl#956 and gone on libfabric 2.5.x. 

The PR adds a warning for that version, since otherwise the bug can be hard to diagnose. 