### PR TITLE
[AMD] Fix HIP pointer attributes for ROCm and DTK

### DIFF
--- a/include/util/gpu_rt.h
+++ b/include/util/gpu_rt.h
@@ -278,7 +278,11 @@ typedef int gpuMemRangeHandleType;
 #define gpuPointerGetAttributes hipPointerGetAttributes
 #define gpuMemoryTypeDevice hipMemoryTypeDevice
 #define gpuMemoryTypeManaged hipMemoryTypeManaged
+#ifdef __UCCL_DTK__
 #define gpuMemTypeOf(a) (a).memoryType
+#else
+#define gpuMemTypeOf(a) (a).type
+#endif
 #define GPU_DRIVER_LIB_NAME "libamdhip64.so"
 #define GPU_DRIVER_LIB_NAME_FALLBACK "libamdhip64.so"
 #define gpuMemGetAddressRange hipMemGetAddressRange

--- a/include/util/util.h
+++ b/include/util/util.h
@@ -1203,8 +1203,7 @@ inline int get_dev_idx(void* ptr) {
   hipPointerAttribute_t attributes;
   hipError_t err = hipPointerGetAttributes(&attributes, ptr);
   if (err == hipSuccess) {
-    // DTK/HIP exposes the memory type as .memoryType (not .type).
-    if (attributes.memoryType == hipMemoryTypeDevice) {
+    if (gpuMemTypeOf(attributes) == hipMemoryTypeDevice) {
       return attributes.device;
     }
     return -1;


### PR DESCRIPTION
## Description

Fix ROCm builds by using `hipPointerAttribute_t.type` while preserving DTK’s `memoryType` field behind `__UCCL_DTK__`. Update `get_dev_idx()` to use the shared GPU runtime abstraction.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

Successfully compiled the three sources that failed in TheRock CI:

```bash
make -f Makefile.rocm transport.o eqds.o rdma_io.o
```

Also verified `gpuMemTypeOf()` compiles against ROCm HIP headers.

## Checklist

- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
