### PR TITLE
Fix auditwheel repair for CUDA 13 EP wheels

### DIFF
--- a/build_inner.sh
+++ b/build_inner.sh
@@ -366,7 +366,9 @@ auditwheel repair dist/uccl-*.whl \
   --exclude "libtorch*.so" \
   --exclude "libc10*.so" \
   --exclude "libibverbs.so.1" \
+  --exclude "libnuma.so.1" \
   --exclude "libcudart.so.12" \
+  --exclude "libcudart.so.13" \
   --exclude "libamdhip64.so.*" \
   --exclude "libcuda.so.1" \
   --exclude "libefa.so.1" \


### PR DESCRIPTION
Exclude libcudart.so.13 and libnuma.so.1 from auditwheel repair so they remain external runtime dependencies. This avoids inconsistent ELF metadata where DT_NEEDED references the public soname while version-needs references auditwheel-renamed hashed libraries, which can trigger ld.so assertions when importing uccl.ep from an installed wheel.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
