### PR TITLE
[AMD] Gate CUDA-only CXI support in ROCm and TheRock builds

### DIFF
--- a/p2p/Makefile
+++ b/p2p/Makefile
@@ -23,6 +23,7 @@ LIBS = -L ${CUDA_HOME}/lib64 -lcudart -lcuda -lpthread -lz -lelf -ldl
 
 CXX := g++
 CXXFLAGS := -O3 -shared -std=c++17 -fPIC \
+	-DUCCL_ENABLE_CXI=1 \
 	-I. -I./util -I./rdma -I./rdma/providers -I./nccl -I../include -I$(CUDA_INC) \
 	-I$(EFA_HOME)/include -I$(LIBFABRIC_HOME)/include \
 	-MMD -MP \

--- a/p2p/endpoint_wrapper.h
+++ b/p2p/endpoint_wrapper.h
@@ -198,8 +198,10 @@ inline bool uccl_regmr(GenericEndpoint const& ep, void* data, size_t len,
           (void)len;
           (void)mhandle;
           return true;
+#if defined(UCCL_ENABLE_CXI)
         } else if constexpr (std::is_same_v<T, CxiEndpoint>) {
           return s->uccl_regmr(data, len, mhandle->cxi_region) >= 0;
+#endif
         } else {
           return s->uccl_regmr(data, len, mhandle->mr_array,
                                mhandle->cache_refs, mhandle->compress_ctx) >= 0;
@@ -334,10 +336,12 @@ inline int uccl_read_async(GenericEndpoint const& ep, Conn* conn,
               dst, size, nccl_item, &nreq);
           from_nccl_req(nreq, ureq);
           return ret;
+#if defined(UCCL_ENABLE_CXI)
         } else if constexpr (std::is_same_v<T, CxiEndpoint>) {
           ureq->type = ReqType::ReqRead;
           return s->uccl_read_async(conn->uccl_conn_id_, local_mh->cxi_region,
                                     dst, size, slot_item, ureq);
+#endif
         } else {
           ureq->type = ReqType::ReqRead;
           return set_request(s, conn, local_mh, dst, size, slot_item, ureq);
@@ -366,10 +370,12 @@ inline int uccl_write_async(GenericEndpoint const& ep, Conn* conn,
               src, size, nccl_item, &nreq);
           from_nccl_req(nreq, ureq);
           return ret;
+#if defined(UCCL_ENABLE_CXI)
         } else if constexpr (std::is_same_v<T, CxiEndpoint>) {
           ureq->type = ReqType::ReqWrite;
           return s->uccl_write_async(conn->uccl_conn_id_, local_mh->cxi_region,
                                      src, size, slot_item, ureq);
+#endif
         } else {
           ureq->type = ReqType::ReqWrite;
           return set_request(s, conn, local_mh, src, size, slot_item, ureq);
@@ -407,6 +413,7 @@ inline int prepare_fifo_metadata(GenericEndpoint const& ep, P2PMhandle* mhandle,
           (void)mhandle;
           return s->prepare_fifo_metadata(nullptr, nullptr, data, size,
                                           out_buf);
+#if defined(UCCL_ENABLE_CXI)
         } else if constexpr (std::is_same_v<T, CxiEndpoint>) {
           (void)s;
           if (!mhandle->cxi_region) return -1;
@@ -420,6 +427,7 @@ inline int prepare_fifo_metadata(GenericEndpoint const& ep, P2PMhandle* mhandle,
           encode_cxi_fifo_metadata(*mhandle->cxi_region, remote_mem_info);
           serialize_fifo_item(remote_mem_info, out_buf);
           return 0;
+#endif
         } else {
           FifoItem remote_mem_info;
           remote_mem_info.addr = reinterpret_cast<uint64_t>(data);
@@ -440,8 +448,10 @@ inline void uccl_deregmr(GenericEndpoint const& ep, P2PMhandle* mhandle) {
         using T = std::decay_t<decltype(*s)>;
         if constexpr (std::is_same_v<T, NCCLEndpoint>) {
           (void)mhandle;
+#if defined(UCCL_ENABLE_CXI)
         } else if constexpr (std::is_same_v<T, CxiEndpoint>) {
           s->uccl_deregmr(mhandle->cxi_region);
+#endif
         } else {
           s->uccl_deregmr(mhandle->cache_refs);
         }

--- a/p2p/engine.cc
+++ b/p2p/engine.cc
@@ -248,9 +248,11 @@ Endpoint::Endpoint(uint32_t const gpu_idx) : passive_accept_(false) {
   if (is_nccl_transport()) {
     ep_ = std::make_shared<NCCLEndpoint>(local_gpu_idx_, 0);
     numa_node_ = get_numa_node_from_iface();
+#if defined(UCCL_ENABLE_CXI)
   } else if (is_cxi_transport()) {
     ep_ = std::make_shared<CxiEndpoint>(local_gpu_idx_, 0);
     numa_node_ = get_numa_node_from_iface();
+#endif
   } else {
     ep_ = std::shared_ptr<RDMAEndpoint>(new RDMAEndpoint(local_gpu_idx_, 0));
   }
@@ -324,8 +326,10 @@ Endpoint::Endpoint() : local_gpu_idx_(INVALID_GPU), passive_accept_(false) {
 
   if (is_nccl_transport()) {
     ep_ = std::make_shared<NCCLEndpoint>(local_gpu_idx_, 0);
+#if defined(UCCL_ENABLE_CXI)
   } else if (is_cxi_transport()) {
     ep_ = std::make_shared<CxiEndpoint>(INVALID_GPU, 0);
+#endif
   } else {
     ep_ = std::shared_ptr<RDMAEndpoint>(new RDMAEndpoint(INVALID_GPU, 0));
   }
@@ -2162,11 +2166,13 @@ int Endpoint::send_notification(uint64_t conn_id,
     if (!nccl_ep || !*nccl_ep) return -1;
     return (*nccl_ep)->send_notification(peer_id, notification);
   }
+#if defined(UCCL_ENABLE_CXI)
   if (is_cxi_transport()) {
     auto* cxi_ep = std::get_if<std::shared_ptr<CxiEndpoint>>(&ep_);
     if (!cxi_ep || !*cxi_ep) return -1;
     return (*cxi_ep)->send_notification(peer_id, notification);
   }
+#endif
   return -1;
 }
 

--- a/p2p/engine.h
+++ b/p2p/engine.h
@@ -2,7 +2,9 @@
 
 #include "adaptive_sleeper.h"
 #include "common.h"
+#if defined(UCCL_ENABLE_CXI)
 #include "cxi/cxi_endpoint.h"
+#endif
 #include "nccl_endpoint.h"
 #include "rdma_endpoint.h"
 #include "transport_type.h"
@@ -28,9 +30,14 @@
 extern thread_local bool inside_python;
 
 // Runtime-polymorphic endpoint.
+#if defined(UCCL_ENABLE_CXI)
 using GenericEndpoint =
     std::variant<std::shared_ptr<RDMAEndpoint>, std::shared_ptr<NCCLEndpoint>,
                  std::shared_ptr<CxiEndpoint>>;
+#else
+using GenericEndpoint =
+    std::variant<std::shared_ptr<RDMAEndpoint>, std::shared_ptr<NCCLEndpoint>>;
+#endif
 
 // Use the RDMA-native request types as the common currency.
 // The NCCL shim functions in endpoint_wrapper.h convert as needed.
@@ -50,7 +57,9 @@ struct P2PMhandle {
   MRArray mr_array;
   CompressCtx compress_ctx;
   std::vector<MrCacheHandleRef> cache_refs;
+#if defined(UCCL_ENABLE_CXI)
   std::shared_ptr<CxiMemoryRegion> cxi_region;
+#endif
 };
 
 struct MR {

--- a/p2p/util/transport_type.h
+++ b/p2p/util/transport_type.h
@@ -4,6 +4,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <stdexcept>
 
 enum class TransportType { RDMA, NCCL, EFA, CXI };
 
@@ -15,7 +16,14 @@ inline TransportType get_transport_type() {
         std::strcmp(env, "tcpx") == 0)
       return TransportType::NCCL;
     if (std::strcmp(env, "efa") == 0) return TransportType::EFA;
-    if (std::strcmp(env, "cxi") == 0) return TransportType::CXI;
+    if (std::strcmp(env, "cxi") == 0) {
+#if defined(UCCL_ENABLE_CXI)
+      return TransportType::CXI;
+#else
+      throw std::runtime_error(
+          "UCCL_P2P_TRANSPORT=cxi requested, but CXI support was not compiled");
+#endif
+    }
     return TransportType::RDMA;
   }();
   return t;


### PR DESCRIPTION
## Description

ROCm and TheRock P2P builds fail because shared engine code unconditionally includes the CUDA-only CXI transport, which requires `cuda_runtime_api.h`. This change enables CXI only for CUDA builds while allowing ROCm/TheRock builds to compile without CXI and reporting a clear error if the unsupported transport is requested.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
