### PR TITLE
  [EP] remove duplicate import and platform-specific print in bench/utils.py

### DIFF
--- a/ep/bench/utils.py
+++ b/ep/bench/utils.py
@@ -23,15 +23,6 @@ except ImportError as exc:
     sys.stderr.write("Failed to import uccl.ep\n")
     raise
 
-# import deep_ep as ep
-try:
-    from uccl import ep
-except ImportError as exc:
-    import sys
-
-    sys.stderr.write("Failed to import uccl.ep\n")
-    raise
-
 
 def calc_diff(x: torch.Tensor, y: torch.Tensor):
     x, y = x.double() + 1, y.double() + 1
@@ -60,7 +51,6 @@ def init_dist(local_rank: int, num_local_ranks: int):
         "world_size": world_size,
         "rank": node_rank,
     }
-    print(params)
     if "device_id" in sig.parameters:
         # noinspection PyTypeChecker
         params["device_id"] = torch.device(f"cuda:{local_rank}")


### PR DESCRIPTION
  Fixes #787.

  Two cleanups in `ep/bench/utils.py`:

  - Remove a duplicated `from uccl import ep` import block (lines 26–33 were identical to lines 17–24)
  - Drop the `print(params)` call in `init_dist()` that logged `{'backend': 'nccl', ...}` to stdout — this was misleading on AMD/ROCm environments where RCCL is the actual backend