### PR TITLE
[EP] Accept vLLM enable_shrink compatibility argument

### DIFF
--- a/ep/bench/buffer.py
+++ b/ep/bench/buffer.py
@@ -83,6 +83,7 @@ class Buffer:
         allow_nvlink_for_low_latency_mode: bool = True,
         allow_mnnvl: bool = False,
         explicitly_destroy: bool = False,
+        enable_shrink: bool = False,
         is_intranode: Optional[bool] = None,
     ) -> None:
         """
@@ -103,9 +104,15 @@ class Buffer:
             explicitly_destroy: If this flag is set to True, you need to explicitly call `destroy()` to release resources;
                 otherwise, the resources will be released by the destructor.
                 Note: Releasing resources in the destructor may cause Python's exception handling process to hang.
+            enable_shrink: whether to enable shrink mode. UCCL EP does not currently support shrink mode.
             is_intranode: whether to force intranode-only proxy mode. If set to `None`, infer it from the
                 process-group topology automatically. Explicit `True` is rejected when the group spans multiple nodes.
         """
+        if enable_shrink:
+            raise NotImplementedError(
+                "UCCL EP does not currently support enable_shrink=True"
+            )
+
         if "LOCAL_RANK" in os.environ:
             device_index = int(os.environ["LOCAL_RANK"])
         else:

--- a/ep/deep_ep_wrapper/tests/test_buffer_compatibility.py
+++ b/ep/deep_ep_wrapper/tests/test_buffer_compatibility.py
@@ -6,6 +6,25 @@ from types import ModuleType
 import pytest
 
 
+@pytest.fixture
+def isolated_deep_ep_import(monkeypatch):
+    def is_deep_ep_module(name):
+        return name == "deep_ep" or name.startswith("deep_ep.")
+
+    previous_modules = {
+        name: module for name, module in sys.modules.items() if is_deep_ep_module(name)
+    }
+    for name in previous_modules:
+        sys.modules.pop(name)
+
+    yield monkeypatch
+
+    for name in list(sys.modules):
+        if is_deep_ep_module(name):
+            sys.modules.pop(name)
+    sys.modules.update(previous_modules)
+
+
 class _StubTorch(ModuleType):
     def __getattr__(self, name):
         placeholder = type(name, (), {})
@@ -45,7 +64,9 @@ def _load_deep_ep_wrapper(monkeypatch, current_device):
     return importlib.import_module("deep_ep"), torch.cuda
 
 
-def test_enable_shrink_compatibility(monkeypatch):
+def test_enable_shrink_compatibility(isolated_deep_ep_import):
+    monkeypatch = isolated_deep_ep_import
+
     def fail_if_cuda_is_queried():
         raise AssertionError("enable_shrink=True reached CUDA initialization")
 

--- a/ep/deep_ep_wrapper/tests/test_buffer_compatibility.py
+++ b/ep/deep_ep_wrapper/tests/test_buffer_compatibility.py
@@ -1,0 +1,69 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+class _StubTorch(ModuleType):
+    def __getattr__(self, name):
+        placeholder = type(name, (), {})
+        setattr(self, name, placeholder)
+        return placeholder
+
+
+def _load_deep_ep_wrapper(monkeypatch, current_device):
+    torch = _StubTorch("torch")
+    torch.cuda = ModuleType("torch.cuda")
+    torch.cuda.current_device = current_device
+
+    torch_dist = ModuleType("torch.distributed")
+    torch_dist.ProcessGroup = type("ProcessGroup", (), {})
+    torch.distributed = torch_dist
+
+    uccl = ModuleType("uccl")
+    uccl_ep = ModuleType("uccl.ep")
+    uccl_ep.Config = type("Config", (), {})
+    uccl_ep.EventHandle = type("EventHandle", (), {})
+    uccl.ep = uccl_ep
+
+    wrapper_utils = ModuleType("deep_ep.utils")
+    wrapper_utils.EventOverlap = type("EventOverlap", (), {})
+    wrapper_utils.check_nvlink_connections = lambda *args, **kwargs: None
+    wrapper_utils.initialize_uccl = lambda *args, **kwargs: None
+    wrapper_utils.destroy_uccl = lambda *args, **kwargs: None
+    wrapper_utils._fp8_e4m3_dtype = object()
+
+    monkeypatch.setitem(sys.modules, "torch", torch)
+    monkeypatch.setitem(sys.modules, "torch.distributed", torch_dist)
+    monkeypatch.setitem(sys.modules, "uccl", uccl)
+    monkeypatch.setitem(sys.modules, "uccl.ep", uccl_ep)
+    monkeypatch.setitem(sys.modules, "deep_ep.utils", wrapper_utils)
+    monkeypatch.syspath_prepend(str(Path(__file__).parents[1]))
+
+    return importlib.import_module("deep_ep"), torch.cuda
+
+
+def test_enable_shrink_compatibility(monkeypatch):
+    def fail_if_cuda_is_queried():
+        raise AssertionError("enable_shrink=True reached CUDA initialization")
+
+    deep_ep, cuda = _load_deep_ep_wrapper(monkeypatch, fail_if_cuda_is_queried)
+    monkeypatch.delenv("LOCAL_RANK", raising=False)
+
+    with pytest.raises(
+        NotImplementedError,
+        match="UCCL EP does not currently support enable_shrink=True",
+    ):
+        deep_ep.Buffer(group=object(), enable_shrink=True)
+
+    class ReachedNormalInitialization(Exception):
+        pass
+
+    def mark_normal_initialization():
+        raise ReachedNormalInitialization
+
+    cuda.current_device = mark_normal_initialization
+    with pytest.raises(ReachedNormalInitialization):
+        deep_ep.Buffer(group=object(), enable_shrink=False)


### PR DESCRIPTION
## Description

vLLM v0.28 always passes `enable_shrink` when it constructs a `deep_ep.Buffer`, including the ordinary `False` case. Accept that keyword at the same constructor position as DeepEP so the UCCL wrapper remains drop-in compatible. `False` follows the existing initialization path; `True` fails before any CUDA query or resource allocation because rank shrinking is not implemented by UCCL EP yet.

Fixes #1042

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
- [x] Unit tests: `uv run --isolated --no-project --python 3.10 --with pytest --with black pytest -q ep/deep_ep_wrapper/tests/test_buffer_compatibility.py`
- [ ] Integration tests
- [ ] Manual testing

The regression test imports the public `deep_ep.Buffer` wrapper with CPU-only stubs, verifies `enable_shrink=True` is rejected before CUDA initialization, and verifies `enable_shrink=False` reaches the unchanged initialization path. It restores imported `deep_ep` modules afterward so the stubs cannot affect later tests in the same process.

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [x] I have removed redundant variables and comments.
- [x] I have updated the constructor documentation.
- [x] I have added tests.

Additional checks: Black left both changed Python files unchanged; Python 3.10 `compileall`, same-process module-isolation verification, and `git diff --check` passed.
