### PR TITLE
[CI] Skip CXI apt install when libfabric/hwloc are already present

### DIFF
--- a/.github/workflows/install_cxi_apt_deps.sh
+++ b/.github/workflows/install_cxi_apt_deps.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install libfabric-dev and libhwloc-dev only when they are missing.
+# Skips apt-get entirely when the packages or their headers are already
+# present, so a full disk or a broken apt index does not fail CI.
+#
+# Optional env:
+#   UCCL_SUDO_PASSWORD  If set, pipe it to `sudo -S`. Otherwise use `sudo -n`.
+
+set -euo pipefail
+
+PKGS=(libfabric-dev libhwloc-dev)
+
+sudo_run() {
+  if [ -n "${UCCL_SUDO_PASSWORD:-}" ]; then
+    printf '%s\n' "${UCCL_SUDO_PASSWORD}" | sudo -S -p '' "$@"
+  else
+    sudo -n "$@"
+  fi
+}
+
+pkg_installed() {
+  dpkg-query -W -f='${Status}\n' "$1" 2>/dev/null | grep -q '^install ok installed$'
+}
+
+headers_present() {
+  [ -e /usr/include/rdma/fabric.h ] && [ -e /usr/include/hwloc.h ]
+}
+
+missing=()
+for pkg in "${PKGS[@]}"; do
+  if pkg_installed "$pkg"; then
+    echo "${pkg} already installed"
+  else
+    missing+=("$pkg")
+  fi
+done
+
+if [ "${#missing[@]}" -eq 0 ] || headers_present; then
+  if [ "${#missing[@]}" -ne 0 ]; then
+    echo "CXI headers already present; skipping apt-get for: ${missing[*]}"
+  else
+    echo "CXI apt deps already present; skipping apt-get"
+  fi
+  exit 0
+fi
+
+echo "Installing missing CXI apt deps: ${missing[*]}"
+sudo_run apt-get update
+sudo_run apt-get install -y "${missing[@]}"

--- a/.github/workflows/uccl-build-l4.yml
+++ b/.github/workflows/uccl-build-l4.yml
@@ -111,11 +111,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ssh -o BatchMode=yes l4-sky-test-01 bash -s << 'EOF'
-            set -euo pipefail
-            sudo -n apt-get update
-            sudo -n apt-get install -y libfabric-dev libhwloc-dev
-          EOF
+          ssh -o BatchMode=yes l4-sky-test-01 bash -s \
+            < .github/workflows/install_cxi_apt_deps.sh
 
       - name: Sync PR code to remote
         shell: bash

--- a/.github/workflows/uccl-build-test-amd-zip.yml
+++ b/.github/workflows/uccl-build-test-amd-zip.yml
@@ -134,11 +134,8 @@ jobs:
         run: |
           set -euo pipefail
           for host in amd0 amd1; do
-            ssh -o BatchMode=yes "$host" bash --norc --noprofile << 'EOF'
-              set -euo pipefail
-              sudo -n apt-get update
-              sudo -n apt-get install -y libfabric-dev libhwloc-dev
-          EOF
+            ssh -o BatchMode=yes "$host" bash --norc --noprofile -s \
+              < .github/workflows/install_cxi_apt_deps.sh
           done
 
       - name: Detect shared NFS between hosts

--- a/.github/workflows/uccl-build-test-amd.yml
+++ b/.github/workflows/uccl-build-test-amd.yml
@@ -132,11 +132,8 @@ jobs:
         run: |
           set -euo pipefail
           for host in amd0 amd1; do
-            ssh -o BatchMode=yes "$host" bash --norc --noprofile << 'EOF'
-              set -euo pipefail
-              sudo -n apt-get update
-              sudo -n apt-get install -y libfabric-dev libhwloc-dev
-          EOF
+            ssh -o BatchMode=yes "$host" bash --norc --noprofile -s \
+              < .github/workflows/install_cxi_apt_deps.sh
           done
 
       - name: Detect shared NFS between hosts

--- a/.github/workflows/uccl-build-test-gb10.yml
+++ b/.github/workflows/uccl-build-test-gb10.yml
@@ -137,11 +137,8 @@ jobs:
         run: |
           set -euo pipefail
           for host in spark0 spark1; do
-            ssh -o BatchMode=yes "$host" bash -s << 'EOF'
-              set -euo pipefail
-              sudo -n apt-get update
-              sudo -n apt-get install -y libfabric-dev libhwloc-dev
-          EOF
+            ssh -o BatchMode=yes "$host" bash -s \
+              < .github/workflows/install_cxi_apt_deps.sh
           done
 
       - name: Sync pushed code to gb10

--- a/.github/workflows/uccl-build-test-gh200.yml
+++ b/.github/workflows/uccl-build-test-gh200.yml
@@ -122,12 +122,10 @@ jobs:
           set -euo pipefail
           passwd_b64="$(printf '%s' "$UCCL_GH200_PASSWD" | base64 -w0)"
           for host in gh0 gh1; do
-            ssh -o BatchMode=yes "$host" bash -s << EOF
-              set -euo pipefail
-              UCCL_GH200_PASSWD="\$(printf '%s' "${passwd_b64}" | base64 -d)"
-              printf '%s\n' "\${UCCL_GH200_PASSWD}" | sudo -S -p '' apt-get update
-              printf '%s\n' "\${UCCL_GH200_PASSWD}" | sudo -S -p '' apt-get install -y libfabric-dev libhwloc-dev
-          EOF
+            {
+              echo "export UCCL_SUDO_PASSWORD=\"\$(printf '%s' '${passwd_b64}' | base64 -d)\""
+              cat .github/workflows/install_cxi_apt_deps.sh
+            } | ssh -o BatchMode=yes "$host" bash -s
           done
 
       - name: Sync pushed code to gh200


### PR DESCRIPTION
L4 failed apt-get update with ENOSPC. Detect installed packages or headers and skip apt entirely so a full disk or broken index does not fail the job.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
