### PR TITLE
[CI] Set NCCL_SOCKET_IFNAME for GH200 EP latency test

### DIFF
--- a/.github/workflows/uccl-build-test-gh200.yml
+++ b/.github/workflows/uccl-build-test-gh200.yml
@@ -190,6 +190,7 @@ jobs:
             cd /home/${{secrets.UCCL_GH200_USER}}/nfs/uccl-ci-sandbox/ep
 
             export UCCL_SOCKET_IFNAME=enx3c18a0d51943
+            export NCCL_SOCKET_IFNAME=enx3c18a0d51943
             /home/${{secrets.UCCL_GH200_USER}}/nfs/miniconda3/envs/uccl-ci-sandbox/bin/torchrun   --nnodes=2 --nproc_per_node=1   --node_rank=0   --master_addr=${{secrets.UCCL_GH200_HOST0}} --master_port=29501   bench/test_low_latency.py   --num-tokens=32 --hidden=7168 --num-topk=8 --num-experts=16
           EOF
           PID_SERVER=$!
@@ -212,6 +213,7 @@ jobs:
 
             cd /home/${{secrets.UCCL_GH200_USER}}/nfs/uccl-ci-sandbox/ep
             export UCCL_SOCKET_IFNAME=enxc8a36290119d
+            export NCCL_SOCKET_IFNAME=enxc8a36290119d
 
             /home/${{secrets.UCCL_GH200_USER}}/nfs/miniconda3/envs/uccl-ci-sandbox/bin/torchrun --nnodes=2 --nproc_per_node=1   --node_rank=1   --master_addr=${{secrets.UCCL_GH200_HOST0}} --master_port=29501   bench/test_low_latency.py   --num-tokens=32 --hidden=7168 --num-topk=8 --num-experts=16
           EOF


### PR DESCRIPTION
Without this, NCCL bootstrap picks the 169.254.3.1 link-local NIC and the 2-node test fails with Connection refused.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
