### PR TITLE
[EP] Honor GRH-required InfiniBand ports

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -62,6 +62,21 @@ jobs:
 
         clang-format --dry-run --Werror "${FILES[@]}"
 
+  rdma-addressing-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install RDMA headers
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libibverbs-dev
+
+    - name: Test RDMA address-vector construction
+      run: make -C ep/tests test HOST_TEST_INCLUDES=-I../include
+
   python-format-check:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -62,21 +62,6 @@ jobs:
 
         clang-format --dry-run --Werror "${FILES[@]}"
 
-  rdma-addressing-test:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Install RDMA headers
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libibverbs-dev
-
-    - name: Test RDMA address-vector construction
-      run: make -C ep/tests test HOST_TEST_INCLUDES=-I../include
-
   python-format-check:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ep-host-tests.yml
+++ b/.github/workflows/ep-host-tests.yml
@@ -1,0 +1,25 @@
+name: EP Host Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  rdma-addressing-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install RDMA headers
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libibverbs-dev
+
+    - name: Test RDMA address-vector construction
+      run: make -C ep/tests test HOST_TEST_INCLUDES=-I../include

--- a/ep/include/rdma.hpp
+++ b/ep/include/rdma.hpp
@@ -32,7 +32,7 @@ struct RDMAConnectionInfo {
   uintptr_t addr;  // Buffer address
   uint64_t len;
   uint16_t lid;     // Local ID
-  uint8_t gid[16];  // Global ID for RoCE (optional)
+  uint8_t gid[16];  // Global ID for GRH routes
 
   // Atomic buffer info (separate from main GPU buffer)
   uint32_t atomic_buffer_rkey = 0;   // Atomic buffer memory region key

--- a/ep/include/rdma_addressing.hpp
+++ b/ep/include/rdma_addressing.hpp
@@ -1,0 +1,44 @@
+#ifndef RDMA_ADDRESSING_HPP
+#define RDMA_ADDRESSING_HPP
+
+#include <infiniband/verbs.h>
+#include <cstdint>
+#include <cstring>
+
+static inline bool rdma_port_uses_grh(struct ibv_port_attr const& port_attr) {
+  return port_attr.link_layer == IBV_LINK_LAYER_ETHERNET ||
+         (port_attr.flags & IBV_QPF_GRH_REQUIRED) != 0;
+}
+
+static inline bool rdma_port_requires_gid(
+    struct ibv_port_attr const& port_attr) {
+  return port_attr.link_layer == IBV_LINK_LAYER_UNSPECIFIED ||
+         rdma_port_uses_grh(port_attr);
+}
+
+static inline int rdma_gid_index_for_port(struct ibv_port_attr const& port_attr,
+                                          int selected_gid_index) {
+  return port_attr.link_layer == IBV_LINK_LAYER_UNSPECIFIED
+             ? 0
+             : selected_gid_index;
+}
+
+static inline void configure_qp_address_vector(
+    struct ibv_ah_attr* ah_attr, struct ibv_port_attr const& port_attr,
+    uint16_t remote_lid, uint8_t const remote_gid[16], int gid_index,
+    int service_level, int traffic_class) {
+  memset(ah_attr, 0, sizeof(*ah_attr));
+  ah_attr->is_global = rdma_port_uses_grh(port_attr);
+  ah_attr->dlid = remote_lid;
+  ah_attr->port_num = 1;
+  ah_attr->sl = service_level;
+
+  if (!ah_attr->is_global) return;
+
+  memcpy(&ah_attr->grh.dgid, remote_gid, 16);
+  ah_attr->grh.sgid_index = gid_index;
+  ah_attr->grh.hop_limit = 255;
+  ah_attr->grh.traffic_class = traffic_class;
+}
+
+#endif  // RDMA_ADDRESSING_HPP

--- a/ep/include/rdma_util.hpp
+++ b/ep/include/rdma_util.hpp
@@ -2,6 +2,7 @@
 #define RDMA_UTIL_HPP
 
 #include "rdma.hpp"
+#include "rdma_addressing.hpp"
 #include <arpa/inet.h>
 #include <infiniband/verbs.h>
 #include <netinet/in.h>
@@ -32,54 +33,20 @@ static inline void fill_local_gid(ProxyCtx& S, RDMAConnectionInfo* local_info) {
     exit(1);
   }
 
-  // For RoCE (Ethernet), we need to fill the GID
-  if (port_attr.link_layer == IBV_LINK_LAYER_ETHERNET ||
-      port_attr.link_layer == IBV_LINK_LAYER_UNSPECIFIED) {
-    union ibv_gid local_gid;
-    int gid_index = S.gid_index;
-    // EFA:
-    if (port_attr.link_layer == IBV_LINK_LAYER_UNSPECIFIED) gid_index = 0;
-
-    if (ibv_query_gid(S.context, 1, gid_index, &local_gid)) {
+  // Advertise the GID selected for this port so a peer that requires a global
+  // route receives the matching destination GID. EFA uses its fixed GID index.
+  union ibv_gid local_gid;
+  int const gid_index = rdma_gid_index_for_port(port_attr, S.gid_index);
+  if (ibv_query_gid(S.context, 1, gid_index, &local_gid)) {
+    if (rdma_port_requires_gid(port_attr)) {
       perror("Failed to query GID");
       exit(1);
     }
-
-    // Copy the GID to the connection info
-    memcpy(local_info->gid, &local_gid, 16);
-    // printf(
-    //     "[RDMA] Local GID filled for RoCE (Ethernet) connection: "
-    //     "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%"
-    //     "02x\n",
-    //     local_info->gid[0], local_info->gid[1], local_info->gid[2],
-    //     local_info->gid[3], local_info->gid[4], local_info->gid[5],
-    //     local_info->gid[6], local_info->gid[7], local_info->gid[8],
-    //     local_info->gid[9], local_info->gid[10], local_info->gid[11],
-    //     local_info->gid[12], local_info->gid[13], local_info->gid[14],
-    //     local_info->gid[15]);
-  } else {
-    // For InfiniBand, GID is not strictly required, but we can still fill it
-    union ibv_gid local_gid;
-    if (ibv_query_gid(S.context, 1, 0, &local_gid) == 0) {
-      memcpy(local_info->gid, &local_gid, 16);
-      // printf(
-      //     "[RDMA] Local GID filled for InfiniBand connection: "
-      //     "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%"
-      //     "02x\n",
-      //     local_info->gid[0], local_info->gid[1], local_info->gid[2],
-      //     local_info->gid[3], local_info->gid[4], local_info->gid[5],
-      //     local_info->gid[6], local_info->gid[7], local_info->gid[8],
-      //     local_info->gid[9], local_info->gid[10], local_info->gid[11],
-      //     local_info->gid[12], local_info->gid[13], local_info->gid[14],
-      //     local_info->gid[15]);
-    } else {
-      // If GID query fails for InfiniBand, zero it out
-      memset(local_info->gid, 0, 16);
-      // printf(
-      //     "[RDMA] GID zeroed for InfiniBand connection (GID query
-      //     failed)\n");
-    }
+    memset(local_info->gid, 0, 16);
+    return;
   }
+
+  memcpy(local_info->gid, &local_gid, 16);
 }
 
 // Helper functions for ncclIbGetGidIndex

--- a/ep/src/rdma.cpp
+++ b/ep/src/rdma.cpp
@@ -1339,27 +1339,13 @@ void modify_qp_to_rtr(ProxyCtx& S, RDMAConnectionInfo* remote,
   attr.max_dest_rd_atomic = 1;
   attr.min_rnr_timer = 12;
 
-  if (is_roce) {
-    attr.ah_attr.is_global = 1;
-    attr.ah_attr.port_num = 1;
-    char const* sl_env = getenv("UCCL_IB_SL");
-    attr.ah_attr.sl = sl_env ? atoi(sl_env) : 3;
-    attr.ah_attr.src_path_bits = 0;
-    char const* tc_env = getenv("UCCL_IB_TC");
-    attr.ah_attr.grh.traffic_class = tc_env ? atoi(tc_env) : 104;
-    attr.ah_attr.grh.hop_limit = 255;
-    // Fill GID from remote_info
-    memcpy(&attr.ah_attr.grh.dgid, remote->gid, 16);
-    attr.ah_attr.grh.sgid_index = S.gid_index;
-  } else {
-    attr.ah_attr.is_global = 0;
-    attr.ah_attr.dlid = remote->lid;
-    attr.ah_attr.port_num = 1;
-    attr.ah_attr.sl = 0;
-    attr.ah_attr.src_path_bits = 0;
-    attr.ah_attr.static_rate = 0;
-    memset(&attr.ah_attr.grh, 0, sizeof(attr.ah_attr.grh));  // Safe
-  }
+  char const* sl_env = getenv("UCCL_IB_SL");
+  int const service_level = is_roce ? (sl_env ? atoi(sl_env) : 3) : 0;
+  char const* tc_env = getenv("UCCL_IB_TC");
+  int const traffic_class = is_roce ? (tc_env ? atoi(tc_env) : 104) : 0;
+  configure_qp_address_vector(&attr.ah_attr, port_attr, remote->lid,
+                              remote->gid, S.gid_index, service_level,
+                              traffic_class);
 
   int flags = IBV_QP_STATE | IBV_QP_PATH_MTU | IBV_QP_AV | IBV_QP_DEST_QPN |
               IBV_QP_RQ_PSN | IBV_QP_MAX_DEST_RD_ATOMIC | IBV_QP_MIN_RNR_TIMER;

--- a/ep/tests/.gitignore
+++ b/ep/tests/.gitignore
@@ -1,3 +1,4 @@
 pcie_bench
 gpu_to_cpu_bench
 batched_gpu_to_cpu_bench
+rdma_addressing_test

--- a/ep/tests/Makefile
+++ b/ep/tests/Makefile
@@ -11,6 +11,8 @@ INCLUDES := -I../include -I../../include -I$(CUDA_HOME)/include -I$(EFA_HOME)/in
 LDFLAGS := -L$(CUDA_HOME)/lib64 -L$(EFA_HOME)/lib -lcuda -lcudart -libverbs -lpthread
 CXXFLAGS := -O3 -g -std=c++17 $(INCLUDES)
 CUDAFLAGS := -arch=sm_90  # Use sm_80 for A100
+HOST_TEST_INCLUDES ?= -Iinclude -I../include
+HOST_TEST_CXXFLAGS := -std=c++17 -Wall -Wextra -Werror $(HOST_TEST_INCLUDES)
 
 # Files
 COMMON_SRC := ../src/common.cpp
@@ -18,6 +20,7 @@ COMMON_OBJ := ../src/common.o
 
 # Binaries
 CUDA_BIN := pcie_bench gpu_to_cpu_bench batched_gpu_to_cpu_bench
+HOST_TEST_BIN := rdma_addressing_test
 
 all: $(CUDA_BIN)
 
@@ -35,5 +38,13 @@ gpu_to_cpu_bench: gpu_to_cpu_bench.cu $(COMMON_OBJ)
 batched_gpu_to_cpu_bench: batched_gpu_to_cpu_bench.cu $(COMMON_OBJ)
 	$(NVCC) $(CUDAFLAGS) $(CXXFLAGS) batched_gpu_to_cpu_bench.cu $(COMMON_OBJ) -o $@ $(LDFLAGS)
 
+$(HOST_TEST_BIN): rdma_addressing_test.cpp ../include/rdma_addressing.hpp
+	$(CXX) $(HOST_TEST_CXXFLAGS) $< -o $@
+
+test: $(HOST_TEST_BIN)
+	./$(HOST_TEST_BIN)
+
 clean:
-	rm -f $(CUDA_BIN) $(COMMON_OBJ)
+	rm -f $(CUDA_BIN) $(HOST_TEST_BIN) $(COMMON_OBJ)
+
+.PHONY: all clean test

--- a/ep/tests/include/infiniband/verbs.h
+++ b/ep/tests/include/infiniband/verbs.h
@@ -1,0 +1,43 @@
+#ifndef TESTS_INCLUDE_INFINIBAND_VERBS_H
+#define TESTS_INCLUDE_INFINIBAND_VERBS_H
+
+#include <cstdint>
+
+enum ibv_link_layer {
+  IBV_LINK_LAYER_UNSPECIFIED,
+  IBV_LINK_LAYER_INFINIBAND,
+  IBV_LINK_LAYER_ETHERNET,
+};
+
+enum ibv_query_port_flags {
+  IBV_QPF_GRH_REQUIRED = 1 << 0,
+};
+
+union ibv_gid {
+  uint8_t raw[16];
+};
+
+struct ibv_global_route {
+  union ibv_gid dgid;
+  uint32_t flow_label;
+  uint8_t sgid_index;
+  uint8_t hop_limit;
+  uint8_t traffic_class;
+};
+
+struct ibv_ah_attr {
+  struct ibv_global_route grh;
+  uint16_t dlid;
+  uint8_t sl;
+  uint8_t src_path_bits;
+  uint8_t static_rate;
+  uint8_t is_global;
+  uint8_t port_num;
+};
+
+struct ibv_port_attr {
+  uint32_t flags;
+  enum ibv_link_layer link_layer;
+};
+
+#endif  // TESTS_INCLUDE_INFINIBAND_VERBS_H

--- a/ep/tests/rdma_addressing_test.cpp
+++ b/ep/tests/rdma_addressing_test.cpp
@@ -94,33 +94,6 @@ void test_roce_address_vector() {
   assert(ah_attr.grh.traffic_class == 104);
 }
 
-void test_asymmetric_infiniband_address_vectors() {
-  struct ibv_port_attr local_port = {};
-  local_port.link_layer = IBV_LINK_LAYER_INFINIBAND;
-  local_port.flags = IBV_QPF_GRH_REQUIRED;
-  struct ibv_port_attr remote_port = {};
-  remote_port.link_layer = IBV_LINK_LAYER_INFINIBAND;
-  auto const gid_from_remote_selected_index = remote_gid();
-
-  assert(rdma_gid_index_for_port(remote_port, 11) == 11);
-
-  struct ibv_ah_attr local_ah_attr;
-  configure_qp_address_vector(&local_ah_attr, local_port, 0x1234,
-                              gid_from_remote_selected_index.data(), 7, 0, 0);
-  assert(local_ah_attr.is_global == 1);
-  assert(local_ah_attr.dlid == 0x1234);
-  assert(memcmp(local_ah_attr.grh.dgid.raw,
-                gid_from_remote_selected_index.data(),
-                gid_from_remote_selected_index.size()) == 0);
-  assert(local_ah_attr.grh.sgid_index == 7);
-
-  struct ibv_ah_attr remote_ah_attr;
-  configure_qp_address_vector(&remote_ah_attr, remote_port, 0x5678,
-                              remote_gid().data(), 11, 0, 0);
-  assert(remote_ah_attr.is_global == 0);
-  assert(remote_ah_attr.dlid == 0x5678);
-}
-
 }  // namespace
 
 int main() {
@@ -128,6 +101,5 @@ int main() {
   test_local_infiniband_address_vector();
   test_grh_required_infiniband_address_vector();
   test_roce_address_vector();
-  test_asymmetric_infiniband_address_vectors();
   return 0;
 }

--- a/ep/tests/rdma_addressing_test.cpp
+++ b/ep/tests/rdma_addressing_test.cpp
@@ -1,0 +1,133 @@
+#include "rdma_addressing.hpp"
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+
+namespace {
+
+std::array<uint8_t, 16> remote_gid() {
+  return {0x20, 0x01, 0x0d, 0xb8, 0x00, 0x01, 0x00, 0x02,
+          0x00, 0x03, 0x00, 0x04, 0x00, 0x05, 0x00, 0x06};
+}
+
+void test_required_gid_policy() {
+  struct ibv_port_attr port_attr = {};
+  port_attr.link_layer = IBV_LINK_LAYER_INFINIBAND;
+  assert(!rdma_port_requires_gid(port_attr));
+  assert(rdma_gid_index_for_port(port_attr, 5) == 5);
+
+  port_attr.flags = IBV_QPF_GRH_REQUIRED;
+  assert(rdma_port_requires_gid(port_attr));
+  assert(rdma_gid_index_for_port(port_attr, 7) == 7);
+
+  port_attr.flags = 0;
+  port_attr.link_layer = IBV_LINK_LAYER_ETHERNET;
+  assert(rdma_port_requires_gid(port_attr));
+  assert(rdma_gid_index_for_port(port_attr, 3) == 3);
+
+  port_attr.link_layer = IBV_LINK_LAYER_UNSPECIFIED;
+  assert(rdma_port_requires_gid(port_attr));
+  assert(rdma_gid_index_for_port(port_attr, 9) == 0);
+}
+
+void test_local_infiniband_address_vector() {
+  struct ibv_port_attr port_attr = {};
+  port_attr.link_layer = IBV_LINK_LAYER_INFINIBAND;
+  auto const gid = remote_gid();
+  struct ibv_ah_attr ah_attr;
+  memset(&ah_attr, 0xff, sizeof(ah_attr));
+
+  configure_qp_address_vector(&ah_attr, port_attr, 0x1234, gid.data(), 7, 0, 0);
+
+  assert(ah_attr.is_global == 0);
+  assert(ah_attr.dlid == 0x1234);
+  assert(ah_attr.port_num == 1);
+  assert(ah_attr.sl == 0);
+  assert(ah_attr.src_path_bits == 0);
+  assert(ah_attr.static_rate == 0);
+  struct ibv_global_route empty_grh = {};
+  assert(memcmp(&ah_attr.grh, &empty_grh, sizeof(empty_grh)) == 0);
+}
+
+void test_grh_required_infiniband_address_vector() {
+  struct ibv_port_attr port_attr = {};
+  port_attr.link_layer = IBV_LINK_LAYER_INFINIBAND;
+  port_attr.flags = IBV_QPF_GRH_REQUIRED;
+  auto const gid = remote_gid();
+  struct ibv_ah_attr ah_attr;
+  memset(&ah_attr, 0xff, sizeof(ah_attr));
+
+  configure_qp_address_vector(&ah_attr, port_attr, 0x1234, gid.data(), 7, 0, 0);
+
+  assert(ah_attr.is_global == 1);
+  assert(ah_attr.dlid == 0x1234);
+  assert(ah_attr.port_num == 1);
+  assert(ah_attr.sl == 0);
+  assert(ah_attr.src_path_bits == 0);
+  assert(ah_attr.static_rate == 0);
+  assert(memcmp(ah_attr.grh.dgid.raw, gid.data(), gid.size()) == 0);
+  assert(ah_attr.grh.flow_label == 0);
+  assert(ah_attr.grh.sgid_index == 7);
+  assert(ah_attr.grh.hop_limit == 255);
+  assert(ah_attr.grh.traffic_class == 0);
+}
+
+void test_roce_address_vector() {
+  struct ibv_port_attr port_attr = {};
+  port_attr.link_layer = IBV_LINK_LAYER_ETHERNET;
+  auto const gid = remote_gid();
+  struct ibv_ah_attr ah_attr;
+  memset(&ah_attr, 0xff, sizeof(ah_attr));
+
+  configure_qp_address_vector(&ah_attr, port_attr, 0, gid.data(), 3, 5, 104);
+
+  assert(ah_attr.is_global == 1);
+  assert(ah_attr.port_num == 1);
+  assert(ah_attr.sl == 5);
+  assert(ah_attr.src_path_bits == 0);
+  assert(ah_attr.static_rate == 0);
+  assert(memcmp(ah_attr.grh.dgid.raw, gid.data(), gid.size()) == 0);
+  assert(ah_attr.grh.flow_label == 0);
+  assert(ah_attr.grh.sgid_index == 3);
+  assert(ah_attr.grh.hop_limit == 255);
+  assert(ah_attr.grh.traffic_class == 104);
+}
+
+void test_asymmetric_infiniband_address_vectors() {
+  struct ibv_port_attr local_port = {};
+  local_port.link_layer = IBV_LINK_LAYER_INFINIBAND;
+  local_port.flags = IBV_QPF_GRH_REQUIRED;
+  struct ibv_port_attr remote_port = {};
+  remote_port.link_layer = IBV_LINK_LAYER_INFINIBAND;
+  auto const gid_from_remote_selected_index = remote_gid();
+
+  assert(rdma_gid_index_for_port(remote_port, 11) == 11);
+
+  struct ibv_ah_attr local_ah_attr;
+  configure_qp_address_vector(&local_ah_attr, local_port, 0x1234,
+                              gid_from_remote_selected_index.data(), 7, 0, 0);
+  assert(local_ah_attr.is_global == 1);
+  assert(local_ah_attr.dlid == 0x1234);
+  assert(memcmp(local_ah_attr.grh.dgid.raw,
+                gid_from_remote_selected_index.data(),
+                gid_from_remote_selected_index.size()) == 0);
+  assert(local_ah_attr.grh.sgid_index == 7);
+
+  struct ibv_ah_attr remote_ah_attr;
+  configure_qp_address_vector(&remote_ah_attr, remote_port, 0x5678,
+                              remote_gid().data(), 11, 0, 0);
+  assert(remote_ah_attr.is_global == 0);
+  assert(remote_ah_attr.dlid == 0x5678);
+}
+
+}  // namespace
+
+int main() {
+  test_required_gid_policy();
+  test_local_infiniband_address_vector();
+  test_grh_required_infiniband_address_vector();
+  test_roce_address_vector();
+  test_asymmetric_infiniband_address_vectors();
+  return 0;
+}


### PR DESCRIPTION
## Summary

- honor `IBV_QPF_GRH_REQUIRED` when EP builds InfiniBand RTR address vectors
- keep each exchanged GID paired with the `S.gid_index` selected for that port
- retain the remote LID and populate `dgid`, `sgid_index`, hop limit, service level, and traffic class for each route type
- add an always-run host regression for local InfiniBand, GRH-required InfiniBand, RoCE, and EFA GID policy

## Motivation

`modify_qp_to_rtr` previously selected a local address vector for every InfiniBand port. Verbs requires a global address vector on ports advertising `IBV_QPF_GRH_REQUIRED`. The connection-info producer also queried GID index 0 for ordinary InfiniBand. A GRH-required peer can consume that GID in an asymmetric topology, so the advertised GID now follows the selected port index.

This follows the GID/index pairing and `needGlobal` address-vector shape in NVIDIA NCCL commit [`a26a9fa`](https://github.com/NVIDIA/nccl/commit/a26a9fa96163bcdc4171d54ad7acafa7f0009c58).

## Validation

- `make -C ep/tests test`
- Ubuntu build and execution against `libibverbs-dev` headers with `make -C ep/tests test HOST_TEST_INCLUDES=-I../include`
- ASan and UBSan host test on macOS
- Alpine Linux build and execution with `rdma-core-dev` headers
- predicate and selected-GID mutation controls both fail the regression
- `clang-format 14 --dry-run --Werror` on changed C++ files
- `git diff --check`

Dual-node validation on a GRH-required InfiniBand fabric remains the hardware integration gate.

Fixes #995
