### PR TITLE
p2p/cxi: fail closed on FI_EIO instead of retrying forever

### DIFF
--- a/p2p/cxi/cxi_endpoint.cc
+++ b/p2p/cxi/cxi_endpoint.cc
@@ -105,6 +105,35 @@ std::string cq_error_string(fid_cq* cq, fi_cq_err_entry const& err) {
   return fi_strerror(err.err);
 }
 
+// Drain and stringify any pending completion-queue error entries. Used to
+// attach provider-level detail (prov_errno, op_context, ...) to a failed RMA
+// post so hard failures like FI_EIO are diagnosable rather than opaque.
+std::string drain_cq_errors(fid_cq* cq) {
+  if (!cq) return "";
+
+  std::ostringstream os;
+  bool wrote = false;
+  for (int i = 0; i < 16; ++i) {
+    fi_cq_err_entry err{};
+    ssize_t rc = fi_cq_readerr(cq, &err, 0);
+    if (rc == -FI_EAGAIN || rc == 0) break;
+    if (rc < 0) {
+      if (wrote) os << "; ";
+      os << "fi_cq_readerr failed rc=" << rc << " " << fi_strerror(-rc);
+      break;
+    }
+    if (wrote) os << "; ";
+    wrote = true;
+    os << "cq_err[" << i << "] err=" << err.err << "(" << fi_strerror(err.err)
+       << ") prov_errno=" << err.prov_errno << " flags=0x" << std::hex
+       << err.flags << " len=0x" << err.len << " olen=0x" << err.olen
+       << " data=0x" << err.data << " op_context=0x"
+       << reinterpret_cast<uintptr_t>(err.op_context) << std::dec << " msg=\""
+       << cq_error_string(cq, err) << "\"";
+  }
+  return os.str();
+}
+
 }  // namespace
 
 CxiEndpoint::CxiEndpoint(int gpu_index, uint64_t port) : gpu_index_(gpu_index) {
@@ -586,6 +615,7 @@ int CxiEndpoint::post_rma(bool is_read, ConnID const& conn,
   uint64_t const remote_offset = fifo_item.addr - metadata.base;
 
   ssize_t rc;
+  std::string post_error_cq_errors;
   {
     std::lock_guard<std::mutex> fabric_lock(fabric_mutex_);
     if (is_read) {
@@ -596,10 +626,16 @@ int CxiEndpoint::post_rma(bool is_read, ConnID const& conn,
                     remote_offset, metadata.key, &op->ctx);
     }
 
-    if (rc == -FI_EAGAIN || rc == -FI_EIO) {
+    // FI_EAGAIN means the provider is momentarily out of posting resources;
+    // drive the CQ, yield, and let the caller retry. Any other non-zero rc
+    // (notably FI_EIO) is a hard failure: fall through and fail closed.
+    if (rc == -FI_EAGAIN) {
       poll_cq_locked();
       std::this_thread::yield();
       return UCCL_POST_TRANSIENT;
+    }
+    if (rc != 0) {
+      post_error_cq_errors = drain_cq_errors(cq_);
     }
   }
   if (rc != 0) {
@@ -612,7 +648,17 @@ int CxiEndpoint::post_rma(bool is_read, ConnID const& conn,
        << " remote_base=0x" << metadata.base << " remote_len=0x" << metadata.len
        << " remote_offset=0x" << remote_offset << " key=0x" << metadata.key
        << std::dec;
-    UCCL_LOG(ERROR) << os.str();
+    if (!post_error_cq_errors.empty()) {
+      os << " pending_cq_errors=[" << post_error_cq_errors << "]";
+    }
+    // FI_EIO indicates a fatal transport error (e.g. an unrecoverable link or
+    // memory-registration fault); crash loudly rather than limp on with a
+    // half-broken KV path.
+    if (rc == -FI_EIO) {
+      UCCL_LOG(FATAL) << os.str();
+    } else {
+      UCCL_LOG(ERROR) << os.str();
+    }
     return -1;
   }
 

--- a/p2p/cxi/cxi_endpoint.cc
+++ b/p2p/cxi/cxi_endpoint.cc
@@ -108,6 +108,9 @@ std::string cq_error_string(fid_cq* cq, fi_cq_err_entry const& err) {
 // Drain and stringify any pending completion-queue error entries. Used to
 // attach provider-level detail (prov_errno, op_context, ...) to a failed RMA
 // post so hard failures like FI_EIO are diagnosable rather than opaque.
+// Consumes the entries without marking their owning OpContexts failed, which
+// starves poll_cq_locked() of error completions for unrelated inflight ops —
+// only call this when the process is about to abort.
 std::string drain_cq_errors(fid_cq* cq) {
   if (!cq) return "";
 
@@ -634,7 +637,10 @@ int CxiEndpoint::post_rma(bool is_read, ConnID const& conn,
       std::this_thread::yield();
       return UCCL_POST_TRANSIENT;
     }
-    if (rc != 0) {
+    // Drain only on the fatal path (FI_EIO aborts below): draining consumes
+    // CQ error entries that may belong to other inflight ops, which would
+    // otherwise never be marked failed by poll_cq_locked().
+    if (rc == -FI_EIO) {
       post_error_cq_errors = drain_cq_errors(cq_);
     }
   }


### PR DESCRIPTION
## Problem

`CxiEndpoint::post_rma()` classified both `-FI_EAGAIN` and `-FI_EIO` as `UCCL_POST_TRANSIENT`. The engine's post-retry loop (`is_retryable_post_failure`) therefore spun on `FI_EIO` **indefinitely**. `FI_EIO` is a hard transport error, not a transient out-of-resources condition, so the retry never succeeded and never surfaced — no completion and no error ever reached NIXL, and KV transfers stalled forever in `WAITING_FOR_REMOTE_KVS`.

Observed as a decode-side hang in DeepSeek-V4 prefill/decode disaggregation over CXI: prefill healthy, decode stuck, no error line.

## Fix

- Only `-FI_EAGAIN` is treated as transient (drive CQ, yield, retry).
- Any other non-zero post result falls through to the failure path and logs `ERROR`.
- On `-FI_EIO` specifically, the CQ error queue is first drained (`drain_cq_errors`) for provider-level detail and the failure is logged `FATAL`. `UCCL_LOG(FATAL)` aborts the process — intentional: a fatal transport fault should fail-stop rather than continue with a half-broken KV path. The drain is confined to this about-to-abort path because it consumes CQ error entries that may belong to other inflight ops, which would otherwise never be marked failed by `poll_cq_locked()`.

Confined to `p2p/cxi/cxi_endpoint.cc`; no change needed in `engine.cc` (its `rc < 0` bail already fires once `post_rma` stops mislabelling `FI_EIO` as transient).
