### PR TITLE
[p2p] lkey bug && make MR key accessors explicit

### DIFF
--- a/p2p/endpoint_wrapper.h
+++ b/p2p/endpoint_wrapper.h
@@ -421,7 +421,7 @@ inline int prepare_fifo_metadata(GenericEndpoint const& ep, P2PMhandle* mhandle,
           serialize_fifo_item(remote_mem_info, out_buf);
           return 0;
         } else {
-          FifoItem remote_mem_info;
+          FifoItem remote_mem_info{};
           remote_mem_info.addr = reinterpret_cast<uint64_t>(data);
           remote_mem_info.size = size;
           copy_rkeys_from_mr_array_to_bytes(

--- a/p2p/rdma/rdma_connection.cc
+++ b/p2p/rdma/rdma_connection.cc
@@ -657,7 +657,7 @@ int64_t SendConnection::compress_write_request_split_first(
   uint32_t total_uncomp = req->local_mem->size;
   uint64_t user_remote_addr = req->remote_mem->addr;
   uint32_t user_remote_rkey =
-      req->remote_mem->get_key_by_context_id(0);  // diagnostic / logging only
+      req->remote_mem->get_rkey_by_context_id(0);  // diagnostic / logging only
 
   // Reserve space in the peer's decompress_buffer; released on ack receipt.
   uint64_t arena_bytes = static_cast<uint64_t>(total_uncomp);
@@ -916,7 +916,7 @@ void RecvConnection::handle_compressed_write_arrival(WriteReqMeta const& m) {
   // acked".
   ctrl_channel_->post_ack_write(
       remote_ack_ring_.addr + m.ack_slot * sizeof(AckSlot),
-      remote_ack_ring_.get_key_by_context_id(0), m.ack_slot,
+      remote_ack_ring_.get_rkey_by_context_id(0), m.ack_slot,
       static_cast<uint64_t>(m.wr_id) + 1);
 
   Compressor::get_instance().decompress_async(

--- a/p2p/util/common.cc
+++ b/p2p/util/common.cc
@@ -167,14 +167,24 @@ struct ibv_mr* RegMemBlock::get_mr_by_context_id(uint32_t context_id) const {
   return mr_array.get_key_by_context_id(context_id);
 }
 
-uint32_t RegMemBlock::get_key_by_channel_id(uint32_t channel_id) const {
+uint32_t RegMemBlock::get_rkey_by_channel_id(uint32_t channel_id) const {
   struct ibv_mr* mr = get_mr_by_channel_id(channel_id);
   return mr ? mr->rkey : 0;
 }
 
-uint32_t RegMemBlock::get_key_by_context_id(uint32_t context_id) const {
+uint32_t RegMemBlock::get_lkey_by_channel_id(uint32_t channel_id) const {
+  struct ibv_mr* mr = get_mr_by_channel_id(channel_id);
+  return mr ? mr->lkey : 0;
+}
+
+uint32_t RegMemBlock::get_rkey_by_context_id(uint32_t context_id) const {
   struct ibv_mr* mr = get_mr_by_context_id(context_id);
   return mr ? mr->rkey : 0;
+}
+
+uint32_t RegMemBlock::get_lkey_by_context_id(uint32_t context_id) const {
+  struct ibv_mr* mr = get_mr_by_context_id(context_id);
+  return mr ? mr->lkey : 0;
 }
 
 std::ostream& operator<<(std::ostream& os, RegMemBlock const& block) {
@@ -214,11 +224,11 @@ RemoteMemInfo::RemoteMemInfo(std::shared_ptr<RegMemBlock> const block)
   copy_rkey_array_from_mr_array(block->mr_array, rkey_array);
 }
 
-uint32_t RemoteMemInfo::get_key_by_channel_id(uint32_t channel_id) const {
+uint32_t RemoteMemInfo::get_rkey_by_channel_id(uint32_t channel_id) const {
   return rkey_array.get_key_by_channel_id(channel_id);
 }
 
-uint32_t RemoteMemInfo::get_key_by_context_id(size_t context_id) const {
+uint32_t RemoteMemInfo::get_rkey_by_context_id(size_t context_id) const {
   return rkey_array.get_key_by_context_id(context_id);
 }
 
@@ -255,11 +265,11 @@ RDMASendRequest::RDMASendRequest(RDMASendRequest const& other,
       need_signaled(signaled) {}
 
 uint32_t RDMASendRequest::get_local_key() const {
-  return local_mem->get_key_by_channel_id(channel_id);
+  return local_mem->get_lkey_by_channel_id(channel_id);
 }
 
 uint32_t RDMASendRequest::get_remote_key() const {
-  return remote_mem->get_key_by_channel_id(channel_id);
+  return remote_mem->get_rkey_by_channel_id(channel_id);
 }
 
 uint64_t RDMASendRequest::get_local_address() const {

--- a/p2p/util/common.h
+++ b/p2p/util/common.h
@@ -405,11 +405,17 @@ typedef struct RegMemBlock {
   // Get MR by context ID
   struct ibv_mr* get_mr_by_context_id(uint32_t context_id) const;
 
-  // Get rkey by channel ID (for backward compatibility)
-  uint32_t get_key_by_channel_id(uint32_t channel_id) const;
+  // Get rkey by channel ID (for remote RDMA access)
+  uint32_t get_rkey_by_channel_id(uint32_t channel_id) const;
 
-  // Get rkey by context ID (for backward compatibility)
-  uint32_t get_key_by_context_id(uint32_t context_id) const;
+  // Get rkey by context ID (for remote RDMA access)
+  uint32_t get_rkey_by_context_id(uint32_t context_id) const;
+
+  // Get lkey by channel ID (for local SGE access, e.g. one-sided read dst)
+  uint32_t get_lkey_by_channel_id(uint32_t channel_id) const;
+
+  // Get lkey by context ID (for local SGE access)
+  uint32_t get_lkey_by_context_id(uint32_t context_id) const;
 
   friend std::ostream& operator<<(std::ostream& os, RegMemBlock const& block);
 } RegMemBlock;
@@ -428,10 +434,11 @@ typedef struct RemoteMemInfo {
 
   RemoteMemInfo(std::shared_ptr<RegMemBlock> const block);
 
-  uint32_t get_key_by_channel_id(uint32_t channel_id) const;
+  // Remote memory only carries rkeys (lkey stays local to the owner).
+  uint32_t get_rkey_by_channel_id(uint32_t channel_id) const;
 
   // Get rkey by context ID (direct index access)
-  uint32_t get_key_by_context_id(size_t context_id) const;
+  uint32_t get_rkey_by_context_id(size_t context_id) const;
 
   friend std::ostream& operator<<(std::ostream& os, RemoteMemInfo const& info);
 } RemoteMemInfo;


### PR DESCRIPTION
## Description
Local SGE entries must reference the memory region's lkey, but RDMASendRequest::get_local_key() was returning the rkey. This only worked on hardware where the lkey and rkey happen to match; on stricter implementations it would surface as a local protection error. Fix the SGE path to use the lkey, and split the ambiguous get_key_by_* accessors into explicit get_lkey_by_* / get_rkey_by_* pairs (with RemoteMemInfo renamed to get_rkey_by_*) so the two keys can't be mixed up again.

Fixes # (issue)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [x] Unit tests
- [x] Integration tests
- [x] Manual testing

## Checklist
- [x] I have run `format.sh` to follow the style guidelines.
- [x] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
