### PR TITLE
ep: widen WriteImm EXPERT_IDX 9->10 bits (support >512 experts)

### DIFF
--- a/ep/include/rdma.hpp
+++ b/ep/include/rdma.hpp
@@ -216,26 +216,26 @@ class WriteImm {
   // Bit layout (bits [31:30] reserved = 0 for write type):
   //   [29]    IS_COMBINE   (1 bit)
   //   [28]    BUFFER_IDX   (1 bit)
-  //   [27:19] EXPERT_IDX   (9 bits, 0..511)
-  //   [18:6]  NUM_TOKENS   (13 bits, 0..8191)
+  //   [27:18] EXPERT_IDX   (10 bits, 0..1023)
+  //   [17:6]  NUM_TOKENS   (12 bits, 0..4095)
   //   [5:0]   RANK         (6 bits, 0..63)
   static constexpr int kRANK = 0;
   static constexpr int kNUM_TOKENS = 6;
-  static constexpr int kEXPERT_IDX = 19;
+  static constexpr int kEXPERT_IDX = 18;
   static constexpr int kBUFFER_IDX = 28;
   static constexpr int kIS_COMBINE = 29;
 
   // Masks
-  static constexpr uint32_t kRANK_MASK = 0x3Fu;      // 6 bits
-  static constexpr uint32_t kTOKENS_MASK = 0x1FFFu;  // 13 bits
-  static constexpr uint32_t kEXPERT_MASK = 0x1FFu;   // 9 bits
+  static constexpr uint32_t kRANK_MASK = 0x3Fu;     // 6 bits
+  static constexpr uint32_t kTOKENS_MASK = 0xFFFu;  // 12 bits
+  static constexpr uint32_t kEXPERT_MASK = 0x3FFu;  // 10 bits
 
   explicit WriteImm(uint32_t imm_data = 0) : imm_data_(imm_data) {}
 
   static WriteImm Pack(bool is_combine,
                        uint32_t buffer_idx,  // 0/1
-                       uint32_t expert_idx,  // 0..511  (9 bits)
-                       uint32_t num_tokens,  // 0..8191 (13 bits)
+                       uint32_t expert_idx,  // 0..1023 (10 bits)
+                       uint32_t num_tokens,  // 0..4095 (12 bits)
                        uint32_t my_rank) {   // 0..63   (6 bits)
     constexpr uint32_t kIS_COMBINE_MASK = 0x1u;
     constexpr uint32_t kBUFFER_IDX_MASK = 0x1u;
@@ -247,17 +247,18 @@ class WriteImm {
            "buffer_idx overflow (1 bit)");
     if ((expert_idx & ~kEXPERT_MASK) != 0) {
       fprintf(stderr,
-              "[RDMA ERROR] expert_idx=%u exceeds 9-bit limit (max 511)\n",
+              "[RDMA ERROR] expert_idx=%u exceeds 10-bit limit (max 1023)\n",
               expert_idx);
     }
-    assert((expert_idx & ~kEXPERT_MASK) == 0 && "expert_idx overflow (9 bits)");
+    assert((expert_idx & ~kEXPERT_MASK) == 0 &&
+           "expert_idx overflow (10 bits)");
     if ((num_tokens & ~kTOKENS_MASK) != 0) {
       fprintf(stderr,
-              "[RDMA ERROR] num_tokens=%u exceeds 13-bit limit (max 8191)\n",
+              "[RDMA ERROR] num_tokens=%u exceeds 12-bit limit (max 4095)\n",
               num_tokens);
     }
     assert((num_tokens & ~kTOKENS_MASK) == 0 &&
-           "num_tokens overflow (13 bits)");
+           "num_tokens overflow (12 bits)");
     if ((my_rank & ~kRANK_MASK) != 0) {
       fprintf(stderr, "[RDMA ERROR] my_rank=%u exceeds 6-bit limit (max 63)\n",
               my_rank);


### PR DESCRIPTION
## Description
`WriteImm` packs the routed expert index into the 32-bit RDMA immediate. The combine path carries the **global** expert index, so models with more than 512 routed experts abort in `Pack()`:

```
[RDMA ERROR] expert_idx=NNN exceeds 9-bit limit (max 511)
```

For example LongCat-2.0 has 768 routed experts (global idx 0..767), so any token routed to an expert `>= 512` crashes low-latency combine at startup.

This is also a **half-finished migration**: `ring_buffer.cuh` already uses a 10-bit expert field (`kLLExpertBits=10`, `unpack_ll_expert()` returns up to 1023), but `WriteImm` in `rdma.hpp` was never updated to match — `Pack()` masks the value with the 9-bit `kEXPERT_MASK` and asserts.

The write-type imm only has bits `[29:0]` (bits `[31:30]` are the atomics/ctrl type discriminator) and they were fully allocated. This PR steals one bit from `NUM_TOKENS` (13 -> 12 bits) and gives it to `EXPERT_IDX` (9 -> 10 bits):

```
[29] IS_COMBINE(1) [28] BUFFER_IDX(1) [27:18] EXPERT_IDX(10) [17:6] NUM_TOKENS(12) [5:0] RANK(6)
```

`NUM_TOKENS` in the imm is a per-`(expert, rank)` token count, bounded by `num_max_dispatch_tokens_per_rank` (asserted `<= 1024` by callers such as SGLang), so 12 bits (max 4095) keeps ~4x headroom; the old 13-bit width was unused capacity. Sender and receiver share this one header so both ends stay consistent. `EXPERT_IDX` now covers 0..1023.

Fixes # (no tracking issue)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

LongCat-2.0-FP8 (768 routed experts), tp16/ep16 across 2 nodes over EFA:
- **Before:** low-latency dispatch/combine aborts at startup with the 9-bit error.
- **After:** runs cleanly; decode with CUDA graph enabled (GPU util ~99%, TPOT ~51 ms vs ~277 ms in normal mode).

## Checklist
- [x] I have run `format.sh` to follow the style guidelines. (verified `clang-format-14 --dry-run --Werror ep/include/rdma.hpp` passes, matching the Clang Format Check CI)
- [ ] I have run `build.sh` to verify compilation. (built via the project's `setup.py build_ext` / `pip install .` in a cu13 + EFA image; `build.sh` not run directly)
- [x] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.


---

### Note on the NUM_TOKENS narrowing (13 -> 12 bits)

For reviewers wondering why `NUM_TOKENS` shrinks: the 32-bit RDMA immediate only
exposes bits `[29:0]` for the write type (bits `[31:30]` are the atomics/ctrl
discriminator), and they were fully allocated, so widening `EXPERT_IDX` requires
taking a bit from another field. `RANK` (6 bits / 64 ranks) is kept for multi-node
headroom, leaving `NUM_TOKENS` as the only donor.

**Relation to `ring_buffer.cuh`.** `EXPERT_IDX` was *already* 10 bits on the wire:
the LL slot packs `[9:0]=expert (10 bits)` (`kLLExpertBits=10`), and
`unpack_ll_expert()` returns up to 1023. `WriteImm` was simply never migrated to
match, so `Pack()` truncated the value with the 9-bit mask and asserted — this PR
finishes that migration. The LL slot encodes `num_tokens` as 13 bits across two
fields (`atomic_val` low 8 + slot `[14:10]` high 5), because it has a 24-bit budget
(16-bit slot + 8-bit `atomic_val`) with room to spare; the WriteImm has no such
spare bit in its 30-bit write-type imm.

**Why 12 bits is safe.** On the receive side `GetNumTokens()` is only used as a
counter increment (`dispatch_token_counter.Add(..., k)` /
`combine_token_counter.Add(..., k)`), never as an index or bitmask. The value is a
per-`(expert, rank)` token count bounded by `num_max_dispatch_tokens_per_rank`
(callers such as SGLang assert `<= 1024`), so 12 bits (max 4095) keeps ~4x
headroom, and the retained runtime check makes any overflow loud rather than a
silent truncation. The only change is that the WriteImm `num_tokens` ceiling
(4095) is now lower than the LL slot's 13-bit wire capacity (8191), which is
unused in practice.

**More conservative alternative (not taken).** Since the `IS_COMBINE` bit is
already in the imm and the dispatch path only needs a *local* expert index
(`num_experts / num_ranks`, e.g. 48 for LongCat — 6 bits), one could make the
`EXPERT_IDX` width conditional on `is_combine` and return the freed bit to
`NUM_TOKENS` on the dispatch path. That keeps the full 13-bit `num_tokens` but adds
mode-dependent packing/unpacking on both ends; I chose the simpler static layout
since the 12-bit ceiling is far above real usage. Happy to switch to the
conditional scheme if you prefer preserving the 13-bit width.
