### PR TITLE
[EP] Add optional dedicated NIC-per-GPU mapping

### DIFF
--- a/ep/README.md
+++ b/ep/README.md
@@ -134,6 +134,7 @@ Notes:
 | UCCL_IB_MAX_INFLIGHT_BYTES | Max inflight bytes per GPU/NIC | SIZE_MAX (no limit) |
 | UCCL_IB_MAX_INFLIGHT_NORMAL | Max inflight writes per GPU/NIC in HT | 8 |
 | UCCL_IB_MAX_INFLIGHT_LOW_LATENCY | Max inflight writes per GPU/NIC in LL | 32 |
+| UCCL_EP_DEDICATED_NIC_PER_GPU | Assign all proxy threads for each GPU to one of its closest NICs, selected by physical GPU rank | 0 |
 | UCCL_IB_SL | Service level in RDMA network | 3/8 (IB/EFA) |
 | UCCL_IB_TC | Traffic class in RDMA network | 104/0 (IB/EFA) |
 | UCCL_EP_ENABLE_AGGRESSIVE_ATOMIC | Use relaxed atomics with manual `s_waitcnt vmcnt(0)` fences instead of acquire/release semantics. Required on AMD CDNA so the combine receiver actually sees the producer's tail-pointer updates over XGMI; without it the kernel deadlocks at scale. | 1 on AMD, 0 on CUDA |

--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -393,6 +393,11 @@ char const* rdma_hca_filter_from_env() {
   return ib_hca;
 }
 
+bool dedicated_nic_per_gpu_enabled() {
+  char const* env = getenv("UCCL_EP_DEDICATED_NIC_PER_GPU");
+  return env && std::atoi(env) != 0;
+}
+
 bool rdma_device_matches_filter(char const* name, int port,
                                 char const* ib_hca) {
   struct uccl::ib_dev user_ib_ifs[MAX_IB_DEVS];
@@ -568,6 +573,12 @@ void per_thread_rdma_init(ProxyCtx& S, void* gpu_buf, size_t bytes, int rank,
         use_ll_sl = true;
       }
 #endif
+      if (dedicated_nic_per_gpu_enabled()) {
+        auto const& dedicated_candidates =
+            numa_candidates.empty() ? candidates : numa_candidates;
+        selected_nic_name = dedicated_candidates[nic_affinity_rank %
+                                                 dedicated_candidates.size()];
+      }
     }
   }
 


### PR DESCRIPTION
Add UCCL_EP_DEDICATED_NIC_PER_GPU to assign all proxy threads for each GPU to one topology-local NIC while preserving multi-rail as the default. Document the new environment variable.

## Description
Please include a summary of the changes and the related issue.

Fixes # (issue)

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## How Has This Been Tested?
Include any tests here. 
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist
- [ ] I have run `format.sh` to follow the style guidelines.
- [ ] I have run `build.sh` to verify compilation.
- [ ] I have removed redundant variables and comments.
- [ ] I have updated the documentation.
- [ ] I have added tests.
